### PR TITLE
New key "crosshairText". Shown when aimed at this entity.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,8 @@ set(GAME_SRC
 	game/Lmd_Crafting.c 
 	game/Lmd_CrashReport.c 
 	game/Lmd_Credits.c 
-	game/Lmd_Creditshunt.c 
+	game/Lmd_Creditshunt.c
+	game/Lmd_Crosshair.c  
 	game/Lmd_Data.c 
 	game/Lmd_Entities_Commands.c 
 	game/Lmd_Entities_Core.c 

--- a/game/Lmd_Accounts_Property.c
+++ b/game/Lmd_Accounts_Property.c
@@ -683,6 +683,7 @@ const entityInfoData_t lmd_propertyterminal_keys[] = {
 	{"#UKEYS", NULL},
 	{"#MODEL", NULL},
 	{"#HITBOX", NULL},
+	{"crosshairText", "Displays this text when a player looks at this entity."},
 	{"Property", "The name of the property to check access to."},
 	{"Target", "Target to fire if the user is a member of the property."},
 	{"Target2", "Target to fire if the user is not a member of the property."},

--- a/game/Lmd_Crosshair.c
+++ b/game/Lmd_Crosshair.c
@@ -1,0 +1,51 @@
+﻿#include "Lmd_Crosshair.h"
+
+void lmd_crosshairEntText(const gentity_t* ent)
+{
+    const int lastEntNum = ent->client->Lmd.crosshairText.entNum;
+    
+    const int tracedEntNum = ent->client->Lmd.crosshairEntNum;
+    const char* tracedText = (tracedEntNum != ENTITYNUM_NONE) ? g_entities[tracedEntNum].Lmd.crosshairText : NULL;
+
+    const qboolean hasNewValidText = tracedText && tracedText[0];
+    const int newEntNum = hasNewValidText ? tracedEntNum : 0;
+    
+    if (lastEntNum != newEntNum && lastEntNum != 0)
+    {
+        trap_SendServerCommand(ent - g_entities, "cp \"\"");
+    }
+    
+    ent->client->Lmd.crosshairText.entNum = newEntNum;
+    
+    if (lastEntNum != newEntNum)
+    {
+        ent->client->Lmd.crosshairText.debounceTime = 0;
+    }
+    
+    if (newEntNum && ent->client->Lmd.crosshairText.debounceTime < level.time)
+    {
+        trap_SendServerCommand(ent - g_entities, va("cp \"%s\n\"", tracedText));
+        ent->client->Lmd.crosshairText.debounceTime = level.time + 1000;
+    }
+}
+
+
+void lmd_crosshairEntTrace(const gentity_t* ent)
+{
+    if (!ent->client)
+        return;
+
+    trace_t tr;
+    vec3_t tfrom, tto, fwd;
+
+    VectorCopy(ent->client->ps.origin, tfrom);
+    tfrom[2] += ent->client->ps.viewheight;
+    AngleVectors(ent->client->ps.viewangles, fwd, NULL, NULL);
+
+    tto[0] = tfrom[0] + fwd[0] * 9999;
+    tto[1] = tfrom[1] + fwd[1] * 9999;
+    tto[2] = tfrom[2] + fwd[2] * 9999;
+
+    trap_Trace(&tr, tfrom, NULL, NULL, tto, ent->s.number, MASK_ALL);
+    ent->client->Lmd.crosshairEntNum = tr.entityNum;
+}

--- a/game/Lmd_Crosshair.h
+++ b/game/Lmd_Crosshair.h
@@ -1,0 +1,8 @@
+﻿#ifndef LMD_CROSSHAIR_H
+#define LMD_CROSSHAIR_H
+#include "g_local.h"
+
+void lmd_crosshairEntText(const gentity_t* ent);
+void lmd_crosshairEntTrace(const gentity_t* ent);
+
+#endif

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -211,6 +211,9 @@ qboolean SpawnEntModel(gentity_t* ent, qboolean isSolid, qboolean isAnimated)
     {
         ent->r.contents = 0;
     }
+
+    G_SpawnString("crosshairText", "", &ent->Lmd.crosshairText);
+    
     return hasModel;
 }
 
@@ -666,6 +669,7 @@ void use_lmd_mover(gentity_t* ent, gentity_t* other, gentity_t* activator)
 const entityInfoData_t lmd_mover_keys[] = {
     {"#MODEL", NULL},
     {"#HITBOX", NULL},
+    {"crosshairText", "Displays this text when a player looks at this entity."},
     {
         "OnDelta",
         "The movement offset when turned on.  This is a vector, and needs the x, y, and z values specified (like mins/maxs/origin and others).  This is the origin/angles the entity should be at once 'duration' completes."
@@ -1223,6 +1227,7 @@ const entityInfoData_t lmd_pwterminal_keys[] = {
     {"#UKEYS", NULL},
     {"#MODEL", NULL},
     {"#HITBOX", NULL},
+    {"crosshairText", "Displays this text when a player looks at this entity."},
     {"Message", "Text to show when used."},
     {"Password", "The correct password."},
     {"Target", "Target to fire when correct password is entered."},
@@ -1422,6 +1427,7 @@ const entityInfoData_t lmd_door_keys[] = {
         "Even if locked, this team can always open and close it just by walking up to it.  Values are: 0 - none, 1 - red, 2 - blue."
     },
     {"VehOpen", "If non-0, vehicles/players riding vehicles can open this door by getting close."},
+    {"crosshairText", "Displays this text when a player looks at this entity."},
     {NULL, NULL}
 };
 
@@ -1936,6 +1942,7 @@ const entityInfoData_t lmd_terminal_keys[] = {
     {"#UKEYS", NULL},
     {"#MODEL", NULL},
     {"#HITBOX", NULL},
+    {"crosshairText", "Displays this text when a player looks at this entity."},
     {"Message", "Message to display when used."},
     {"UseTarget", "Target to fire when the player presses the use key on this."},
     {"GlobalTarget", "Targe to fire when any command is used."},
@@ -2339,6 +2346,7 @@ const entityInfoData_t lmd_rentterminal_keys[] = {
     {"#UKEYS", NULL},
     {"#MODEL", NULL},
     {"#HITBOX", NULL},
+    {"crosshairText", "Displays this text when a player looks at this entity."},
     {"Message", "The message to be displayed when the terminal is used."},
     {"Count", "Cost to rent this terminal."},
     {"Minutes", "Number of minutes to gain when payed \'count\' number of credits."},
@@ -2768,6 +2776,7 @@ const entityInfoData_t lmd_drop_keys[] = {
         "Count",
         "Number of credits to give the player.  If this is set and no noise key is specified, then the noise key defaults to sound/interface/secret_area.wav"
     },
+    {"crosshairText", "Displays this text when a player looks at this entity."},
     {"Velocity", "Speed at which to toss this item.  Default 50."},
     {"Offset", "Offset to drop from the player if spawnflag 4 is set.  Default 64."},
     {"Angles", "Angles to launch this item at"},
@@ -3122,6 +3131,7 @@ const entityInfoData_t lmd_train_keys[] = {
     {"#UKEYS", NULL},
     {"#MODEL", NULL},
     {"#HITBOX", NULL},
+    {"crosshairText", "Displays this text when a player looks at this entity."},
     {"Speed", "Movement speed.  Default 100."},
     {"Dmg", "Damage to inflict when blocked."},
     {"Target", "The first path_corner to move to."},

--- a/game/Lmd_Main.c
+++ b/game/Lmd_Main.c
@@ -1,5 +1,6 @@
 
 #include "g_local.h"
+#include "Lmd_Crosshair.h"
 #include "Lmd_EntityCore.h"
 #include "Lmd_SetSaber.h"
 
@@ -187,6 +188,7 @@ void Lmd_PlayerThink(gentity_t *ent){
 	}
 
 	lmd_checkSaberChanges(ent);
+	lmd_crosshairEntText(ent);
 	
 	ent->client->Lmd.thinkDelay = level.time + FRAMETIME;
 }

--- a/game/g_active.c
+++ b/game/g_active.c
@@ -8,6 +8,7 @@
 #include "Lmd_Accounts_Stats.h"
 
 #include "Lmd_Commands_Auths.h"
+#include "Lmd_Crosshair.h"
 #include "Lmd_Professions.h"
 #include "Lmd_Prof_Merc.h"
 
@@ -4659,9 +4660,12 @@ void ClientEndFrame( gentity_t *ent ) {
 
 	SendPendingPredictableEvents( &ent->client->ps );
 
+	lmd_crosshairEntTrace(ent);
+
 	// set the bit for the reachability area the client is currently in
 	//	i = trap_AAS_PointReachabilityAreaIndex( ent->client->ps.origin );
 	//	ent->client->areabits[i >> 3] |= 1 << (i & 7);
+
 }
 
 

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -583,6 +583,15 @@ struct gclient_s {
     		int trainerMenuMode;
     		int currentPage;
 		} lmdMenu;
+
+		struct
+		{
+			int entNum;
+			unsigned int debounceTime;
+			char* text;
+		} crosshairText;
+
+		int crosshairEntNum;
 	}Lmd;
 	unsigned int lastTargetUse;
 	unsigned int infoChanged;

--- a/game/gentity_t.h
+++ b/game/gentity_t.h
@@ -374,6 +374,7 @@ struct gentity_s {
 		int choiceDelay;
 		int prof;
 		int sideAcc;
+		char * crosshairText;
 	}Lmd;
 	//RoboPhred
 	qboolean isAutoTargeted; //we were given a targetname automatically


### PR DESCRIPTION
Made a new key for builders "crosshairText" -> Text.
When we aim at the entity where this key,value is set it's displaying the text above our crosshair as long as we aim / look at this entity.
Works on the following entities: lmd_propertyterminal, lmd_mover, lmd_pwterminal, lmd_door, lmd_terminal, lmd_rentterminal, lmd_drop, lmd_train, lmd_turret, lmd_stashdepo, lmd_stashspawnpoint, misc_model_breakable, misc_camera.