### PR TITLE
Lmd trainer

### DIFF
--- a/game/Lmd_Accounts_Core.c
+++ b/game/Lmd_Accounts_Core.c
@@ -713,10 +713,10 @@ int Accounts_LoadTitles(void)
 
 static int GetTitleIndex(int levelp)
 {
-	if (levelp >= 1 && levelp <= 9) return 0;
-	if (levelp >= 10 && levelp <= 19) return 1;
-	if (levelp >= 20 && levelp <= 29) return 2;
-	if (levelp >= 30 && levelp <= 39) return 3;
+	if (levelp <= 9) return 0;
+	if (levelp <= 19) return 1;
+	if (levelp <= 29) return 2;
+	if (levelp <= 39) return 3;
 	return 4;
 }
 

--- a/game/Lmd_Accounts_Core.c
+++ b/game/Lmd_Accounts_Core.c
@@ -611,6 +611,155 @@ void Accounts_SetTime(Account_t *acc, int value) {
 	Lmd_Accounts_Modify(acc);
 }
 
+// lumaya Titles:
+
+#define MAX_TITLE_LENGTH 32
+#define DEFAULT_TITLE "Unknown"
+#define TITLES_FILE "lugormod/prof_titles.txt"
+
+typedef struct {
+	char jedi_titles[5][MAX_TITLE_LENGTH];
+	char sith_titles[5][MAX_TITLE_LENGTH];
+	char merc_titles[5][MAX_TITLE_LENGTH];
+} LmdTitleData_t;
+
+static LmdTitleData_t lmd_titleData;
+static int lmd_titlesLoaded = 0;
+
+void Accounts_CreateDefaultTitlesFile(void)
+{
+	FILE *file = fopen(TITLES_FILE, "w");
+	if (file == NULL) {
+		G_Printf("Failed to create default titles file\n");
+		return;
+	}
+	
+	fprintf(file, "# Jedi Titles (Level 1-9, 10-19, 20-29, 30-39, 40)\n");
+	fprintf(file, "JEDI,Youngling,Jedi Padawan,Jedi Knight,Jedi Master,Grand Master\n");
+	fprintf(file, "# Sith Titles (Level 1-9, 10-19, 20-29, 30-39, 40)\n");
+	fprintf(file, "SITH,Initiate,Sith Acolyte,Sith Apprentice,Sith Warrior,Sith Lord\n");
+	fprintf(file, "# Mercenary Titles (Level 1-9, 10-19, 20-29, 30-39, 40)\n");
+	fprintf(file, "MERC,Rookie,Hired Gun,Outlaw,Bounty Hunter,Elite Enforcer\n");
+    
+	fclose(file);
+	G_Printf("Created default titles file\n");
+}
+
+int Accounts_LoadTitles(void)
+{
+    FILE *file = fopen(TITLES_FILE, "r");
+    if (file == NULL) {
+        G_Printf("Titles file not found, creating default...\n");
+        Accounts_CreateDefaultTitlesFile();
+        file = fopen(TITLES_FILE, "r");
+        if (file == NULL) {
+            G_Printf("Failed to open titles file\n");
+            return 0;
+        }
+    }
+    
+    char line[256];
+    char *token;
+    int profession = -1;
+	
+    for (int i = 0; i < 5; i++) {
+        strcpy(lmd_titleData.jedi_titles[i], DEFAULT_TITLE);
+        strcpy(lmd_titleData.sith_titles[i], DEFAULT_TITLE);
+        strcpy(lmd_titleData.merc_titles[i], DEFAULT_TITLE);
+    }
+    
+    while (fgets(line, sizeof(line), file)) {
+        if (line[0] == '#' || line[0] == '\n' || line[0] == '\r') {
+            continue;
+        }
+    	
+        line[strcspn(line, "\r\n")] = 0;
+    	
+        token = strtok(line, ",");
+        if (token == NULL) continue;
+        
+        if (strcmp(token, "JEDI") == 0) {
+            profession = 0;
+        } else if (strcmp(token, "SITH") == 0) {
+            profession = 1;
+        } else if (strcmp(token, "MERC") == 0) {
+            profession = 2;
+        } else {
+            continue;
+        }
+    	
+        for (int i = 0; i < 5; i++) {
+            token = strtok(NULL, ",");
+            if (token == NULL) break;
+            
+            if (profession == 0) {
+                strncpy(lmd_titleData.jedi_titles[i], token, MAX_TITLE_LENGTH - 1);
+                lmd_titleData.jedi_titles[i][MAX_TITLE_LENGTH - 1] = '\0';
+            } else if (profession == 1) {
+                strncpy(lmd_titleData.sith_titles[i], token, MAX_TITLE_LENGTH - 1);
+                lmd_titleData.sith_titles[i][MAX_TITLE_LENGTH - 1] = '\0';
+            } else if (profession == 2) {
+                strncpy(lmd_titleData.merc_titles[i], token, MAX_TITLE_LENGTH - 1);
+                lmd_titleData.merc_titles[i][MAX_TITLE_LENGTH - 1] = '\0';
+            }
+        }
+    }
+    
+    fclose(file);
+    lmd_titlesLoaded = 1;
+    G_Printf("Titles loaded successfully\n");
+    return 1;
+}
+
+static int GetTitleIndex(int levelp)
+{
+	if (levelp >= 1 && levelp <= 9) return 0;
+	if (levelp >= 10 && levelp <= 19) return 1;
+	if (levelp >= 20 && levelp <= 29) return 2;
+	if (levelp >= 30 && levelp <= 39) return 3;
+	return 4;
+}
+
+char* Accounts_GetTitle(Account_t *acc)
+{
+	if (acc == NULL) {
+		return DEFAULT_TITLE;
+	}
+	
+	if (!lmd_titlesLoaded) {
+		if (!Accounts_LoadTitles()) {
+			return DEFAULT_TITLE;
+		}
+	}
+    
+	int levelp = Accounts_Prof_GetLevel(acc);
+	const int profession = Accounts_Prof_GetProfession(acc);
+    
+	// idk if that happens, but let's make sure
+	if (levelp < 1) levelp = 1;
+	if (levelp > 40) levelp = 40;
+    
+	int titleIndex = GetTitleIndex(levelp);
+	
+	if (profession == PROF_JEDI)
+	{
+		const int sideAcc = Jedi_GetAccSide(acc);
+		switch (sideAcc)
+		{
+			default:	
+			case 0:
+			case 1:
+				return lmd_titleData.jedi_titles[titleIndex];
+			case 2:
+				return lmd_titleData.sith_titles[titleIndex];
+		}
+	}
+	
+	if (profession == PROF_MERC) return lmd_titleData.merc_titles[titleIndex];
+	
+	return DEFAULT_TITLE;
+}
+
 int Accounts_GetFlags(Account_t *acc) {
 	if(!acc)
 		return 0;

--- a/game/Lmd_Accounts_Core.c
+++ b/game/Lmd_Accounts_Core.c
@@ -748,6 +748,7 @@ char* Accounts_GetTitle(Account_t *acc)
 		{
 			default:	
 			case 0:
+				return "None";
 			case 1:
 				return lmd_titleData.jedi_titles[titleIndex];
 			case 2:

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -15,6 +15,13 @@
 #include "Lmd_Interact.h"
 #include "Lmd_Professions_Public.h"
 
+extern profession_t *Professions[];
+extern void Cmd_SkillSelect_Level(gentity_t* ent, int prof, profSkill_t* skill, qboolean down);
+extern int Professions_AvailableSkillPoints(Account_t *acc, int prof, profSkill_t *skill, profSkill_t **parent);
+extern int Professions_UsedSkillPoints(Account_t *acc, int prof, profSkill_t *skill);
+extern void Cmd_ResetSkills_f (gentity_t *ent, int iArg);
+extern int Jedi_GetSide(gentity_t* ent);
+
 int EntitiesInBox(const vec3_t mins, const vec3_t maxs, int* list, int maxcount, qboolean logical);
 
 //for fake body
@@ -240,8 +247,6 @@ void PlayerUsableGetKeys(gentity_t* ent)
     G_SpawnInt("requirecredits", "", &ent->Lmd.UseReq.credits);
 }
 
-char* ProfessionName(int prof);
-extern int Jedi_GetSide(gentity_t* ent);
 qboolean PlayerUseableCheck(gentity_t* self, gentity_t* activator)
 {
     int activatorLevel;
@@ -3214,7 +3219,6 @@ entityInfo_t lmd_trainer_info = {
 void lmd_menu_exit(gentity_t* player);
 void lmd_filteredskillmenu_show(gentity_t* player, gentity_t* menu, int filterMode);
 void lmd_trainer_use(gentity_t* self, gentity_t* other, gentity_t* activator);
-extern profession_t *Professions[];
 
 void lmd_trainer(gentity_t* self)
 {
@@ -3357,6 +3361,11 @@ void lmd_profselectionmenu_show(gentity_t* player, gentity_t* menu)
     
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
 }
+
+extern qboolean Professions_ChooseProf(gentity_t *ent, int prof);
+extern int Professions_LevelCost(int prof, int level, int time);
+extern int Accounts_Prof_GetLastLevelup(Account_t *acc);
+char* Accounts_GetTitle(Account_t *acc);
 
 void lmd_profselectionmenu_key(gentity_t* player, usercmd_t* cmd)
 {
@@ -3886,8 +3895,6 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
     }
 }
 
-extern void Cmd_SkillSelect_Level(gentity_t* ent, int prof, profSkill_t* skill, qboolean down);
-extern int Professions_AvailableSkillPoints(Account_t *acc, int prof, profSkill_t *skill, profSkill_t **parent);
 void lmd_mercenaryskillmenu_show(gentity_t* player, gentity_t* menu)
 {
     if (!player || !player->client || !menu || !menu->inuse || !player->client->pers.Lmd.account)
@@ -4138,7 +4145,7 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
         player->client->Lmd.lmdMenu.nextUpdateTime = level.time;
     }
 }
-extern void Cmd_ResetSkills_f (gentity_t *ent, int iArg);
+
 void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3226,7 +3226,7 @@ void lmd_trainer(gentity_t* self)
     G_SpawnString("navsnd", "sound/interface/menuroam.mp3", &self->Lmd.navsnd);
     G_SpawnString("cancelsnd", "sound/interface/esc.mp3", &self->Lmd.cancelsnd);
     G_SpawnInt("prof", "0", &self->Lmd.prof);
-    G_SpawnInt("sideAcc", "0", &self->Lmd.sideAcc);
+    G_SpawnInt("subprof", "0", &self->Lmd.sideAcc);
     G_SpawnInt("anim", "0", &self->Lmd.customIndex);
     
     self->use = lmd_trainer_use;

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3496,11 +3496,10 @@ void lmd_levelupmenu_show(gentity_t* player, gentity_t* menu)
 
     if (playerLevel < 40)
     {
-        Q_strcat(msg, sizeof(msg), va("%sLevel Up Confirmation\n\n", colorInfo));
-        Q_strcat(msg, sizeof(msg), va("%sCurrent Level: %i\n", colorNormal, playerLevel));
-        Q_strcat(msg, sizeof(msg), va("%sNew Level: %i\n", colorNormal, playerLevel + 1));
-        Q_strcat(msg, sizeof(msg), va("%sCost: %i credits\n", colorNormal, cost));
-        Q_strcat(msg, sizeof(msg), va("%sRemaining Credits: %i\n\n", colorNormal, remainingCreds));
+        Q_strcat(msg, sizeof(msg), va("%sCurrent Level: %s%i\n", colorInfo, colorNormal, playerLevel));
+        Q_strcat(msg, sizeof(msg), va("%sNew Level: %s%i\n", colorInfo, colorNormal, playerLevel + 1));
+        Q_strcat(msg, sizeof(msg), va("%sCost: %s%i credits\n", colorInfo, colorNormal, cost));
+        Q_strcat(msg, sizeof(msg), va("%sRemaining Credits: %s%i\n\n", colorInfo, colorNormal, remainingCreds));
     }
     
     if (remainingCreds < 0) {
@@ -3708,7 +3707,7 @@ void lmd_trainermenu_show(gentity_t* player, gentity_t* menu)
     } else {
         menuMessage = va("%s[%s ACCOUNT TERMINAL %s]\n"
                         "%sName: %s\n"
-                        "%sTitle: %s%s | %sLevel: %s%i",
+                        "%sTitle: %s%s%s | Level: %s%i",
                         colorInfo, colorNormal, colorInfo,
                         colorNormal, Accounts_GetName(player->client->pers.Lmd.account),
                         colorNormal, colorInfo, Accounts_GetTitle(player->client->pers.Lmd.account), 

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3249,7 +3249,7 @@ void lmd_trainer_use(gentity_t* self, gentity_t* other, gentity_t* activator)
         activator->client->Lmd.lmdMenu.stoppedPressingUsing = qfalse;
         activator->client->Lmd.lmdMenu.menuActive = qtrue;
         activator->client->Lmd.lmdMenu.nextUpdateTime = level.time;
-        activator->client->Lmd.lmdMenu.trainerMenuMode = 9; // New mode for profession selection
+        activator->client->Lmd.lmdMenu.trainerMenuMode = LMD_SELECT_PROF_MENU;
         
         activator->flags |= FL_GODMODE;
         for (int j = 0; j < 2; j++) {
@@ -3276,11 +3276,11 @@ void lmd_trainer_use(gentity_t* self, gentity_t* other, gentity_t* activator)
         
         // Only check side if player has actually chosen one
         if (playerSide != 0) {  // If they have a side
-            if (self->Lmd.sideAcc == 1 && playerSide != FORCE_LIGHTSIDE) {
+            if (self->Lmd.sideAcc == FORCE_LIGHTSIDE && playerSide != FORCE_LIGHTSIDE) {
                 trap_SendServerCommand(activator->s.number, va("cp \"^3This trainer only trains Jedi.\""));
                 return;
             }
-            else if (self->Lmd.sideAcc == 2 && playerSide != FORCE_DARKSIDE) {
+            else if (self->Lmd.sideAcc == FORCE_DARKSIDE && playerSide != FORCE_DARKSIDE) {
                 trap_SendServerCommand(activator->s.number, va("cp \"^3This trainer only trains Sith.\""));
                 return;
             }
@@ -3303,7 +3303,7 @@ void lmd_trainer_use(gentity_t* self, gentity_t* other, gentity_t* activator)
     activator->client->Lmd.lmdMenu.choicesVisible = 0;
     activator->client->Lmd.lmdMenu.menuActive = qtrue;
     activator->client->Lmd.lmdMenu.nextUpdateTime = level.time;
-    activator->client->Lmd.lmdMenu.trainerMenuMode = 0;
+    activator->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
 
     activator->flags |= FL_GODMODE;
     for (int j = 0; j < 2; j++)
@@ -3574,7 +3574,7 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
         if (cmd->buttons & BUTTON_USE && player->client->Lmd.lmdMenu.stoppedPressingUsing)
         {
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-            player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
             player->client->Lmd.lmdMenu.selection = 0;
             updateMenu = qtrue;
             player->client->Lmd.lmdMenu.stoppedPressingUsing = qfalse;
@@ -3627,7 +3627,7 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
     {
         if (remainingCreds < 0) {
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-            player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
             player->client->Lmd.lmdMenu.selection = 0;
         } else {
             if (player->client->Lmd.lmdMenu.selection == 0) {
@@ -3638,7 +3638,7 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
                 WP_InitForcePowers(player);
             } else {
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-                player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+                player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
                 player->client->Lmd.lmdMenu.selection = 0;
             }
         }
@@ -3868,7 +3868,7 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
             trap_SendServerCommand(player->s.number, "cp \" \"");
         } else {
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-            player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
             player->client->Lmd.lmdMenu.selection = 0;
         }
         
@@ -4091,7 +4091,7 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
             else if (player->client->Lmd.lmdMenu.skillIndex == skillsOnCurrentPage + 1 && (isAttack || isUse))
             {
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-                player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+                player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
                 player->client->Lmd.lmdMenu.selection = 0;
                 player->client->Lmd.lmdMenu.currentPage = 0;
                 updateMenu = qtrue;
@@ -4226,58 +4226,54 @@ void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd)
     {
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qtrue;
     }
-
-    // Handle selection
+    
     if (cmd->buttons & BUTTON_USE && player->client->Lmd.lmdMenu.stoppedPressingUsing)
     {
-        // Level Up is always option 0
         if (player->client->Lmd.lmdMenu.selection == 0) {
             player->client->Lmd.lmdMenu.selection = 0;
-            player->client->Lmd.lmdMenu.trainerMenuMode = 6; // Level up menu
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_LEVEL_UP_MENU;
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
         }
-        // Check for profession-specific options
         else if (prof == PROF_MERC && player->client->Lmd.lmdMenu.selection == mercOption) {
             player->client->Lmd.lmdMenu.skillIndex = 0;
-            player->client->Lmd.lmdMenu.trainerMenuMode = 5; // Mercenary skills
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_MERC_SKILLS_MENU;
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
         }
         else if (prof == PROF_JEDI) {
-            // Neutral Skills
             if (player->client->Lmd.lmdMenu.selection == neutralOption) {
                 player->client->Lmd.lmdMenu.skillIndex = 0;
-                player->client->Lmd.lmdMenu.trainerMenuMode = 2; // Neutral skills
+                player->client->Lmd.lmdMenu.trainerMenuMode = LMD_NEUTRAL_SKILLS_MENU;
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
             }
-            // Jedi Skills
+
             else if (jediOption != -1 && player->client->Lmd.lmdMenu.selection == jediOption) {
                 player->client->Lmd.lmdMenu.skillIndex = 0;
                 player->client->ps.fd.forceSide = FORCE_LIGHTSIDE;
-                player->client->Lmd.lmdMenu.trainerMenuMode = 3; // Jedi skills
+                player->client->Lmd.lmdMenu.trainerMenuMode = LMD_JEDI_SKILLS_MENU;
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
             }
-            // Sith Skills
+
             else if (sithOption != -1 && player->client->Lmd.lmdMenu.selection == sithOption) {
                 player->client->Lmd.lmdMenu.skillIndex = 0;
                 player->client->ps.fd.forceSide = FORCE_DARKSIDE;
-                player->client->Lmd.lmdMenu.trainerMenuMode = 4; // Sith skills
+                player->client->Lmd.lmdMenu.trainerMenuMode = LMD_SITH_SKILLS_MENU;
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
             }
         }
         
-        // Swap Profession
+
         if (player->client->Lmd.lmdMenu.selection == swapProfOption) {
             player->client->Lmd.lmdMenu.selection = 0; 
-            player->client->Lmd.lmdMenu.trainerMenuMode = 8; // Swap profession menu (new menu mode)
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_SWAP_PROF_MENU;
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
         }
-        // Reset Skills (available to everyone)
+
         else if (player->client->Lmd.lmdMenu.selection == resetOption) {
             player->client->Lmd.lmdMenu.selection = 0; 
-            player->client->Lmd.lmdMenu.trainerMenuMode = 7; // Reset skills menu
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_RESET_SKILLS_MENU;
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
         }
-        // Exit (available to everyone)
+
         else if (player->client->Lmd.lmdMenu.selection == exitOption) {
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             lmd_menu_exit(player);
@@ -4477,18 +4473,17 @@ void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd)
 
     int totalSkills = 0;
     profSkill_t* root = &Professions[PlayerAcc_Prof_GetProfession(player)]->primarySkill;
-
-    // Count skills based on mode
+    
     for (int t = 0; t < root->subSkills.count; t++)
     {
         profSkill_t* tree = &root->subSkills.skill[t];
         const char* treeName = tree->name ? tree->name : "Unknown";
 
-        if (player->client->Lmd.lmdMenu.trainerMenuMode == 3) {
+        if (player->client->Lmd.lmdMenu.trainerMenuMode == LMD_JEDI_SKILLS_MENU) {
             if (Q_stricmp(treeName, "Jedi") != 0) {
                 continue;
             }
-        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == 4) {
+        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == LMD_SITH_SKILLS_MENU) {
             if (Q_stricmp(treeName, "Sith") != 0) {
                 continue;
             }
@@ -4565,7 +4560,7 @@ void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.skillIndex == totalSkills)
         {
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-            player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
             player->client->Lmd.lmdMenu.selection = 0;
             updateMenu = qtrue;
         }
@@ -4688,17 +4683,17 @@ void lmd_skillmenu_tryLevelChange(gentity_t* player, qboolean down)
         profSkill_t* tree = &root->subSkills.skill[t];
         const char* treeName = tree->name ? tree->name : "Unknown";
         
-        if (player->client->Lmd.lmdMenu.trainerMenuMode == 2) {
+        if (player->client->Lmd.lmdMenu.trainerMenuMode == LMD_NEUTRAL_SKILLS_MENU) {
             if (!Q_stricmp(treeName, "Saber") || 
                 !Q_stricmp(treeName, "Jedi") || 
                 !Q_stricmp(treeName, "Sith")) {
                 continue;
                 }
-        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == 3) {
+        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == LMD_JEDI_SKILLS_MENU) {
             if (Q_stricmp(treeName, "Jedi") != 0) {
                 continue;
             }
-        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == 4) {
+        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == LMD_SITH_SKILLS_MENU) {
             if (Q_stricmp(treeName, "Sith") != 0) {
                 continue;
             }
@@ -4815,17 +4810,17 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
     {
         if (used == 0) {
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-            player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
             player->client->Lmd.lmdMenu.selection = 0;
         } else {
             if (player->client->Lmd.lmdMenu.selection == 0) {
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
                 Cmd_ResetSkills_f(player, 0);
-                player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+                player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
                 player->client->Lmd.lmdMenu.selection = 0;
             } else {
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-                player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+                player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
                 player->client->Lmd.lmdMenu.selection = 0;
             }
         }
@@ -4853,31 +4848,31 @@ void lmd_menu_display(gentity_t* player)
         return;
 
     switch (player->client->Lmd.lmdMenu.trainerMenuMode) {
-    case 0:
+    case LMD_TRAINER_MENU:
         lmd_trainermenu_show(player, menu);
         break;
-    case 2:
+    case LMD_NEUTRAL_SKILLS_MENU:
         lmd_filteredskillmenu_show(player, menu, player->client->Lmd.lmdMenu.trainerMenuMode);
         break;
-    case 3:
+    case LMD_JEDI_SKILLS_MENU:
         lmd_jediskillmenu_show(player, menu);
         break;
-    case 4:
+    case LMD_SITH_SKILLS_MENU:
         lmd_sithskillmenu_show(player, menu);
         break;
-    case 5:
+    case LMD_MERC_SKILLS_MENU:
         lmd_mercenaryskillmenu_show(player, menu);
         break;
-    case 6:
+    case LMD_LEVEL_UP_MENU:
         lmd_levelupmenu_show(player, menu);
         break;
-    case 7:
+    case LMD_RESET_SKILLS_MENU:
         lmd_resetskillsmenu_show(player, menu);
         break;
-    case 8:
+    case LMD_SWAP_PROF_MENU:
         lmd_swapprofmenu_show(player, menu);
         break;
-    case 9:
+    case LMD_SELECT_PROF_MENU:
         lmd_profselectionmenu_show(player, menu);
         break;
     default:
@@ -4992,7 +4987,7 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.skillIndex == totalSkills)
         {
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-            player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+            player->client->Lmd.lmdMenu.trainerMenuMode = LMD_TRAINER_MENU;
             player->client->Lmd.lmdMenu.selection = 0;
             player->client->Lmd.lmdMenu.skillIndex = 0;
             updateMenu = qtrue;

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1638,7 +1638,7 @@ void lmd_menu_enter(gentity_t* player, gentity_t* menu)
         player->client->ps.velocity[j] = 0.0f;
     }
 
-    G_SetAnim(player, SETANIM_BOTH, BOTH_CONSOLE1, SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD | SETANIM_FLAG_RESTART, 0);
+    G_SetAnim(player, SETANIM_BOTH, menu->Lmd.customIndex == 0 ? BOTH_CONSOLE1 : BOTH_TALK1, SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD | SETANIM_FLAG_RESTART, 0);
 }
 
 
@@ -1939,6 +1939,7 @@ const entityInfoData_t lmd_terminal_keys[] = {
     {"navsnd", "Sound played for navigation."},
     {"cancelsnd", "Sound played for cancel."},
     {"targetname", "Activate the lmd_terminal when targetted."},
+    {"anim", "Animation to use (0 = console, 1 = console)."},
     NULL
 };
 
@@ -1995,6 +1996,7 @@ void lmd_terminal(gentity_t* ent)
     G_SpawnString("cancelsnd", "sound/interface/esc.mp3", &ent->Lmd.cancelsnd);
     G_SpawnInt("messageDelay", "0", &ent->Lmd.messageDelay);
     G_SpawnInt("choiceDelay", "0", &ent->Lmd.choiceDelay);
+    G_SpawnInt("anim", "0", &ent->Lmd.customIndex);
 
 
     if (ent->Lmd.spawnData && Q_stricmp(ent->classname, "t2_terminal") == 0)
@@ -3192,9 +3194,12 @@ const entityInfoData_t lmd_trainer_keys[] = {
     {"targetname", "Activate the lmd_trainer when targetted."},
     {"prof", "Professions this trainer handles (0 = all, 1 = Jedi, 2 = Merc)"},
     {"sideAcc", "Force sides this trainer handles (0 = all, 1 = light, 2 = dark). Only matters if prof = 1."},
+    {"anim", "Animation to use (0 = console, 1 = console)."},
+    {"selectsnd", "Sound played for confirmation."},
+    {"navsnd", "Sound played for navigation."},
+    {"cancelsnd", "Sound played for cancel."},
     {NULL, NULL}
 };
-
 entityInfo_t lmd_trainer_info = {
     "An interactive menu letting you level up skills and whatnot.",
     lmd_trainer_spawnflags,
@@ -3211,10 +3216,12 @@ void lmd_trainer(gentity_t* self)
     G_SpawnString("color1", "^3", &self->Lmd.color);
     G_SpawnString("color2", "^5", &self->Lmd.color2);
     G_SpawnString("message", "Welcome to the Skills Trainer", &self->message);
-    
-    // Initialize new fields with defaults
+    G_SpawnString("selectsnd", "sound/movers/switches/switch1.mp3", &self->Lmd.selectsnd);
+    G_SpawnString("navsnd", "sound/interface/menuroam.mp3", &self->Lmd.navsnd);
+    G_SpawnString("cancelsnd", "sound/interface/esc.mp3", &self->Lmd.cancelsnd);
     G_SpawnInt("prof", "0", &self->Lmd.prof);
     G_SpawnInt("sideAcc", "0", &self->Lmd.sideAcc);
+    G_SpawnInt("anim", "0", &self->Lmd.customIndex);
     
     self->use = lmd_trainer_use;
     self->classname = "lmd_trainer";
@@ -3243,7 +3250,7 @@ void lmd_trainer_use(gentity_t* self, gentity_t* other, gentity_t* activator)
             activator->client->ps.velocity[j] = 0.0f;
         }
         
-        G_SetAnim(activator, SETANIM_BOTH, BOTH_TALK1, SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD | SETANIM_FLAG_RESTART, 0);
+        G_SetAnim(activator, SETANIM_BOTH, self->Lmd.customIndex == 0 ? BOTH_CONSOLE1 : BOTH_TALK1, SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD | SETANIM_FLAG_RESTART, 0);
         return;
     }
     
@@ -3298,7 +3305,7 @@ void lmd_trainer_use(gentity_t* self, gentity_t* other, gentity_t* activator)
         activator->client->ps.velocity[j] = 0.0f;
     }
 
-    G_SetAnim(activator, SETANIM_BOTH, BOTH_TALK1, SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD | SETANIM_FLAG_RESTART, 0);
+        G_SetAnim(activator, SETANIM_BOTH, self->Lmd.customIndex == 0 ? BOTH_CONSOLE1 : BOTH_TALK1, SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD | SETANIM_FLAG_RESTART, 0);
 }
 
 void lmd_profselectionmenu_show(gentity_t* player, gentity_t* menu)
@@ -3384,7 +3391,7 @@ void lmd_profselectionmenu_key(gentity_t* player, usercmd_t* cmd)
             // Wrap to bottom
             player->client->Lmd.lmdMenu.selection = totalOptions - 1;
         }
-        G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+        G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
         updateMenu = qtrue;
         player->client->Lmd.lmdMenu.stoppedPressingForward = qfalse;
     }
@@ -3404,7 +3411,7 @@ void lmd_profselectionmenu_key(gentity_t* player, usercmd_t* cmd)
             // Wrap to top
             player->client->Lmd.lmdMenu.selection = 0;
         }
-        G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+        G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
         updateMenu = qtrue;
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qfalse;
     }
@@ -3419,7 +3426,7 @@ void lmd_profselectionmenu_key(gentity_t* player, usercmd_t* cmd)
         // Check if Exit option was selected (last option)
         if (player->client->Lmd.lmdMenu.selection == profOptions) {
             // Exit selected
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             lmd_menu_exit(player);
             trap_SendServerCommand(player->s.number, "cp \" \"");
             return;
@@ -3484,12 +3491,15 @@ void lmd_levelupmenu_show(gentity_t* player, gentity_t* menu)
     int cost = Professions_LevelCost(prof, playerLevel, 
                 Time_Now() - Accounts_Prof_GetLastLevelup(player->client->pers.Lmd.account));
     int remainingCreds = myCreds - cost;
-    
-    Q_strcat(msg, sizeof(msg), va("%sLevel Up Confirmation\n\n", colorHighlight));
-    Q_strcat(msg, sizeof(msg), va("%sCurrent Level: %i\n", colorNormal, playerLevel));
-    Q_strcat(msg, sizeof(msg), va("%sNew Level: %i\n", colorNormal, playerLevel + 1));
-    Q_strcat(msg, sizeof(msg), va("%sCost: %i credits\n", colorNormal, cost));
-    Q_strcat(msg, sizeof(msg), va("%sRemaining Credits: %i\n\n", colorNormal, remainingCreds));
+
+    if (playerLevel < 40)
+    {
+        Q_strcat(msg, sizeof(msg), va("%sLevel Up Confirmation\n\n", colorHighlight));
+        Q_strcat(msg, sizeof(msg), va("%sCurrent Level: %i\n", colorNormal, playerLevel));
+        Q_strcat(msg, sizeof(msg), va("%sNew Level: %i\n", colorNormal, playerLevel + 1));
+        Q_strcat(msg, sizeof(msg), va("%sCost: %i credits\n", colorNormal, cost));
+        Q_strcat(msg, sizeof(msg), va("%sRemaining Credits: %i\n\n", colorNormal, remainingCreds));
+    }
     
     if (remainingCreds < 0) {
         Q_strcat(msg, sizeof(msg), va("%sYou need %i more credits to level up.\n\n", 
@@ -3500,7 +3510,19 @@ void lmd_levelupmenu_show(gentity_t* player, gentity_t* menu)
             (player->client->Lmd.lmdMenu.selection == 0) ? ">" : " "));
             
         Q_strcat(msg, sizeof(msg), va("%sPress Use to go back\n", colorHighlight));
-    } else {
+    }
+    else if (playerLevel >= 40)
+    {
+        Q_strcat(msg, sizeof(msg), va("%sYou have reached the maximum level.\n\n", 
+                                   colorHighlight, -remainingCreds));
+        
+        Q_strcat(msg, sizeof(msg), va("%s%sBack\n\n", 
+            (player->client->Lmd.lmdMenu.selection == 0) ? colorHighlight : colorNormal,
+            (player->client->Lmd.lmdMenu.selection == 0) ? ">" : " "));
+            
+        Q_strcat(msg, sizeof(msg), va("%sPress Use to go back\n", colorHighlight));
+    }
+    else {
         Q_strcat(msg, sizeof(msg), va("%s%sYes\n", 
             (player->client->Lmd.lmdMenu.selection == 0) ? colorHighlight : colorNormal,
             (player->client->Lmd.lmdMenu.selection == 0) ? ">" : " "));
@@ -3520,25 +3542,62 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)
         return;
-    
+
+    gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
+    if (!menu)
+        return;
+
     int prof = PlayerAcc_Prof_GetProfession(player);
     int playerLevel = PlayerAcc_Prof_GetLevel(player);
     int myCreds = PlayerAcc_GetCredits(player);
     int cost = Professions_LevelCost(prof, playerLevel, 
                 Time_Now() - Accounts_Prof_GetLastLevelup(player->client->pers.Lmd.account));
     int remainingCreds = myCreds - cost;
-    
-    int totalOptions = (remainingCreds < 0) ? 1 : 2;
+
+    const int maxLevel = 40;
     qboolean up = cmd->forwardmove > 0;
     qboolean down = cmd->forwardmove < 0;
     qboolean updateMenu = qfalse;
-    
+
+    // --- If max level is reached, only allow "Back" option ---
+    if (playerLevel >= maxLevel)
+    {
+        if ((up && player->client->Lmd.lmdMenu.stoppedPressingForward) ||
+            (down && player->client->Lmd.lmdMenu.stoppedPressingBackward)) {
+            // No selection change possible, only one item
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
+            updateMenu = qtrue;
+        }
+
+        if (cmd->buttons & BUTTON_USE && player->client->Lmd.lmdMenu.stoppedPressingUsing)
+        {
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
+            player->client->Lmd.lmdMenu.trainerMenuMode = 0;
+            player->client->Lmd.lmdMenu.selection = 0;
+            updateMenu = qtrue;
+            player->client->Lmd.lmdMenu.stoppedPressingUsing = qfalse;
+        }
+        else if (!(cmd->buttons & BUTTON_USE))
+        {
+            player->client->Lmd.lmdMenu.stoppedPressingUsing = qtrue;
+        }
+
+        if (updateMenu)
+        {
+            player->client->Lmd.lmdMenu.nextUpdateTime = level.time;
+        }
+        return;
+    }
+
+    // --- Normal behavior for selection navigation ---
+    int totalOptions = (remainingCreds < 0) ? 1 : 2;
+
     if (up && player->client->Lmd.lmdMenu.stoppedPressingForward)
     {
         if (player->client->Lmd.lmdMenu.selection > 0)
         {
             player->client->Lmd.lmdMenu.selection--;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingForward = qfalse;
@@ -3553,7 +3612,7 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.selection < totalOptions - 1)
         {
             player->client->Lmd.lmdMenu.selection++;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qfalse;
@@ -3562,11 +3621,11 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
     {
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qtrue;
     }
-    
+
     if (cmd->buttons & BUTTON_USE && player->client->Lmd.lmdMenu.stoppedPressingUsing)
     {
         if (remainingCreds < 0) {
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             player->client->Lmd.lmdMenu.trainerMenuMode = 0;
             player->client->Lmd.lmdMenu.selection = 0;
         } else {
@@ -3576,12 +3635,8 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
                 PlayerAcc_Prof_SetLevel(player, playerLevel + 1);
                 trap_SendServerCommand(player->s.number, va("print \"^3You are now at level ^2%i^3.\n\"", playerLevel + 1));
                 WP_InitForcePowers(player);
-
-                // lumaya: we are staying here, for now
-                //player->client->Lmd.lmdMenu.trainerMenuMode = 0;
-                //player->client->Lmd.lmdMenu.selection = 0;
             } else {
-                G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+                G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
                 player->client->Lmd.lmdMenu.trainerMenuMode = 0;
                 player->client->Lmd.lmdMenu.selection = 0;
             }
@@ -3593,12 +3648,13 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
     {
         player->client->Lmd.lmdMenu.stoppedPressingUsing = qtrue;
     }
-    
+
     if (updateMenu)
     {
         player->client->Lmd.lmdMenu.nextUpdateTime = level.time;
     }
 }
+
 
 void lmd_trainermenu_show(gentity_t* player, gentity_t* menu)
 {
@@ -3721,10 +3777,16 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)
         return;
+
+    gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
+    if (!menu)
+        return;
         
     int prof = PlayerAcc_Prof_GetProfession(player);
     int targetProf = (prof == PROF_MERC) ? PROF_JEDI : PROF_MERC;
     int totalOptions = 2; // Yes/No
+
+    
     
     qboolean up = cmd->forwardmove > 0;
     qboolean down = cmd->forwardmove < 0;
@@ -3736,7 +3798,7 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.selection > 0)
         {
             player->client->Lmd.lmdMenu.selection--;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingForward = qfalse;
@@ -3751,7 +3813,7 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.selection < totalOptions - 1)
         {
             player->client->Lmd.lmdMenu.selection++;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qfalse;
@@ -3776,7 +3838,7 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
             player->client->Lmd.lmdMenu.selection = 0;
         } else {
             // "No" - cancel
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             // Return to main menu
             player->client->Lmd.lmdMenu.trainerMenuMode = 0;
             player->client->Lmd.lmdMenu.selection = 0;
@@ -3817,10 +3879,10 @@ void lmd_mercenaryskillmenu_show(gentity_t* player, gentity_t* menu)
         colorHighlight = menu->Lmd.color;
     }
 
-    profSkill_t* root = &Professions[PlayerAcc_Prof_GetProfession(player)]->primarySkill;
+    int prof = PlayerAcc_Prof_GetProfession(player);
 
-    // lumaya: nope
-    //Q_strcat(msg, sizeof(msg), va("%sSkills for Mercenary\n\n", colorHighlight));
+    profSkill_t* root = &Professions[prof]->primarySkill;
+
     
     if (root->subSkills.count > 0 && root->subSkills.skill)
     {
@@ -3847,11 +3909,12 @@ void lmd_mercenaryskillmenu_show(gentity_t* player, gentity_t* menu)
     
     qboolean selectedExit = (player->client->Lmd.lmdMenu.skillIndex == skillCount);
     const char* exitColor = selectedExit ? colorHighlight : colorNormal;
-    Q_strcat(msg, sizeof(msg), va("\n%s%sBack to Main Menu\n\n", exitColor, selectedExit ? ">" : " "));
-    
+    int availablePoints = Professions_AvailableSkillPoints(player->client->pers.Lmd.account, prof, &root->subSkills.skill[0], NULL);
+    Q_strcat(msg, sizeof(msg), va("\n%s%sBack to Main Menu\n", exitColor, selectedExit ? ">" : " "));
+
     Q_strcat(msg, sizeof(msg),
-        va("%sAttack (Increase) | Alt Attack (Decrease)", colorHighlight)
-);
+            va("%sAttack (Increase) | Alt Attack (Decrease)\n"
+                "%sAvailable Points: %s%i", colorNormal, colorNormal, colorHighlight, availablePoints));
 
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
 }
@@ -3859,6 +3922,10 @@ void lmd_mercenaryskillmenu_show(gentity_t* player, gentity_t* menu)
 void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)
+        return;
+
+    gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
+    if (!menu)
         return;
 
     profSkill_t* root = &Professions[PlayerAcc_Prof_GetProfession(player)]->primarySkill;
@@ -3874,7 +3941,7 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.skillIndex > 0)
         {
             player->client->Lmd.lmdMenu.skillIndex--;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingForward = qfalse;
@@ -3889,7 +3956,7 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.skillIndex < totalItems - 1)
         {
             player->client->Lmd.lmdMenu.skillIndex++;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qfalse;
@@ -3908,7 +3975,7 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
             {
                 profSkill_t* skill = &root->subSkills.skill[player->client->Lmd.lmdMenu.skillIndex];
                 Cmd_SkillSelect_Level(player, PlayerAcc_Prof_GetProfession(player), skill, qfalse);
-                G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/movers/switches/switch1.mp3"));
+                G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
             }
             player->client->Lmd.lmdMenu.stoppedPressingAttack = qfalse;
             updateMenu = qtrue;
@@ -3928,7 +3995,7 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
             {
                 profSkill_t* skill = &root->subSkills.skill[player->client->Lmd.lmdMenu.skillIndex];
                 Cmd_SkillSelect_Level(player, PlayerAcc_Prof_GetProfession(player), skill, qtrue);
-                G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/movers/switches/switch1.mp3"));
+                G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
             }
             player->client->Lmd.lmdMenu.stoppedPressingAltAttack = qfalse;
             updateMenu = qtrue;
@@ -3943,7 +4010,7 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
     {
         if (player->client->Lmd.lmdMenu.skillIndex == totalSkills)
         {
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             player->client->Lmd.lmdMenu.trainerMenuMode = 0;
             player->client->Lmd.lmdMenu.selection = 0;
             updateMenu = qtrue;
@@ -3965,6 +4032,10 @@ extern void Cmd_ResetSkills_f (gentity_t *ent, int iArg);
 void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)
+        return;
+
+    gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
+    if (!menu)
         return;
     
     int totalOptions = 1;
@@ -4012,7 +4083,7 @@ void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd)
     totalOptions++;
 
     exitOption = currentOption;
-    totalOptions += 2;
+    totalOptions++;
     
     qboolean up = cmd->forwardmove > 0;
     qboolean down = cmd->forwardmove < 0;
@@ -4023,7 +4094,7 @@ void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.selection > 0)
         {
             player->client->Lmd.lmdMenu.selection--;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingForward = qfalse;
@@ -4038,7 +4109,7 @@ void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.selection < totalOptions - 1)
         {
             player->client->Lmd.lmdMenu.selection++;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qfalse;
@@ -4100,7 +4171,7 @@ void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd)
         }
         // Exit (available to everyone)
         else if (player->client->Lmd.lmdMenu.selection == exitOption) {
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             lmd_menu_exit(player);
             trap_SendServerCommand(player->s.number, "cp \" \"");
         }
@@ -4130,8 +4201,9 @@ void lmd_jediskillmenu_show(gentity_t* player, gentity_t* menu)
 
     const char* colorNormal = (menu->Lmd.color2 && *menu->Lmd.color2) ? menu->Lmd.color2 : "^5";
     const char* colorHighlight = (menu->Lmd.color && *menu->Lmd.color) ? menu->Lmd.color : "^3";
+    const int prof = PlayerAcc_Prof_GetProfession(player);
 
-    profSkill_t* root = &Professions[PlayerAcc_Prof_GetProfession(player)]->primarySkill;
+    profSkill_t* root = &Professions[prof]->primarySkill;
 
     // lumaya: nope
     //Q_strcat(msg, sizeof(msg), va("%sJedi Skills Menu\n\n", colorHighlight));
@@ -4170,10 +4242,13 @@ void lmd_jediskillmenu_show(gentity_t* player, gentity_t* menu)
 
     qboolean selectedExit = (player->client->Lmd.lmdMenu.skillIndex == skillCount);
     const char* exitColor = selectedExit ? colorHighlight : colorNormal;
-    Q_strcat(msg, sizeof(msg), va("\n%s%sBack to Main Menu\n\n", exitColor, selectedExit ? ">" : " "));
+    
+    int availablePoints = Professions_AvailableSkillPoints(player->client->pers.Lmd.account, prof, &root->subSkills.skill[0], NULL);
+    Q_strcat(msg, sizeof(msg), va("\n%s%sBack to Main Menu\n", exitColor, selectedExit ? ">" : " "));
 
     Q_strcat(msg, sizeof(msg),
-            va("%sAttack (Increase) | Alt Attack (Decrease)", colorHighlight)
+            va("%sAttack (Increase) | Alt Attack (Decrease)\n"
+                "%sAvailable Points: %s%i", colorNormal, colorNormal, colorHighlight, availablePoints)
     );
 
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
@@ -4190,8 +4265,9 @@ void lmd_sithskillmenu_show(gentity_t* player, gentity_t* menu)
     
     const char* colorNormal = (menu->Lmd.color2 && *menu->Lmd.color2) ? menu->Lmd.color2 : "^5";
     const char* colorHighlight = (menu->Lmd.color && *menu->Lmd.color) ? menu->Lmd.color : "^3";
+    const int prof = PlayerAcc_Prof_GetProfession(player);
 
-    profSkill_t* root = &Professions[PlayerAcc_Prof_GetProfession(player)]->primarySkill;
+    profSkill_t* root = &Professions[prof]->primarySkill;
 
     // lumaya: nope
     //Q_strcat(msg, sizeof(msg), va("%sSith Skills Menu\n\n", colorHighlight));
@@ -4230,11 +4306,12 @@ void lmd_sithskillmenu_show(gentity_t* player, gentity_t* menu)
 
     qboolean selectedExit = (player->client->Lmd.lmdMenu.skillIndex == skillCount);
     const char* exitColor = selectedExit ? colorHighlight : colorNormal;
-    Q_strcat(msg, sizeof(msg), va("\n%s%sBack to Main Menu\n\n", exitColor, selectedExit ? ">" : " "));
+    int availablePoints = Professions_AvailableSkillPoints(player->client->pers.Lmd.account, prof, &root->subSkills.skill[0], NULL);
+    Q_strcat(msg, sizeof(msg), va("\n%s%sBack to Main Menu\n", exitColor, selectedExit ? ">" : " "));
 
     Q_strcat(msg, sizeof(msg),
-            va("%sAttack (Increase) | Alt Attack (Decrease)", colorHighlight)
-    );
+            va("%sAttack (Increase) | Alt Attack (Decrease)\n"
+                "%sAvailable Points: %s%i", colorNormal, colorNormal, colorHighlight, availablePoints));
 
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
 }
@@ -4243,6 +4320,10 @@ void lmd_skillmenu_tryLevelChange(gentity_t* player, qboolean down);
 void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)
+        return;
+
+    gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
+    if (!menu)
         return;
 
     int totalSkills = 0;
@@ -4277,7 +4358,7 @@ void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.skillIndex > 0)
         {
             player->client->Lmd.lmdMenu.skillIndex--;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingForward = qfalse;
@@ -4292,7 +4373,7 @@ void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.skillIndex < totalItems - 1)
         {
             player->client->Lmd.lmdMenu.skillIndex++;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qfalse;
@@ -4334,7 +4415,7 @@ void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd)
     {
         if (player->client->Lmd.lmdMenu.skillIndex == totalSkills)
         {
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             player->client->Lmd.lmdMenu.trainerMenuMode = 0;
             player->client->Lmd.lmdMenu.selection = 0;
             updateMenu = qtrue;
@@ -4364,7 +4445,9 @@ void lmd_filteredskillmenu_show(gentity_t* player, gentity_t* menu, int filterMo
     const char* colorNormal = (menu->Lmd.color2 && *menu->Lmd.color2) ? menu->Lmd.color2 : "^3";
     const char* colorHighlight = (menu->Lmd.color && *menu->Lmd.color) ? menu->Lmd.color : "^5";
 
-    profSkill_t* root = &Professions[PlayerAcc_Prof_GetProfession(player)]->primarySkill;
+    const int prof = PlayerAcc_Prof_GetProfession(player);
+
+    profSkill_t* root = &Professions[prof]->primarySkill;
 
     for (int t = 0; t < root->subSkills.count; t++)
     {
@@ -4405,17 +4488,22 @@ void lmd_filteredskillmenu_show(gentity_t* player, gentity_t* menu, int filterMo
 
     qboolean selectedExit = (player->client->Lmd.lmdMenu.skillIndex == skillCount);
     const char* exitColor = selectedExit ? colorHighlight : colorNormal;
-    Q_strcat(msg, sizeof(msg), va("\n%s%sBack to Main Menu\n\n", exitColor, selectedExit ? ">" : " "));
+    int availablePoints = Professions_AvailableSkillPoints(player->client->pers.Lmd.account, prof, &root->subSkills.skill[0], NULL);
+    Q_strcat(msg, sizeof(msg), va("\n%s%sBack to Main Menu\n", exitColor, selectedExit ? ">" : " "));
 
     Q_strcat(msg, sizeof(msg),
-            va("%sAttack (Increase) | Alt Attack (Decrease)", colorHighlight)
-    );
+            va("%sAttack (Increase) | Alt Attack (Decrease)\n"
+                "%sAvailable Points: %s%i", colorNormal, colorNormal, colorHighlight, availablePoints));
 
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
 }
 
 void lmd_skillmenu_tryLevelChange(gentity_t* player, qboolean down)
 {
+    gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
+    if (!menu)
+        return;
+    
     int selection = player->client->Lmd.lmdMenu.skillIndex;
     int counter = 0;
 
@@ -4454,7 +4542,7 @@ void lmd_skillmenu_tryLevelChange(gentity_t* player, qboolean down)
             if (counter == selection)
             {
                 Cmd_SkillSelect_Level(player, PlayerAcc_Prof_GetProfession(player), &tree->subSkills.skill[s], down);
-                G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/movers/switches/switch1.mp3"));
+                G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
                 return;
             }
             counter++;
@@ -4508,6 +4596,10 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)
         return;
+
+    gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
+    if (!menu)
+        return;
         
     // Check if player has any skills to reset
     int prof = PlayerAcc_Prof_GetProfession(player);
@@ -4524,7 +4616,7 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.selection > 0)
         {
             player->client->Lmd.lmdMenu.selection--;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingForward = qfalse;
@@ -4539,7 +4631,7 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.selection < totalOptions - 1)
         {
             player->client->Lmd.lmdMenu.selection++;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qfalse;
@@ -4554,7 +4646,7 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
     {
         if (used == 0) {
             // No skills to reset - only "Back" option
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             // Return to main menu
             player->client->Lmd.lmdMenu.trainerMenuMode = 0;
             player->client->Lmd.lmdMenu.selection = 0;
@@ -4569,7 +4661,7 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
                 player->client->Lmd.lmdMenu.selection = 0;
             } else {
                 // "No" - cancel
-                G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+                G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
                 // Return to main menu
                 player->client->Lmd.lmdMenu.trainerMenuMode = 0;
                 player->client->Lmd.lmdMenu.selection = 0;
@@ -4638,10 +4730,13 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
     if (!player || !player->client || !player->client->pers.Lmd.account)
         return;
 
+    gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
+    if (!menu)
+        return;
+
     int totalSkills = 0;
     profSkill_t* root = &Professions[PlayerAcc_Prof_GetProfession(player)]->primarySkill;
-
-    // Count only skills that are actually displayed based on filter
+    
     for (int t = 0; t < root->subSkills.count; t++)
     {
         profSkill_t* tree = &root->subSkills.skill[t];
@@ -4654,12 +4749,11 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
             continue;
         }
 
-        // Count each valid skill individually
+
         if (tree->subSkills.count > 0 && tree->subSkills.skill)
         {
             for (int s = 0; s < tree->subSkills.count; s++)
             {
-                // Only count skills that are actually visible
                 totalSkills++;
             }
         }
@@ -4676,7 +4770,7 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.skillIndex > 0)
         {
             player->client->Lmd.lmdMenu.skillIndex--;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingForward = qfalse;
@@ -4692,7 +4786,7 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (player->client->Lmd.lmdMenu.skillIndex < totalItems - 1)
         {
             player->client->Lmd.lmdMenu.skillIndex++;
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/menuroam.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.navsnd));
             updateMenu = qtrue;
         }
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qfalse;
@@ -4737,7 +4831,7 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
         // Check for the Back to Main Menu option being selected
         if (player->client->Lmd.lmdMenu.skillIndex == totalSkills)
         {
-            G_ClientSound(player, CHAN_AUTO, G_SoundIndex("sound/interface/esc.mp3"));
+            G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
             // Go back to main menu
             player->client->Lmd.lmdMenu.trainerMenuMode = 0;
             player->client->Lmd.lmdMenu.selection = 0;

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3198,7 +3198,7 @@ const entityInfoData_t lmd_trainer_keys[] = {
     {"message", "Custom message displayed on the main menu screen. .t = title, .l = level, .n = name"},
     {"targetname", "Activate the lmd_trainer when targetted."},
     {"prof", "Professions this trainer handles (0 = all, 1 = Jedi, 2 = Merc)"},
-    {"sideAcc", "Force sides this trainer handles (0 = all, 1 = light, 2 = dark). Only matters if prof = 1."},
+    {"subprof", "Force sides this trainer handles (0 = all, 1 = light, 2 = dark). Only matters if prof = 1."},
     {"anim", "Animation to use (0 = console, 1 = console)."},
     {"selectsnd", "Sound played for confirmation."},
     {"navsnd", "Sound played for navigation."},

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1832,7 +1832,6 @@ void lmd_terminal_use(gentity_t* self, gentity_t* other, gentity_t* activator)
         return;
     self->genericValue1 = level.time + 800;
 
-    G_UseTargets2(self, activator, self->GenericStrings[7]);
 
     if (self->spawnflags & 4)
     {
@@ -1840,9 +1839,14 @@ void lmd_terminal_use(gentity_t* self, gentity_t* other, gentity_t* activator)
             && activator->client->ps.groundEntityNum != ENTITYNUM_NONE)
         {
             lmd_menu_enter(activator, self);
+            G_UseTargets2(self, activator, self->GenericStrings[7]);
+
         }
         return;
     }
+
+    G_UseTargets2(self, activator, self->GenericStrings[7]);
+
 
     // Normal mode (spawnflag 1 or 2)
     char msg[MAX_STRING_CHARS] = "";
@@ -3817,7 +3821,7 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
         
     int prof = PlayerAcc_Prof_GetProfession(player);
     int targetProf = (prof == PROF_MERC) ? PROF_JEDI : PROF_MERC;
-    int totalOptions = 2; // Yes/No
+    int totalOptions = 2;
 
     
     
@@ -3825,7 +3829,6 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
     qboolean down = cmd->forwardmove < 0;
     qboolean updateMenu = qfalse;
     
-    // Handle navigation
     if (up && player->client->Lmd.lmdMenu.stoppedPressingForward)
     {
         if (player->client->Lmd.lmdMenu.selection > 0)
@@ -3856,7 +3859,6 @@ void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd)
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qtrue;
     }
     
-    // Handle selection
     if (cmd->buttons & BUTTON_USE && player->client->Lmd.lmdMenu.stoppedPressingUsing)
     {
         if (player->client->Lmd.lmdMenu.selection == 0) {
@@ -3902,19 +3904,16 @@ void lmd_mercenaryskillmenu_show(gentity_t* player, gentity_t* menu)
     int prof = PlayerAcc_Prof_GetProfession(player);
     profSkill_t* root = &Professions[prof]->primarySkill;
     
-    // Fixed 2-page system
-    int currentPage = player->client->Lmd.lmdMenu.currentPage; // 0 or 1
+    int currentPage = player->client->Lmd.lmdMenu.currentPage;
     int totalSkills = root->subSkills.count;
     
-    // Calculate how many skills on each page
-    int skillsOnFirstPage = 5; // First 5 skills on page 1
-    int skillsOnSecondPage = totalSkills - skillsOnFirstPage; // Remaining skills on page 2
+    int skillsOnFirstPage = 5;
+    int skillsOnSecondPage = totalSkills - skillsOnFirstPage;
     
     if (skillsOnSecondPage < 0) {
-        skillsOnSecondPage = 0; // In case there are fewer than 5 skills total
+        skillsOnSecondPage = 0;
     }
     
-    // Calculate start and end indices for current page
     int startSkill, endSkill;
     if (currentPage == 0) {
         startSkill = 0;
@@ -3925,10 +3924,8 @@ void lmd_mercenaryskillmenu_show(gentity_t* player, gentity_t* menu)
         endSkill = totalSkills;
     }
     
-    // Display page info
     Q_strcat(msg, sizeof(msg), va("%sPage %s(%d/2)\n", colorInfo, colorNormal, currentPage + 1));
     
-    // Display skills for the current page
     if (root->subSkills.count > 0 && root->subSkills.skill)
     {
         for (int s = startSkill; s < endSkill; s++)
@@ -4007,11 +4004,9 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
 
     profSkill_t* root = &Professions[PlayerAcc_Prof_GetProfession(player)]->primarySkill;
     
-    // Fixed 2-page system
-    int currentPage = player->client->Lmd.lmdMenu.currentPage; // 0 or 1
+    int currentPage = player->client->Lmd.lmdMenu.currentPage;
     int totalSkills = root->subSkills.count;
     
-    // Calculate skills on current page
     int skillsOnFirstPage = 5;
     int skillsOnCurrentPage;
     int startSkill;
@@ -4026,7 +4021,6 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
         if (skillsOnCurrentPage < 0) skillsOnCurrentPage = 0;
     }
     
-    // Total menu items: skills + change page + exit
     int totalItems = skillsOnCurrentPage + 2;
 
     qboolean up = cmd->forwardmove > 0;
@@ -4072,7 +4066,6 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
         
         if (stoppedPressing)
         {
-            // Handle skill selection
             if (player->client->Lmd.lmdMenu.skillIndex < skillsOnCurrentPage)
             {
                 if (isAttack) {
@@ -4086,22 +4079,21 @@ void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd)
                 }
                 updateMenu = qtrue;
             }
-            // Handle page change option
+
             else if (player->client->Lmd.lmdMenu.skillIndex == skillsOnCurrentPage && (isAttack || isUse))
             {
-                // Toggle between page 0 and 1
                 player->client->Lmd.lmdMenu.currentPage = (currentPage == 0) ? 1 : 0;
-                player->client->Lmd.lmdMenu.skillIndex = 0; // Reset selection to first item
+                player->client->Lmd.lmdMenu.skillIndex = 0;
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
                 updateMenu = qtrue;
             }
-            // Handle exit option
+
             else if (player->client->Lmd.lmdMenu.skillIndex == skillsOnCurrentPage + 1 && (isAttack || isUse))
             {
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
                 player->client->Lmd.lmdMenu.trainerMenuMode = 0;
                 player->client->Lmd.lmdMenu.selection = 0;
-                player->client->Lmd.lmdMenu.currentPage = 0; // Reset page when exiting
+                player->client->Lmd.lmdMenu.currentPage = 0;
                 updateMenu = qtrue;
             }
             
@@ -4192,11 +4184,9 @@ void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd)
         }
     }
     
-    // Reset option first
     resetOption = currentOption++;
     totalOptions++;
-
-    // Add swap profession option second
+    
     swapProfOption = currentOption++;
     totalOptions++;
 
@@ -4704,11 +4694,11 @@ void lmd_skillmenu_tryLevelChange(gentity_t* player, qboolean down)
                 !Q_stricmp(treeName, "Sith")) {
                 continue;
                 }
-        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == 3) { // Jedi skills only
+        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == 3) {
             if (Q_stricmp(treeName, "Jedi") != 0) {
                 continue;
             }
-        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == 4) { // Sith skills only
+        } else if (player->client->Lmd.lmdMenu.trainerMenuMode == 4) {
             if (Q_stricmp(treeName, "Sith") != 0) {
                 continue;
             }
@@ -4774,7 +4764,6 @@ void lmd_resetskillsmenu_show(gentity_t* player, gentity_t* menu)
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
 }
 
