### PR TITLE
Hotfix that when we engage with an Lmd Menu, any potential CrosshairT…

### DIFF
--- a/game/Lmd_Crosshair.c
+++ b/game/Lmd_Crosshair.c
@@ -2,6 +2,8 @@
 
 void lmd_crosshairEntText(const gentity_t* ent)
 {
+    if (ent->client->Lmd.lmdMenu.entityNum != 0) return;
+    
     const int lastEntNum = ent->client->Lmd.crosshairText.entNum;
     
     const int tracedEntNum = ent->client->Lmd.crosshairEntNum;


### PR DESCRIPTION
…ext isn't displaying.