### PR TITLE
Fixed "jump" level 4 and 5 prediction

### DIFF
--- a/game/bg_pmove.c
+++ b/game/bg_pmove.c
@@ -13054,21 +13054,15 @@ void Pmove (pmove_t *pmove) {
 
 #ifdef QAGAME
 	int i;
-	for (i = 0; i < 8; i++) {
+	for (i = 0;i < 8;i++) {
 		if (pmove->ps->fd.forcePowerLevel[i] & 4) {
-			pmove->ps->stats[STAT_EXTRA_FORCE_BITS] |= (1 << i);
-		}
-		if (pmove->ps->fd.forcePowerLevel[i] >= 5) {
-			pmove->ps->stats[STAT_EXTRA_FORCE_BITS_L5] |= (1 << i);
+			pmove->ps->stats[STAT_EXTRA_FORCE_BITS]|=(1 << i);
 		}
 	}
 
-	for (i = 8; i < 16; i++) {
+	for (i = 8;i < 16;i++) {
 		if (pmove->ps->fd.forcePowerLevel[i] & 4) {
-			pmove->ps->stats[STAT_EXTRA_FORCE_BITS2] |= (1 << (i - 8));
-		}
-		if (pmove->ps->fd.forcePowerLevel[i] >= 5) {
-			pmove->ps->stats[STAT_EXTRA_FORCE_BITS_L5_2] |= (1 << (i - 8));
+			pmove->ps->stats[STAT_EXTRA_FORCE_BITS2]|=(1 << (i - 8));
 		}
 	}
 

--- a/game/bg_pmove.c
+++ b/game/bg_pmove.c
@@ -13056,13 +13056,21 @@ void Pmove (pmove_t *pmove) {
 	int i;
 	for (i = 0;i < 8;i++) {
 		if (pmove->ps->fd.forcePowerLevel[i] & 4) {
-			pmove->ps->stats[STAT_EXTRA_FORCE_BITS]|=(1 << i);
+			// Turn the "extra force bit" flag ON for the "i" skill
+			pmove->ps->stats[STAT_EXTRA_FORCE_BITS] |= (1 << i);
+		} else {
+			// Turn the "extra force bit" flag OFF for the "i" skill
+			pmove->ps->stats[STAT_EXTRA_FORCE_BITS] &= ~(1 << i);
 		}
 	}
 
 	for (i = 8;i < 16;i++) {
 		if (pmove->ps->fd.forcePowerLevel[i] & 4) {
-			pmove->ps->stats[STAT_EXTRA_FORCE_BITS2]|=(1 << (i - 8));
+			// Turn the "extra force bit" flag ON for the "i" skill
+			pmove->ps->stats[STAT_EXTRA_FORCE_BITS2] |= (1 << (i - 8));
+		} else {
+			// Turn the "extra force bit" flag OFF for the "i" skill
+			pmove->ps->stats[STAT_EXTRA_FORCE_BITS2] &= ~(1 << (i - 8));
 		}
 	}
 

--- a/game/bg_public.h
+++ b/game/bg_public.h
@@ -544,9 +544,7 @@ typedef enum {
         STAT_PROFESSION,      //Lugormod profession
         STAT_LEVEL,           //Lugormod Level
         STAT_EXTRA_FORCE_BITS, //Lugormod extra bits for >3 force levels
-        STAT_EXTRA_FORCE_BITS2,  //Lugormod extra bits for >3 force levels
-		STAT_EXTRA_FORCE_BITS_L5, //Lugormod extra bits for force level 5
-		STAT_EXTRA_FORCE_BITS_L5_2 //Lugormod extra bits for force level 5
+        STAT_EXTRA_FORCE_BITS2  //Lugormod extra bits for >3 force levels
 
 //        STAT_PERS_FLAGS, //Lugormod persistant flags
 } statIndex_t;


### PR DESCRIPTION
### 1. Reverted the commit where `STAT_EXTRA_FORCE_BITS_L5` and `STAT_EXTRA_FORCE_BITS_L5_2` were added
They aren't actually necessary: `STAT_EXTRA_FORCE_BITS` and `STAT_EXTRA_FORCE_BITS2` are enough for the client-side game library to be aware of both level 4 **and** level 5.

The caveat is that a version of **TaystJK** released on 2025-04-26 relied on these additional flags (see: [taysta/TaystJK#226](https://github.com/taysta/TaystJK/pull/226)).

It was fixed a few hours later (see: [taysta/TaystJK#231](https://github.com/taysta/TaystJK/pull/231)), along with a (minor) issue that was preventing the client-side prediction from picking up skill upgrades / downgrades immediately (it worked on respawn).

The fixed client-side prediction should work on any Lugormod server, without requiring a patched/updated Lugormod server-side library.

(Tayst also fixed side effects that the original PR had introduced, impacting jaPRO).

### 2. Turned the "extra force bits" off immediately when downgrading a skill
Even though skill upgrades were immediately reflected in the "jump" prediction, there was a still minor problem when downgrading:  
`STAT_EXTRA_FORCE_BITS` would not turn itself OFF until the player respawned.

Which was mostly visible in one scenario:  
When downgrading from "jump" level 4 (or level 5) all the way to level 1.  
The client-side would erroneously detect the "jump" level as being 5 (instead of 1) until the player respawned, impacting client-side prediction.

This issue was **not** introduced by [PR#10](https://github.com/NexiloDev/Lugormod-v3/pull/10). It is **much** older than that.