-// Handle key input for reset skills menu
 void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)
@@ -4783,8 +4772,7 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
     gentity_t* menu = &g_entities[player->client->Lmd.lmdMenu.entityNum];
     if (!menu)
         return;
-        
-    // Check if player has any skills to reset
+    
     int prof = PlayerAcc_Prof_GetProfession(player);
     int used = Professions_UsedSkillPoints(player->client->pers.Lmd.account, prof, &Professions[prof]->primarySkill);
     
@@ -4793,7 +4781,6 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
     qboolean down = cmd->forwardmove < 0;
     qboolean updateMenu = qfalse;
     
-    // Handle navigation
     if (up && player->client->Lmd.lmdMenu.stoppedPressingForward)
     {
         if (player->client->Lmd.lmdMenu.selection > 0)
@@ -4824,28 +4811,20 @@ void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd)
         player->client->Lmd.lmdMenu.stoppedPressingBackward = qtrue;
     }
     
-    // Handle selection
     if (cmd->buttons & BUTTON_USE && player->client->Lmd.lmdMenu.stoppedPressingUsing)
     {
         if (used == 0) {
-            // No skills to reset - only "Back" option
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-            // Return to main menu
             player->client->Lmd.lmdMenu.trainerMenuMode = 0;
             player->client->Lmd.lmdMenu.selection = 0;
         } else {
-            // Yes/No options
             if (player->client->Lmd.lmdMenu.selection == 0) {
-                // "Yes" - reset skills
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.selectsnd));
                 Cmd_ResetSkills_f(player, 0);
-                // Return to main menu
                 player->client->Lmd.lmdMenu.trainerMenuMode = 0;
                 player->client->Lmd.lmdMenu.selection = 0;
             } else {
-                // "No" - cancel
                 G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-                // Return to main menu
                 player->client->Lmd.lmdMenu.trainerMenuMode = 0;
                 player->client->Lmd.lmdMenu.selection = 0;
             }
