### PR TITLE
Increased the number 7 to 9 for IsColorString.

### DIFF
--- a/game/q_shared.c
+++ b/game/q_shared.c
@@ -1276,7 +1276,7 @@ char *Q_CleanStrC( char *string ) {
 	s = string;
 	d = string;
 	while ((c = *s) != 0 ) {
-		if ( s[0] == '^' && s[1] >= '0' && s[1] <= '7') { //Q_IsColorString(s)
+		if ( s[0] == '^' && s[1] >= '0' && s[1] <= '9') { //Q_IsColorString(s)
 			s++;
 		}		
 		else {

--- a/game/q_shared.h
+++ b/game/q_shared.h
@@ -1191,7 +1191,7 @@ extern	vec4_t		colorLtBlue;
 extern	vec4_t		colorDkBlue;
 
 #define Q_COLOR_ESCAPE	'^'
-// you MUST have the last bit on here about colour strings being less than 7 or taiwanese strings register as colour!!!!
+// you MUST have the last bit on here about colour strings being less than or equal to 9, or taiwanese strings register as colour!!!!
 #define Q_IsColorString(p)	( p && *(p) == Q_COLOR_ESCAPE && *((p)+1) && *((p)+1) != Q_COLOR_ESCAPE && *((p)+1) <= '9' && *((p)+1) >= '0' )
 
 

--- a/game/q_shared.h
+++ b/game/q_shared.h
@@ -1192,7 +1192,7 @@ extern	vec4_t		colorDkBlue;
 
 #define Q_COLOR_ESCAPE	'^'
 // you MUST have the last bit on here about colour strings being less than 7 or taiwanese strings register as colour!!!!
-#define Q_IsColorString(p)	( p && *(p) == Q_COLOR_ESCAPE && *((p)+1) && *((p)+1) != Q_COLOR_ESCAPE && *((p)+1) <= '7' && *((p)+1) >= '0' )
+#define Q_IsColorString(p)	( p && *(p) == Q_COLOR_ESCAPE && *((p)+1) && *((p)+1) != Q_COLOR_ESCAPE && *((p)+1) <= '9' && *((p)+1) >= '0' )
 
 
 #define COLOR_BLACK		'0'


### PR DESCRIPTION
Context:

The Clients now support ^8 = Orange and ^9 = Grey. This generated weird bugs, for instance in /hi commands was the alignment broken. Picture below.

![{430E63AE-37D2-4587-9364-D31E435B6C23}](https://github.com/user-attachments/assets/395c609a-a3b0-417c-a15f-e568ce83dcab)

This change should provide a fix for that.

