### PR TITLE
SetSaber now works via Menu and normal /saber or /saber1/2 commands.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ set(GAME_SRC
 	game/Lmd_RandomChat.c 
 	game/Lmd_RandomSpot.c 
 	game/Lmd_Script.c 
+	game/Lmd_SetSaber.c
 	game/Lmd_StashZone.c 
 	game/Lmd_Time.c 
 	game/lmd_turret.c 

--- a/game/Lmd_Commands.c
+++ b/game/Lmd_Commands.c
@@ -1065,6 +1065,12 @@ void Cmd_SetSaber_f(gentity_t* ent, int iArg) {
 		return;
 	}
 
+	if (ent->client->ps.weaponTime > 0 || ent->client->ps.saberInFlight)
+	{
+		Disp(ent, "^3Can't use this while attacking!");
+		return;
+	}
+
 	if (lmd_set_saber_duels.integer == 0 && ent->client->ps.duelInProgress)
 	{
 		Disp(ent, "^3Can't use this in a duel!");

--- a/game/Lmd_Commands.c
+++ b/game/Lmd_Commands.c
@@ -1056,6 +1056,7 @@ Lugormod
 ==================
 */
 extern void forceSaber(gentity_t *ent, char* saber1, char* saber2);
+extern vmCvar_t lmd_set_saber_duels;
 void Cmd_SetSaber_f(gentity_t* ent, int iArg) {
 	char arg[2][64];
 	qboolean invalid = qfalse;
@@ -1064,9 +1065,22 @@ void Cmd_SetSaber_f(gentity_t* ent, int iArg) {
 		return;
 	}
 
+	if (lmd_set_saber_duels.integer == 0 && ent->client->ps.duelInProgress)
+	{
+		Disp(ent, "^3Can't use this in a duel!");
+		return;
+	}
+
 	if (ent->client->Lmd.setSaber.delayTime >= level.time)
 	{
 		Disp(ent, "^3Already in use. Please wait!");
+		return;
+	}
+
+	if (ent->client->Lmd.setSaber.cooldownTime >= level.time)
+	{
+		const unsigned int remainingMs = ent->client->Lmd.setSaber.cooldownTime - level.time;
+		Disp(ent, va("^3On cooldown for ^5%d.%d ^3more seconds.", remainingMs / 1000, (remainingMs % 1000) / 100));
 		return;
 	}
 

--- a/game/Lmd_Commands.c
+++ b/game/Lmd_Commands.c
@@ -30,7 +30,6 @@ void       Jedi_Decloak    (gentity_t *self );
 void       HiScore         (gentity_t *ent, int field);
 void       HiRatio         (gentity_t* ent, int field);
 void       Cmd_Say_f       (gentity_t *ent, int mode, qboolean arg0 );
-void       Cmd_SetSaber_f  (gentity_t *ent, int iArg);
 
 extern gentity_t  *g_bestKing;
 extern int         g_bestKingScore;
@@ -1047,81 +1046,6 @@ Cmd disable
 void Cmd_Confirm_f(gentity_t *ent, int iArg);
 void Cmd_Interact_f(gentity_t *ent, int iArg);
 
-
-
-/*
-==================
-Cmd_SetSaber_f
-Lugormod
-==================
-*/
-extern void forceSaber(gentity_t *ent, char* saber1, char* saber2);
-extern vmCvar_t lmd_set_saber_duels;
-void Cmd_SetSaber_f(gentity_t* ent, int iArg) {
-	char arg[2][64];
-	qboolean invalid = qfalse;
-
-	if (!ent || !ent->client) {
-		return;
-	}
-
-	if (ent->client->ps.weaponTime > 0 || ent->client->ps.saberInFlight)
-	{
-		Disp(ent, "^3Can't use this while attacking!");
-		return;
-	}
-
-	if (lmd_set_saber_duels.integer == 0 && ent->client->ps.duelInProgress)
-	{
-		Disp(ent, "^3Can't use this in a duel!");
-		return;
-	}
-
-	if (ent->client->Lmd.setSaber.delayTime >= level.time)
-	{
-		Disp(ent, "^3Already in use. Please wait!");
-		return;
-	}
-
-	if (ent->client->Lmd.setSaber.cooldownTime >= level.time)
-	{
-		const float remaining = (float)(ent->client->Lmd.setSaber.cooldownTime - level.time) / 1000.0f;
-		Disp(ent, va("^3On cooldown for ^5%.1f ^3more seconds.", remaining));
-
-		return;
-	}
-
-	if (trap_Argc() == 3) {
-		for (int i = 0; i < 2; i++) {
-			trap_Argv(i + 1, arg[i], sizeof(arg[i]));
-		}
-		forceSaber(ent, arg[0], arg[1]);
-	}
-	else if (trap_Argc() == 2) {
-		trap_Argv(1, arg[0], sizeof(arg[0]));
-
-		if (!Q_stricmp(arg[0], "single")) {
-			forceSaber(ent, "kyle", "none");
-		}
-		else if (!Q_stricmp(arg[0], "duals")) {
-			forceSaber(ent, "kyle", "kyle");
-		}
-		else if (!Q_stricmp(arg[0], "staff")) {
-			forceSaber(ent, "dual_2", "none");
-		}
-		else
-		{
-			invalid = qtrue;
-		}
-	}
-	else {
-		invalid = qtrue;
-	}
-
-	if (invalid) Disp(ent, CT_B"Usage: "CT_C"/setsaber "CT_AO"<single | duals | staff> "CT_B"OR "CT_C"/setsaber "CT_AO"<saber1> <saber2>");
-
-}
-
 cmdEntry_t playerCommandEntries[] = {
 	//{"testline", "\n", Cmd_TestLine_f, 0, 1, 0, 0, 0},
 	{"actions", "List and use your current pending actions.", Cmd_Action_f, 0, qfalse, 0, 0, 0, 0},
@@ -1168,7 +1092,6 @@ cmdEntry_t playerCommandEntries[] = {
 	{"say_buddies", "Send a message to your buddies.", Cmd_Say2_f, SAY_BUDDIES, qfalse, 0, 0, 0, 0},
 	{"say_close", "Send a message to those standing close to where you are.", Cmd_Say2_f, SAY_CLOSE, qfalse, 0, 0, 0, 0},
 	//{"scanner", "Scans for players, items, and the money stash.", Cmd_TechScanner_f, 0, 0, 256, 0, PROF_TECH},
-	{"setsaber", "Set your saber type and model. Usage: "CT_C"/setsaber "CT_AO"<single | duals | staff> "CT_B"OR "CT_C"/setsaber "CT_AO"<saber1> <saber2>", Cmd_SetSaber_f, 0, qfalse, 0, 0, ~(1 << GT_FFA), PROF_JEDI},
 	{"stash", "Tells you if there is a money stash spawned, and who is holding on to it (if anyone).", Cmd_Stash_f, 0, qfalse, 0, 512 | 128, 0, 0},
 	{NULL},
 };

--- a/game/Lmd_Commands.c
+++ b/game/Lmd_Commands.c
@@ -1085,8 +1085,9 @@ void Cmd_SetSaber_f(gentity_t* ent, int iArg) {
 
 	if (ent->client->Lmd.setSaber.cooldownTime >= level.time)
 	{
-		const unsigned int remainingMs = ent->client->Lmd.setSaber.cooldownTime - level.time;
-		Disp(ent, va("^3On cooldown for ^5%d.%d ^3more seconds.", remainingMs / 1000, (remainingMs % 1000) / 100));
+		const float remaining = (float)(ent->client->Lmd.setSaber.cooldownTime - level.time) / 1000.0f;
+		Disp(ent, va("^3On cooldown for ^5%.1f ^3more seconds.", remaining));
+
 		return;
 	}
 

--- a/game/Lmd_Main.c
+++ b/game/Lmd_Main.c
@@ -1,6 +1,7 @@
 
 #include "g_local.h"
 #include "Lmd_EntityCore.h"
+#include "Lmd_SetSaber.h"
 
 //#define LMD_MEMORY_DEBUG
 
@@ -88,7 +89,6 @@ void Chicken (gentity_t *chicken);
 void checkKingTimer(gentity_t *ent);
 void CheckRestrictAll(gentity_t *player);
 void Cmd_Kill_f(gentity_t *ent);
-extern vmCvar_t lmd_set_saber_cooldown;
 void Lmd_PlayerThink(gentity_t *ent){
 
 	//Ufo:
@@ -182,10 +182,11 @@ void Lmd_PlayerThink(gentity_t *ent){
 				ent->client->ps.saberHolstered != 0 &&
 				ent->client->ps.weapon == WP_SABER) Cmd_ToggleSaber_f(ent);
 		}
-
-		ent->client->Lmd.setSaber.cooldownTime = lmd_set_saber_cooldown.integer + level.time;
+		
 		ent->client->Lmd.setSaber.newRequest = qfalse;
 	}
+
+	lmd_checkSaberChanges(ent);
 	
 	ent->client->Lmd.thinkDelay = level.time + FRAMETIME;
 }

--- a/game/Lmd_Main.c
+++ b/game/Lmd_Main.c
@@ -172,7 +172,7 @@ void Lmd_PlayerThink(gentity_t *ent){
 
 	updatePenalties(ent);
 	
-	if (ent->client->Lmd.setSaber.delayTime < level.time)
+	if (ent->client->Lmd.setSaber.delayTime < level.time && ent->client->Lmd.setSaber.newRequest)
 	{
 		if (ent->client->Lmd.setSaber.openAgain)
 		{
@@ -184,6 +184,7 @@ void Lmd_PlayerThink(gentity_t *ent){
 		}
 
 		ent->client->Lmd.setSaber.cooldownTime = lmd_set_saber_cooldown.integer + level.time;
+		ent->client->Lmd.setSaber.newRequest = qfalse;
 	}
 	
 	ent->client->Lmd.thinkDelay = level.time + FRAMETIME;

--- a/game/Lmd_Main.c
+++ b/game/Lmd_Main.c
@@ -88,6 +88,7 @@ void Chicken (gentity_t *chicken);
 void checkKingTimer(gentity_t *ent);
 void CheckRestrictAll(gentity_t *player);
 void Cmd_Kill_f(gentity_t *ent);
+extern vmCvar_t lmd_set_saber_cooldown;
 void Lmd_PlayerThink(gentity_t *ent){
 
 	//Ufo:
@@ -171,13 +172,18 @@ void Lmd_PlayerThink(gentity_t *ent){
 
 	updatePenalties(ent);
 	
-	if (ent->client->Lmd.setSaber.delayTime < level.time && ent->client->Lmd.setSaber.openAgain)
+	if (ent->client->Lmd.setSaber.delayTime < level.time)
 	{
-		ent->client->Lmd.setSaber.openAgain = qfalse;
-		if (ent->health > 0 &&
-			ent->client->ps.weaponTime <= 0 &&
-			ent->client->ps.saberHolstered != 0 &&
-			ent->client->ps.weapon == WP_SABER) Cmd_ToggleSaber_f(ent);
+		if (ent->client->Lmd.setSaber.openAgain)
+		{
+			ent->client->Lmd.setSaber.openAgain = qfalse;
+			if (ent->health > 0 &&
+				ent->client->ps.weaponTime <= 0 &&
+				ent->client->ps.saberHolstered != 0 &&
+				ent->client->ps.weapon == WP_SABER) Cmd_ToggleSaber_f(ent);
+		}
+
+		ent->client->Lmd.setSaber.cooldownTime = lmd_set_saber_cooldown.integer + level.time;
 	}
 	
 	ent->client->Lmd.thinkDelay = level.time + FRAMETIME;

--- a/game/Lmd_SetSaber.c
+++ b/game/Lmd_SetSaber.c
@@ -1,0 +1,97 @@
+#include "Lmd_SetSaber.h"
+
+extern vmCvar_t lmd_allow_set_saber;
+extern vmCvar_t lmd_set_saber_duels;
+extern vmCvar_t lmd_set_saber_delay;
+void lmd_checkSaberChanges(gentity_t* ent)
+{
+    if (!ent || !ent->client || !ent->inuse) return;
+
+    if (!lmd_allow_set_saber.integer
+            || (ent->client->ps.duelInProgress && !lmd_set_saber_duels.integer)
+            || level.time - ent->client->ps.forceHandExtendTime < 750
+            || ent->client->ps.saberMove != LS_READY
+            || ent->client->ps.saberInFlight) return;
+    
+    int clientNum = ent - g_entities;
+    
+    char userinfo[MAX_INFO_STRING];
+    char saber1[MAX_QPATH];
+    char saber2[MAX_QPATH];
+
+    trap_GetUserinfo(clientNum, userinfo, sizeof(userinfo));
+    Q_strncpyz(saber1, Info_ValueForKey(userinfo, "saber1"), sizeof(saber1));
+    Q_strncpyz(saber2, Info_ValueForKey(userinfo, "saber2"), sizeof(saber2));
+    
+    if (!clientSaberHistory[clientNum].initialized)
+    {
+        Q_strncpyz(clientSaberHistory[clientNum].saber1, saber1, sizeof(clientSaberHistory[clientNum].saber1));
+        Q_strncpyz(clientSaberHistory[clientNum].saber2, saber2, sizeof(clientSaberHistory[clientNum].saber2));
+        clientSaberHistory[clientNum].initialized = qtrue;
+        return;
+    }
+    
+    if (Q_stricmp(saber1, clientSaberHistory[clientNum].saber1) ||
+        Q_stricmp(saber2, clientSaberHistory[clientNum].saber2))
+    {
+        if (ent->client->ps.saberHolstered == 0) ent->client->Lmd.setSaber.openAgain = qtrue;
+        ent->client->ps.saberHolstered = 2;
+        
+        G_SetSaber(ent, 0, saber1, qfalse);
+        G_SetSaber(ent, 1, saber2, qfalse);
+
+        // Make sure userinfo is updated properly
+        trap_SetUserinfo(clientNum, userinfo);
+        ClientUserinfoChanged(clientNum);
+
+        G_SaberModelSetup(ent);
+
+        // Update saber style
+        if (ent->client->saber[0].model[0] && ent->client->saber[1].model[0])
+        {
+            // dual
+            ent->client->ps.fd.saberAnimLevelBase = ent->client->ps.fd.saberAnimLevel = ent->client->ps.fd.
+                saberDrawAnimLevel = SS_DUAL;
+        }
+        else if (ent->client->saber[0].saberFlags & SFL_TWO_HANDED)
+        {
+            // staff
+            ent->client->ps.fd.saberAnimLevel = ent->client->ps.fd.saberDrawAnimLevel = SS_STAFF;
+        }
+        else
+        {
+            // single
+            if (ent->client->sess.saberLevel < SS_FAST)
+            {
+                ent->client->sess.saberLevel = SS_FAST;
+            }
+            else if (ent->client->sess.saberLevel > SS_STRONG)
+            {
+                ent->client->sess.saberLevel = SS_STRONG;
+            }
+            ent->client->ps.fd.saberAnimLevelBase = ent->client->ps.fd.saberAnimLevel = ent->client->ps.fd.
+                saberDrawAnimLevel = ent->client->sess.saberLevel;
+            if (ent->client->ps.fd.saberAnimLevel > ent->client->ps.fd.forcePowerLevel[FP_SABER_OFFENSE])
+            {
+                ent->client->ps.fd.saberAnimLevelBase = ent->client->ps.fd.saberAnimLevel = ent->client->ps.fd.
+                    saberDrawAnimLevel = ent->client->sess.saberLevel = ent->client->ps.fd.forcePowerLevel[
+                        FP_SABER_OFFENSE];
+            }
+        }
+        
+        if (!WP_SaberStyleValidForSaber(&ent->client->saber[0], &ent->client->saber[1], ent->client->ps.saberHolstered,
+                                        ent->client->ps.fd.saberAnimLevel))
+        {
+            WP_UseFirstValidSaberStyle(&ent->client->saber[0], &ent->client->saber[1], ent->client->ps.saberHolstered,
+                                       &ent->client->ps.fd.saberAnimLevel);
+            ent->client->ps.fd.saberAnimLevelBase = ent->client->saberCycleQueue = ent->client->ps.fd.saberAnimLevel;
+        }
+        
+        Q_strncpyz(clientSaberHistory[clientNum].saber1, saber1, sizeof(clientSaberHistory[clientNum].saber1));
+        Q_strncpyz(clientSaberHistory[clientNum].saber2, saber2, sizeof(clientSaberHistory[clientNum].saber2));
+
+        ent->client->Lmd.setSaber.delayTime = level.time +  lmd_set_saber_delay.integer;
+        ent->client->ps.weaponTime = lmd_set_saber_delay.integer;
+        ent->client->Lmd.setSaber.newRequest = qtrue;
+    }
+}

--- a/game/Lmd_SetSaber.c
+++ b/game/Lmd_SetSaber.c
@@ -1,5 +1,10 @@
 #include "Lmd_SetSaber.h"
 
+extern qboolean G_SetSaber(gentity_t *ent, int saberNum, char *saberName, qboolean siegeOverride);
+extern qboolean G_SaberModelSetup(gentity_t* ent);
+extern qboolean WP_SaberStyleValidForSaber(saberInfo_t *saber1, saberInfo_t *saber2, int saberHolstered, int saberAnimLevel);
+extern qboolean WP_UseFirstValidSaberStyle(saberInfo_t *saber1, saberInfo_t *saber2, int saberHolstered, int *saberAnimLevel);
+
 extern vmCvar_t lmd_allow_set_saber;
 extern vmCvar_t lmd_set_saber_duels;
 extern vmCvar_t lmd_set_saber_delay;

--- a/game/Lmd_SetSaber.h
+++ b/game/Lmd_SetSaber.h
@@ -1,0 +1,15 @@
+#ifndef LMD_SETSABER_H
+#define LMD_SETSABER_H
+#include "g_local.h"
+
+typedef struct {
+    char saber1[MAX_QPATH];
+    char saber2[MAX_QPATH];
+    qboolean initialized;
+} clientSaberInfo_t;
+
+static clientSaberInfo_t clientSaberHistory[MAX_CLIENTS];
+
+void lmd_checkSaberChanges(gentity_t* ent);
+
+#endif

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -395,6 +395,8 @@ vmCvar_t lmd_drain_below_level_3_range;
 
 // lumaya: SetSaber enable use time
 vmCvar_t lmd_set_saber_delay;
+vmCvar_t lmd_set_saber_cooldown;
+vmCvar_t lmd_set_saber_duels;
 
 //RoboPhred: track this and force it to off
 vmCvar_t sv_allowdownload;
@@ -619,6 +621,12 @@ static cvarTable_t		gameCvarTable[] = {
 	},
 	{ &lmd_set_saber_delay, "lmd_set_saber_delay", "750", CVAR_ARCHIVE, 0, qtrue, qfalse,
 		"Set the delay for /setsaber for when to be able to use saber again after swapping.",
+	},
+	{ &lmd_set_saber_cooldown, "lmd_set_saber_cooldown", "5000", CVAR_ARCHIVE, 0, qtrue, qfalse,
+		"Set a cooldown for when /setsaber can be used again.",
+	},
+	{ &lmd_set_saber_duels, "lmd_set_saber_duels", "1", CVAR_ARCHIVE, 0, qtrue, qfalse,
+		"Enable/Disable /setsaber in duels.",
 	},
 	//====================================================================================================
 	//====================================================================================================

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -395,8 +395,8 @@ vmCvar_t lmd_drain_below_level_3_range;
 
 // lumaya: SetSaber enable use time
 vmCvar_t lmd_set_saber_delay;
-vmCvar_t lmd_set_saber_cooldown;
 vmCvar_t lmd_set_saber_duels;
+vmCvar_t lmd_allow_set_saber;
 
 //RoboPhred: track this and force it to off
 vmCvar_t sv_allowdownload;
@@ -620,13 +620,13 @@ static cvarTable_t		gameCvarTable[] = {
 	"Set the range for force drain below level 3.",
 	},
 	{ &lmd_set_saber_delay, "lmd_set_saber_delay", "750", CVAR_ARCHIVE, 0, qtrue, qfalse,
-		"Set the delay for /setsaber for when to be able to use saber again after swapping.",
-	},
-	{ &lmd_set_saber_cooldown, "lmd_set_saber_cooldown", "5000", CVAR_ARCHIVE, 0, qtrue, qfalse,
-		"Set a cooldown for when /setsaber can be used again.",
+		"Set the delay for instant saber switch for when to be able to use saber again after swapping.",
 	},
 	{ &lmd_set_saber_duels, "lmd_set_saber_duels", "1", CVAR_ARCHIVE, 0, qtrue, qfalse,
-		"Enable/Disable /setsaber in duels.",
+		"Enable/Disable instant saber switch in duels.",
+	},
+	{ &lmd_allow_set_saber, "lmd_allow_set_saber", "1", CVAR_ARCHIVE, 0, qtrue, qfalse,
+		"Enable/Disable instant saber switch.",
 	},
 	//====================================================================================================
 	//====================================================================================================

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -545,6 +545,7 @@ struct gclient_s {
 			unsigned int delayTime;
 			qboolean openAgain;
 			unsigned int cooldownTime;
+			qboolean newRequest;
 		} setSaber;
 		
     struct 

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -544,6 +544,7 @@ struct gclient_s {
 		{
 			unsigned int delayTime;
 			qboolean openAgain;
+			unsigned int cooldownTime;
 		} setSaber;
 		
     struct 

--- a/game/w_saber.c
+++ b/game/w_saber.c
@@ -247,59 +247,6 @@ static GAME_INLINE int G_SaberAttackPower(gentity_t *ent, qboolean attacking)
 	return baseLevel;
 }
 
-extern qboolean G_SetSaber(gentity_t *ent, int saberNum, char *saberName, qboolean siegeOverride);
-extern qboolean G_SaberModelSetup(gentity_t *ent);
-extern qboolean WP_SaberStyleValidForSaber(int clientNum, saberInfo_t *saber1, saberInfo_t *saber2, int saberHolstered, int saberAnimLevel);
-extern qboolean WP_UseFirstValidSaberStyle(int clientNum, saberInfo_t* saber1, saberInfo_t* saber2, int holstered, int* saberAnimLevel);
-extern vmCvar_t lmd_set_saber_delay;
-void forceSaber(gentity_t *ent, char* saber1, char* saber2)
-{
-	if (ent->client->ps.saberHolstered == 0) ent->client->Lmd.setSaber.openAgain = qtrue;
-	ent->client->ps.saberHolstered = 2;
-	char userinfo[MAX_INFO_STRING];
-
-	trap_GetUserinfo(ent->s.number, userinfo, sizeof(userinfo));
-	Info_SetValueForKey(userinfo, "saber1", saber1);
-	G_SetSaber(ent, 0, saber1, qfalse);
-	Info_SetValueForKey(userinfo, "saber2", saber2);
-	G_SetSaber(ent, 1, saber2, qfalse);
-
-	trap_SetUserinfo(ent->s.number, userinfo);
-	ClientUserinfoChanged(ent->s.number);
-
-	G_SaberModelSetup(ent);
-	
-	if (ent->client->saber[0].saberFlags & SFL_TWO_HANDED) {
-		ent->client->ps.fd.saberAnimLevelBase = ent->client->ps.fd.saberAnimLevel = ent->client->ps.fd.saberDrawAnimLevel = SS_STAFF;
-	}
-	else if (ent->client->saber[1].model[0] && Q_stricmp(ent->client->saber[1].model, "none")) {
-		ent->client->ps.fd.saberAnimLevelBase = ent->client->ps.fd.saberAnimLevel = ent->client->ps.fd.saberDrawAnimLevel = SS_DUAL;
-	}
-	else {
-		if (ent->client->sess.saberLevel < SS_FAST) {
-			ent->client->sess.saberLevel = SS_FAST;
-		}
-		else if (ent->client->sess.saberLevel > SS_STRONG) {
-			ent->client->sess.saberLevel = SS_STRONG;
-		}
-		ent->client->ps.fd.saberAnimLevelBase = ent->client->ps.fd.saberAnimLevel = ent->client->ps.fd.saberDrawAnimLevel = ent->client->sess.saberLevel;
-		if (ent->client->ps.fd.saberAnimLevel > ent->client->ps.fd.forcePowerLevel[FP_SABER_OFFENSE]) {
-			ent->client->ps.fd.saberAnimLevelBase = ent->client->ps.fd.saberAnimLevel = ent->client->ps.fd.saberDrawAnimLevel = ent->client->sess.saberLevel = ent->client->ps.fd.forcePowerLevel[FP_SABER_OFFENSE];
-		}
-	}
-
-	
-	// let's just make sure the styles we chose are cool
-	if (!WP_SaberStyleValidForSaber(ent->s.number, &ent->client->saber[0], &ent->client->saber[1], ent->client->ps.saberHolstered, ent->client->ps.fd.saberAnimLevel)) {
-		WP_UseFirstValidSaberStyle(ent->s.number, &ent->client->saber[0], &ent->client->saber[1], ent->client->ps.saberHolstered, &ent->client->ps.fd.saberAnimLevel);
-		ent->client->ps.fd.saberAnimLevelBase = ent->client->saberCycleQueue = ent->client->ps.fd.saberAnimLevel;
-	}
-	
-	ent->client->Lmd.setSaber.delayTime = level.time +  lmd_set_saber_delay.integer;
-	ent->client->ps.weaponTime = lmd_set_saber_delay.integer;
-	ent->client->Lmd.setSaber.newRequest = qtrue;
-}
-
 void WP_DeactivateSaber( gentity_t *self, qboolean clearLength )
 {
 	if ( !self || !self->client )

--- a/game/w_saber.c
+++ b/game/w_saber.c
@@ -297,6 +297,7 @@ void forceSaber(gentity_t *ent, char* saber1, char* saber2)
 	
 	ent->client->Lmd.setSaber.delayTime = level.time +  lmd_set_saber_delay.integer;
 	ent->client->ps.weaponTime = lmd_set_saber_delay.integer;
+	ent->client->Lmd.setSaber.newRequest = qtrue;
 }
 
 void WP_DeactivateSaber( gentity_t *self, qboolean clearLength )


### PR DESCRIPTION
Removed /setsaber command.

Saber changes occur based on user information now, so it's reacting to /saber or /saber1 or /saber2.

Added new cvars:

- lmd_allow_set_saber: 1 = Allow instant changes (default). 0 = Disallow instant changes.
- lmd_set_saber_duels: 1 = Allow instant changes in duels (default), 0 = Disallow instant changes in duels.