@@ -4907,7 +4886,6 @@ void lmd_menu_display(gentity_t* player)
     }
 }
 
-// Handle key input for filtered skill menu (Neutral skills)
 void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
 {
     if (!player || !player->client || !player->client->pers.Lmd.account)
@@ -4942,7 +4920,7 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
         }
     }
 
-    int totalItems = totalSkills + 1; // +1 for Back to Main Menu option
+    int totalItems = totalSkills + 1;
 
     qboolean up = cmd->forwardmove > 0;
     qboolean down = cmd->forwardmove < 0;
@@ -4982,7 +4960,7 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
     if (cmd->buttons & BUTTON_ATTACK)
     {
         if (player->client->Lmd.lmdMenu.stoppedPressingAttack &&
-            player->client->Lmd.lmdMenu.skillIndex < totalSkills) // Only allow skill changes when a skill is selected
+            player->client->Lmd.lmdMenu.skillIndex < totalSkills)
         {
             lmd_skillmenu_tryLevelChange(player, qfalse);
             player->client->Lmd.lmdMenu.stoppedPressingAttack = qfalse;
@@ -4997,7 +4975,7 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
     if (cmd->buttons & BUTTON_ALT_ATTACK)
     {
         if (player->client->Lmd.lmdMenu.stoppedPressingAltAttack &&
-            player->client->Lmd.lmdMenu.skillIndex < totalSkills) // Only allow skill changes when a skill is selected
+            player->client->Lmd.lmdMenu.skillIndex < totalSkills)
         {
             lmd_skillmenu_tryLevelChange(player, qtrue);
             player->client->Lmd.lmdMenu.stoppedPressingAltAttack = qfalse;
@@ -5011,14 +4989,11 @@ void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd)
 
     if (cmd->buttons & BUTTON_USE && player->client->Lmd.lmdMenu.stoppedPressingUsing)
     {
-        // Check for the Back to Main Menu option being selected
         if (player->client->Lmd.lmdMenu.skillIndex == totalSkills)
         {
             G_ClientSound(player, CHAN_AUTO, G_SoundIndex(menu->Lmd.cancelsnd));
-            // Go back to main menu
             player->client->Lmd.lmdMenu.trainerMenuMode = 0;
             player->client->Lmd.lmdMenu.selection = 0;
-            // Reset selection index
             player->client->Lmd.lmdMenu.skillIndex = 0;
             updateMenu = qtrue;
         }

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3199,7 +3199,7 @@ const entityInfoData_t lmd_trainer_keys[] = {
     {"targetname", "Activate the lmd_trainer when targetted."},
     {"prof", "Professions this trainer handles (0 = all, 1 = Jedi, 2 = Merc)"},
     {"subprof", "Force sides this trainer handles (0 = all, 1 = light, 2 = dark). Only matters if prof = 1."},
-    {"anim", "Animation to use (0 = console, 1 = console)."},
+    {"anim", "Animation to use (0 = console, 1 = talking)."},
     {"selectsnd", "Sound played for confirmation."},
     {"navsnd", "Sound played for navigation."},
     {"cancelsnd", "Sound played for cancel."},

--- a/game/Lmd_Prof_Core.c
+++ b/game/Lmd_Prof_Core.c
@@ -880,13 +880,13 @@ void Cmd_SkillSelect_f(gentity_t *ent, int iArg){
 	Disp(ent, "^4===========================================");
 }
 
-void Cmd_ResetSkills_f (gentity_t *ent, int iArg){
+void Cmd_ResetSkills_f (gentity_t *ent, int iArg) {
 	Account_t *acc = ent->client->pers.Lmd.account;
-	int credits = 0;
-	int myCredits = PlayerAcc_GetCredits(ent);
+	// int credits = 0;
+	// int myCredits = PlayerAcc_GetCredits(ent);
 	int prof = PlayerAcc_Prof_GetProfession(ent);
 	int used;
-	
+    
 	if (!acc) {
 		return;
 	}
@@ -898,26 +898,35 @@ void Cmd_ResetSkills_f (gentity_t *ent, int iArg){
 		return;
 	}
 
+	// Credit cost system has been disabled, since we can downrank skills for free
+	/*
 	if (trap_Argc() > 1) {
-		credits = atoi(ConcatArgs(1));
+	   credits = atoi(ConcatArgs(1));
 	}
 	if (myCredits < credits) {
-		credits = myCredits;
+	   credits = myCredits;
 	}
 
 	if(used == 0) {
-		Disp(ent, "^3All your skills are already at their lowest level.");
-		return;
+	   Disp(ent, "^3All your skills are already at their lowest level.");
+	   return;
 	}
 
 	int cost = used * 200;
 
 	if (credits < cost) {
-		Disp(ent,va("^3The cost to reset your skills is ^2CR %i^3.", cost));
-		return;
+	   Disp(ent,va("^3The cost to reset your skills is ^2CR %i^3.", cost));
+	   return;
 	}
 
 	PlayerAcc_SetCredits(ent, myCredits - cost);
+	*/
+	
+	if(used == 0) {
+		Disp(ent, "^3All your skills are already at their lowest level.");
+		return;
+	}
+	
 	Accounts_Prof_ClearData(ent->client->pers.Lmd.account);
 	Professions_SetDefaultSkills(ent->client->pers.Lmd.account, prof);
 	Profession_UpdateSkillEffects(ent, prof);

--- a/game/Lmd_Prof_Core.c
+++ b/game/Lmd_Prof_Core.c
@@ -515,13 +515,16 @@ qboolean Professions_ChooseProf(gentity_t *ent, int prof){
 		return qfalse;
 	}
 
+	// lumaya: we dont take crs on prof swapping
+	/*
 	if(flags & ACCFLAGS_NOPROFCRLOSS){
 		PlayerAcc_AddFlags(ent, -ACCFLAGS_NOPROFCRLOSS);
 		Disp(ent, "^3Your free profession change has been used up.");
 	}
 	else
 		PlayerAcc_SetCredits(ent, PlayerAcc_GetCredits(ent) / 2);
-
+*/
+	
 	PlayerAcc_Prof_SetProfession(ent, prof);
 	PlayerAcc_Prof_SetLevel(ent, 1);
 

--- a/game/g_cmds.c
+++ b/game/g_cmds.c
@@ -3494,6 +3494,9 @@ void Cmd_EngageDuel_f(gentity_t *ent){
 		if(ent->client->ps.weapon != challenged->client->ps.weapon)
 			return;
 
+		if (challenged && challenged->client && challenged->client->Lmd.lmdMenu.entityNum != 0)
+			return;
+
 		//Lugormod: cannot engage if too close
 		float dist = Distance(ent->client->ps.origin, challenged->client->ps.origin);
 		if(dist < 80){

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -5661,10 +5661,13 @@ ContinueThink:
 									break;
 								case 7:
 									lmd_resetskillsmenu_key(ent, &ent->client->pers.cmd);
+									break;
 								case 8:
 									lmd_swapprofmenu_key(ent, &ent->client->pers.cmd);
+									break;
 								case 9:
 									lmd_profselectionmenu_key(ent, &ent->client->pers.cmd);
+									break;
 								default:
 									lmd_trainermenu_key(ent, &ent->client->pers.cmd);
 									break;

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -5674,10 +5674,17 @@ ContinueThink:
 							{
 								lmd_menu_update(ent);
 
-								if (level.time >= ent->client->Lmd.lmdMenu.nextUpdateTime)
+								if (ent->client->Lmd.lmdMenu.choicesVisible >= menu->count)
+								{
+									if (level.time >= ent->client->Lmd.lmdMenu.nextUpdateTime)
+									{
+										lmd_menu_show(ent, menu);
+										ent->client->Lmd.lmdMenu.nextUpdateTime = level.time + 1000;
+									}
+								}
+								else
 								{
 									lmd_menu_show(ent, menu);
-									ent->client->Lmd.lmdMenu.nextUpdateTime = level.time + 1000;
 								}
 
 								lmd_menu_key(ent, &ent->client->pers.cmd);

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -4884,8 +4884,6 @@ extern void lmd_menu_key(gentity_t *player, usercmd_t *cmd);
 extern void lmd_menu_show(gentity_t *player, gentity_t *menu);
 extern void lmd_menu_exit(gentity_t *player);
 extern void lmd_menu_update(gentity_t *player);
-extern void lmd_skillmenu_key(gentity_t* player, usercmd_t* cmd);
-extern void lmd_skillmenu_show(gentity_t *player, gentity_t *menu);
 extern void lmd_menu_display(gentity_t* player);
 extern void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd);
 extern void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd);
@@ -4893,7 +4891,8 @@ extern void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd);
 extern void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd);
 extern void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd);
 extern void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd);
-
+extern void lmd_swapprofmenu_key(gentity_t* player, usercmd_t* cmd);
+extern void lmd_profselectionmenu_key(gentity_t* player, usercmd_t* cmd);
 void G_RunFrame( int levelTime ) {
 	int			i;
 	gentity_t	       *ent;
@@ -5647,9 +5646,6 @@ ContinueThink:
 								case 0:
 									lmd_trainermenu_key(ent, &ent->client->pers.cmd);
 									break;
-								case 1:
-									lmd_skillmenu_key(ent, &ent->client->pers.cmd);
-									break;
 								case 2:
 									lmd_filteredskillmenu_key(ent, &ent->client->pers.cmd);
 									break;
@@ -5665,6 +5661,10 @@ ContinueThink:
 									break;
 								case 7:
 									lmd_resetskillsmenu_key(ent, &ent->client->pers.cmd);
+								case 8:
+									lmd_swapprofmenu_key(ent, &ent->client->pers.cmd);
+								case 9:
+									lmd_profselectionmenu_key(ent, &ent->client->pers.cmd);
 								default:
 									lmd_trainermenu_key(ent, &ent->client->pers.cmd);
 									break;

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -4884,8 +4884,16 @@ extern void lmd_menu_key(gentity_t *player, usercmd_t *cmd);
 extern void lmd_menu_show(gentity_t *player, gentity_t *menu);
 extern void lmd_menu_exit(gentity_t *player);
 extern void lmd_menu_update(gentity_t *player);
-extern void lmd_skillmenu_key(gentity_t *player, usercmd_t *cmd, gentity_t *menu);
+extern void lmd_skillmenu_key(gentity_t* player, usercmd_t* cmd);
 extern void lmd_skillmenu_show(gentity_t *player, gentity_t *menu);
+extern void lmd_menu_display(gentity_t* player);
+extern void lmd_trainermenu_key(gentity_t* player, usercmd_t* cmd);
+extern void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd);
+extern void lmd_filteredskillmenu_key(gentity_t* player, usercmd_t* cmd);
+extern void lmd_mercenaryskillmenu_key(gentity_t* player, usercmd_t* cmd);
+extern void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd);
+extern void lmd_resetskillsmenu_key(gentity_t* player, usercmd_t* cmd);
+
 void G_RunFrame( int levelTime ) {
 	int			i;
 	gentity_t	       *ent;
@@ -5631,21 +5639,51 @@ ContinueThink:
 							{
 								if (level.time >= ent->client->Lmd.lmdMenu.nextUpdateTime)
 								{
-									lmd_skillmenu_show(ent, menu);
+									lmd_menu_display(ent);
 									ent->client->Lmd.lmdMenu.nextUpdateTime = level.time + 1000;
 								}
 								
-								lmd_skillmenu_key(ent, &ent->client->pers.cmd, menu);
+								switch (ent->client->Lmd.lmdMenu.trainerMenuMode) {
+								case 0:
+									lmd_trainermenu_key(ent, &ent->client->pers.cmd);
+									break;
+								case 1:
+									lmd_skillmenu_key(ent, &ent->client->pers.cmd);
+									break;
+								case 2:
+									lmd_filteredskillmenu_key(ent, &ent->client->pers.cmd);
+									break;
+								case 3:
+								case 4:
+									lmd_forceskillmenu_key(ent, &ent->client->pers.cmd);
+									break;
+								case 5:
+									lmd_mercenaryskillmenu_key(ent, &ent->client->pers.cmd);
+									break;
+								case 6:
+									lmd_levelupmenu_key(ent, &ent->client->pers.cmd);
+									break;
+								case 7:
+									lmd_resetskillsmenu_key(ent, &ent->client->pers.cmd);
+								default:
+									lmd_trainermenu_key(ent, &ent->client->pers.cmd);
+									break;
+								}
 							}
 							else
 							{
 								lmd_menu_update(ent);
-								lmd_menu_show(ent, menu);
+
+								if (level.time >= ent->client->Lmd.lmdMenu.nextUpdateTime)
+								{
+									lmd_menu_show(ent, menu);
+									ent->client->Lmd.lmdMenu.nextUpdateTime = level.time + 1000;
+								}
+
 								lmd_menu_key(ent, &ent->client->pers.cmd);
 							}
 
 							ent->client->Lmd.lmdMenu.lastServerTime = ent->client->pers.cmd.serverTime;
-							
 						}
 
 						ent->client->ps.weaponTime = FRAMETIME;
@@ -5656,7 +5694,6 @@ ContinueThink:
 						lmd_menu_exit(ent);
 					}
 				}
-
 			}
 
 			if (g_allowNPC.integer)

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -5643,29 +5643,29 @@ ContinueThink:
 								}
 								
 								switch (ent->client->Lmd.lmdMenu.trainerMenuMode) {
-								case 0:
+								case LMD_TRAINER_MENU:
 									lmd_trainermenu_key(ent, &ent->client->pers.cmd);
 									break;
-								case 2:
+								case LMD_NEUTRAL_SKILLS_MENU:
 									lmd_filteredskillmenu_key(ent, &ent->client->pers.cmd);
 									break;
-								case 3:
-								case 4:
+								case LMD_JEDI_SKILLS_MENU:
+								case LMD_SITH_SKILLS_MENU:
 									lmd_forceskillmenu_key(ent, &ent->client->pers.cmd);
 									break;
-								case 5:
+								case LMD_MERC_SKILLS_MENU:
 									lmd_mercenaryskillmenu_key(ent, &ent->client->pers.cmd);
 									break;
-								case 6:
+								case LMD_LEVEL_UP_MENU:
 									lmd_levelupmenu_key(ent, &ent->client->pers.cmd);
 									break;
-								case 7:
+								case LMD_RESET_SKILLS_MENU:
 									lmd_resetskillsmenu_key(ent, &ent->client->pers.cmd);
 									break;
-								case 8:
+								case LMD_SWAP_PROF_MENU:
 									lmd_swapprofmenu_key(ent, &ent->client->pers.cmd);
 									break;
-								case 9:
+								case LMD_SELECT_PROF_MENU:
 									lmd_profselectionmenu_key(ent, &ent->client->pers.cmd);
 									break;
 								default:

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -567,6 +567,7 @@ struct gclient_s {
 			int lastServerTime;
 			unsigned int engageTime;
     		int trainerMenuMode;
+    		int currentPage;
 		} lmdMenu;
 	}Lmd;
 	unsigned int lastTargetUse;

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -566,6 +566,7 @@ struct gclient_s {
 			int skillIndex;
 			int lastServerTime;
 			unsigned int engageTime;
+    		int trainerMenuMode;
 		} lmdMenu;
 	}Lmd;
 	unsigned int lastTargetUse;

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -45,6 +45,18 @@ typedef struct Account_s Account_t;
 #define	FOLLOW_ACTIVE1	-1
 #define	FOLLOW_ACTIVE2	-2
 
+// lumaya:
+
+#define LMD_TRAINER_MENU        0
+#define LMD_NEUTRAL_SKILLS_MENU 2
+#define LMD_JEDI_SKILLS_MENU    3
+#define LMD_SITH_SKILLS_MENU    4
+#define LMD_MERC_SKILLS_MENU    5
+#define LMD_LEVEL_UP_MENU       6
+#define LMD_RESET_SKILLS_MENU   7
+#define LMD_SWAP_PROF_MENU      8
+#define LMD_SELECT_PROF_MENU    9
+
 
 //typedef 
 enum {

--- a/game/gentity_t.h
+++ b/game/gentity_t.h
@@ -366,6 +366,7 @@ struct gentity_s {
 		int boundsDisplayedUntil; // How long will the bounding box be displayed? (level.time + xxx)
 		char * color;
 		char * color2;
+		char * color3;
 		char * selectsnd;
 		char * navsnd;
 		char * cancelsnd;

--- a/game/gentity_t.h
+++ b/game/gentity_t.h
@@ -371,6 +371,8 @@ struct gentity_s {
 		char * cancelsnd;
 		int messageDelay;
 		int choiceDelay;
+		int prof;
+		int sideAcc;
 	}Lmd;
 	//RoboPhred
 	qboolean isAutoTargeted; //we were given a targetname automatically


### PR DESCRIPTION
This PR has a new entity named lmd_trainer as well as various fixes to lmd_menu.

- Lmd_trainer let's players do existing cmds such as /profession, /buylevel, /skill, /resetskills, in an interactive menu.
- Fixed a bug where sounds replay on lmd_menus.
- Tried to avoid high ping while using lmd_menu by lowering the amount of times we send it.

How to test:
/place misc_model_breakable 0 model,map_objects/factory/f_con1,spawnflags,97,target,lmdtrainer
/place lmd_trainer * targetname,lmdtrainer