### PR TITLE
Extended ".n .l .t" on lmd_rentterminal, lmd_terminal, misc_model_bre…

### DIFF
--- a/game/Lmd_Accounts_Core.c
+++ b/game/Lmd_Accounts_Core.c
@@ -724,7 +724,8 @@ static int GetTitleIndex(int levelp)
 }
 
 extern int Jedi_GetAccSide(Account_t *acc);
-char* Accounts_GetTitle(Account_t *acc) {
+char* Accounts_GetTitle(Account_t *acc)
+{
 	if (!acc) return DEFAULT_TITLE;
 	if (!lmd_titlesLoaded && !Accounts_LoadTitles()) return DEFAULT_TITLE;
 

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1540,8 +1540,48 @@ void lmd_door(gentity_t* ent)
     }
 }
 
+extern char* Accounts_GetTitle(Account_t *acc);
+char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message)
+{
+    if (!player || !player->client) return message;
+    
+    static char processedMessage[MAX_STRING_CHARS];
+    const char* playerName = player->client->pers.Lmd.account ? Accounts_GetName(player->client->pers.Lmd.account) : player->client->pers.netname;
+    const char* playerTitle = player->client->pers.Lmd.account ? Accounts_GetTitle(player->client->pers.Lmd.account) : "None";
+    int playerLevel = player->client->pers.Lmd.account ? PlayerAcc_Prof_GetLevel(player) : 0;
+    
+    processedMessage[0] = '\0';
+    
+    int msgLen = strlen(message);
+    
+    for (int i = 0; i < msgLen; i++) {
+        if (message[i] == '.' && i + 1 < msgLen) {
+            switch (message[i + 1]) {
+            case 'n':
+                Q_strcat(processedMessage, sizeof(processedMessage), playerName);
+                i++;
+                break;
+            case 'l':
+                Q_strcat(processedMessage, sizeof(processedMessage), va("%i", playerLevel));
+                i++;
+                break;
+            case 't':
+                Q_strcat(processedMessage, sizeof(processedMessage), playerTitle);
+                i++;
+                break;
+            default:
+                strncat(processedMessage, &message[i], 1);
+                break;
+            }
+        } else {
+            strncat(processedMessage, &message[i], 1);
+        }
+    }
+    
+    return processedMessage;
+}
 
-char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, const char* message);
+
 void lmd_menu_show(gentity_t* player, gentity_t* menu)
 {
     char msg[MAX_STRING_CHARS] = "";
@@ -3396,7 +3436,6 @@ void lmd_profselectionmenu_show(gentity_t* player, gentity_t* menu)
 extern qboolean Professions_ChooseProf(gentity_t *ent, int prof);
 extern int Professions_LevelCost(int prof, int level, int time);
 extern int Accounts_Prof_GetLastLevelup(Account_t *acc);
-char* Accounts_GetTitle(Account_t *acc);
 
 void lmd_profselectionmenu_key(gentity_t* player, usercmd_t* cmd)
 {
@@ -3695,47 +3734,6 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
         player->client->Lmd.lmdMenu.nextUpdateTime = level.time;
     }
 }
-
-char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message)
-{
-    if (!player || !player->client) return message;
-    
-    static char processedMessage[MAX_STRING_CHARS];
-    const char* playerName = player->client->pers.Lmd.account ? Accounts_GetName(player->client->pers.Lmd.account) : player->client->pers.netname;
-    const char* playerTitle = player->client->pers.Lmd.account ? Accounts_GetTitle(player->client->pers.Lmd.account) : "None";
-    int playerLevel = player->client->pers.Lmd.account ? PlayerAcc_Prof_GetLevel(player) : 0;
-    
-    processedMessage[0] = '\0';
-    
-    int msgLen = strlen(message);
-    
-    for (int i = 0; i < msgLen; i++) {
-        if (message[i] == '.' && i + 1 < msgLen) {
-            switch (message[i + 1]) {
-            case 'n':
-                Q_strcat(processedMessage, sizeof(processedMessage), playerName);
-                i++;
-                break;
-            case 'l':
-                Q_strcat(processedMessage, sizeof(processedMessage), va("%i", playerLevel));
-                i++;
-                break;
-            case 't':
-                Q_strcat(processedMessage, sizeof(processedMessage), playerTitle);
-                i++;
-                break;
-            default:
-                strncat(processedMessage, &message[i], 1);
-                break;
-            }
-        } else {
-            strncat(processedMessage, &message[i], 1);
-        }
-    }
-    
-    return processedMessage;
-}
-
 
 void lmd_trainermenu_show(gentity_t* player, gentity_t* menu)
 {

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1540,6 +1540,8 @@ void lmd_door(gentity_t* ent)
     }
 }
 
+
+char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, const char* message);
 void lmd_menu_show(gentity_t* player, gentity_t* menu)
 {
     char msg[MAX_STRING_CHARS] = "";
@@ -1597,6 +1599,8 @@ void lmd_menu_show(gentity_t* player, gentity_t* menu)
     {
         Q_strcat(msg, sizeof(msg), va("  %sCancel\n", menu->Lmd.color2));
     }
+    
+    strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(player, msg));
 
 
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
@@ -1863,7 +1867,12 @@ void lmd_terminal_use(gentity_t* self, gentity_t* other, gentity_t* activator)
     char msg[MAX_STRING_CHARS] = "";
     int i;
     if (self->message)
-        Q_strcat(msg, sizeof(msg), va("%s\n^5==============================\n", self->message));
+    {
+        strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(activator, self->message));
+        Q_strcat(msg, sizeof(msg), va("\n^5==============================\n", msg));
+    }
+
+    
 
     for (i = 0; i < self->count; i++)
     {
@@ -2177,7 +2186,11 @@ void lmd_rentterminal_examine(gentity_t* self, gentity_t* activator)
     int min;
 
     if (self->message)
-        Disp(activator, self->message); //send this as a seperate disp, in case the msg makes us hit MAX_STRING_CHARS
+    {
+        char msgt[MAX_STRING_CHARS] = "";
+        strcpy_s(msgt, sizeof(msgt), lmd_trainermenu_processMessagePlaceholders(activator, self->message));
+        Disp(activator, msgt); //send this as a seperate disp, in case the msg makes us hit MAX_STRING_CHARS
+    }
 
     if (self->timestamp)
     {
@@ -2271,7 +2284,10 @@ void lmd_rentterminal_use(gentity_t* self, gentity_t* other, gentity_t* activato
     char msg[MAX_STRING_CHARS] = "";
     int sec = 0, min = 0;
     if (self->message)
-        Q_strcat(msg, sizeof(msg), va("%s\n", self->message));
+    {
+        strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(activator, self->message));
+        Q_strcat(msg, sizeof(msg), va("\n", msg));
+    }
 
     Q_strcat(msg, sizeof(msg), "^3This is a rentable terminal.\n");
     if (self->timestamp > 0)
@@ -2314,7 +2330,10 @@ void lmd_rentterminal_think(gentity_t* ent)
         {
             char msg[MAX_STRING_CHARS] = "";
             if (ent->message)
-                Q_strncpyz(msg, va("%s\n", ent->message), sizeof(msg));
+            {
+                strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(ent->activator, ent->message));
+                Q_strncpyz(msg, va("%s\n", msg), sizeof(msg));
+            }
             Q_strcat(msg, sizeof(msg), va("^3You have ^2%i^3 seconds left.", timeLeft));
             trap_SendServerCommand(ent->activator->s.number, va("cp \"%s\"", msg));
         }
@@ -2325,7 +2344,10 @@ void lmd_rentterminal_think(gentity_t* ent)
             {
                 char msg[MAX_STRING_CHARS] = "";
                 if (ent->message)
-                    Q_strncpyz(msg, va("%s\n", ent->message), sizeof(msg));
+                {
+                    strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(ent->activator, ent->message));
+                    Q_strncpyz(msg, va("%s\n", msg), sizeof(msg));
+                }
                 Q_strcat(msg, sizeof(msg), "^1Your rent has expired.");
                 trap_SendServerCommand(ent->activator->s.number, va("cp \"%s\"", msg));
             }
@@ -3674,12 +3696,14 @@ void lmd_levelupmenu_key(gentity_t* player, usercmd_t* cmd)
     }
 }
 
-char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, const char* message) {
+char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message)
+{
+    if (!player || !player->client) return message;
+    
     static char processedMessage[MAX_STRING_CHARS];
-    Account_t* acc = player->client->pers.Lmd.account;
-    const char* playerName = Accounts_GetName(acc);
-    const char* playerTitle = Accounts_GetTitle(acc);
-    int playerLevel = PlayerAcc_Prof_GetLevel(player);
+    const char* playerName = player->client->pers.Lmd.account ? Accounts_GetName(player->client->pers.Lmd.account) : player->client->pers.netname;
+    const char* playerTitle = player->client->pers.Lmd.account ? Accounts_GetTitle(player->client->pers.Lmd.account) : "None";
+    int playerLevel = player->client->pers.Lmd.account ? PlayerAcc_Prof_GetLevel(player) : 0;
     
     processedMessage[0] = '\0';
     

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1544,40 +1544,41 @@ extern char* Accounts_GetTitle(Account_t *acc);
 char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message)
 {
     if (!player || !player->client) return message;
-    
+
     static char processedMessage[MAX_STRING_CHARS];
     const char* playerName = player->client->pers.Lmd.account ? Accounts_GetName(player->client->pers.Lmd.account) : player->client->pers.netname;
     const char* playerTitle = player->client->pers.Lmd.account ? Accounts_GetTitle(player->client->pers.Lmd.account) : "None";
     int playerLevel = player->client->pers.Lmd.account ? PlayerAcc_Prof_GetLevel(player) : 0;
-    
+
     processedMessage[0] = '\0';
-    
+
     int msgLen = strlen(message);
-    
+
     for (int i = 0; i < msgLen; i++) {
-        if (message[i] == '.' && i + 1 < msgLen) {
-            switch (message[i + 1]) {
-            case 'n':
-                Q_strcat(processedMessage, sizeof(processedMessage), playerName);
-                i++;
-                break;
-            case 'l':
-                Q_strcat(processedMessage, sizeof(processedMessage), va("%i", playerLevel));
-                i++;
-                break;
-            case 't':
-                Q_strcat(processedMessage, sizeof(processedMessage), playerTitle);
-                i++;
-                break;
-            default:
-                strncat(processedMessage, &message[i], 1);
-                break;
+        if (message[i] == '\\') {
+            if (i + 3 < msgLen) {
+                if (!strncmp(&message[i + 1], "aid", 3)) {
+                    Q_strcat(processedMessage, sizeof(processedMessage), playerName);
+                    i += 3;
+                    continue;
+                }
+                if (!strncmp(&message[i + 1], "lvl", 3)) {
+                    Q_strcat(processedMessage, sizeof(processedMessage), va("%i", playerLevel));
+                    i += 3;
+                    continue;
+                }
+                if (!strncmp(&message[i + 1], "tle", 3)) {
+                    Q_strcat(processedMessage, sizeof(processedMessage), playerTitle);
+                    i += 3;
+                    continue;
+                }
             }
-        } else {
-            strncat(processedMessage, &message[i], 1);
         }
+        
+        char buf[2] = { message[i], '\0' };
+        Q_strcat(processedMessage, sizeof(processedMessage), buf);
     }
-    
+
     return processedMessage;
 }
 

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1541,44 +1541,184 @@ void lmd_door(gentity_t* ent)
 }
 
 extern char* Accounts_GetTitle(Account_t *acc);
-char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message)
+extern char* GetPasswordByIndex(const char* index);
+char* lmd_processMessagePlaceholders(gentity_t* entity, char* message, char* target2)
 {
-    if (!player || !player->client) return message;
-
+    if (!message) return message;
+    
     static char processedMessage[MAX_STRING_CHARS];
-    const char* playerName = player->client->pers.Lmd.account ? Accounts_GetName(player->client->pers.Lmd.account) : player->client->pers.netname;
-    const char* playerTitle = player->client->pers.Lmd.account ? Accounts_GetTitle(player->client->pers.Lmd.account) : "None";
-    int playerLevel = player->client->pers.Lmd.account ? PlayerAcc_Prof_GetLevel(player) : 0;
-
     processedMessage[0] = '\0';
-
-    int msgLen = strlen(message);
-
-    for (int i = 0; i < msgLen; i++) {
-        if (message[i] == '\\') {
-            if (i + 3 < msgLen) {
-                if (!strncmp(&message[i + 1], "aid", 3)) {
-                    Q_strcat(processedMessage, sizeof(processedMessage), playerName);
-                    i += 3;
-                    continue;
+    
+    const char* entityName = NULL;
+    const char* entityTitle = NULL;
+    int entityLevel = 0;
+    
+    if (entity && entity->client)
+    {
+        entityName = entity->client->pers.Lmd.account ? 
+                    Accounts_GetName(entity->client->pers.Lmd.account) : 
+                    entity->client->pers.netname;
+        entityTitle = entity->client->pers.Lmd.account ? 
+                     Accounts_GetTitle(entity->client->pers.Lmd.account) : 
+                     "None";
+        entityLevel = entity->client->pers.Lmd.account ? 
+                     PlayerAcc_Prof_GetLevel(entity) : 0;
+    }
+    
+    int msgLen = strnlen(message, MAX_STRING_CHARS - 1);
+    for (int i = 0; i < msgLen; i++)
+    {
+        if (message[i] == '\\' || message[i] == '@')
+        {
+            qboolean placeholderFound = qfalse;
+            char prefix = message[i];
+            
+            // @accname, @level, @title, @name, @health, @armor, @customvalue, @password
+            if (prefix == '@' && i + 7 < msgLen && !strncmp(&message[i + 1], "accname", 7) && entityName)
+            {
+                Q_strcat(processedMessage, sizeof(processedMessage), entityName);
+                i += 7;
+                placeholderFound = qtrue;
+            }
+            else if (prefix == '@' && i + 5 < msgLen && !strncmp(&message[i + 1], "level", 5))
+            {
+                Q_strcat(processedMessage, sizeof(processedMessage), va("%i", entityLevel));
+                i += 5;
+                placeholderFound = qtrue;
+            }
+            else if (prefix == '@' && i + 5 < msgLen && !strncmp(&message[i + 1], "title", 5) && entityTitle)
+            {
+                Q_strcat(processedMessage, sizeof(processedMessage), entityTitle);
+                i += 5;
+                placeholderFound = qtrue;
+            }
+            else if (prefix == '@' && i + 4 < msgLen && !strncmp(&message[i + 1], "name", 4) && 
+                     entity && entity->client && entity->s.number < MAX_CLIENTS)
+            {
+                Q_strcat(processedMessage, sizeof(processedMessage), entity->client->pers.netname);
+                i += 4;
+                placeholderFound = qtrue;
+            }
+            else if (prefix == '@' && i + 6 < msgLen && !strncmp(&message[i + 1], "health", 6) && 
+                     entity && entity->client && entity->s.number < MAX_CLIENTS)
+            {
+                Q_strcat(processedMessage, sizeof(processedMessage), va("%d", entity->client->ps.stats[STAT_HEALTH]));
+                i += 6;
+                placeholderFound = qtrue;
+            }
+            else if (prefix == '@' && i + 5 < msgLen && !strncmp(&message[i + 1], "armor", 5) && 
+                     entity && entity->client && entity->s.number < MAX_CLIENTS)
+            {
+                Q_strcat(processedMessage, sizeof(processedMessage), va("%d", entity->client->ps.stats[STAT_ARMOR]));
+                i += 5;
+                placeholderFound = qtrue;
+            }
+            else if (prefix == '@' && i + 11 < msgLen && !strncmp(&message[i + 1], "customvalue", 11) && 
+                     entity && entity->client && entity->s.number < MAX_CLIENTS && target2)
+            {
+                const char* customValue = Accounts_Custom_GetValue(entity->client->pers.Lmd.account, target2);
+                if (customValue) {
+                    Q_strcat(processedMessage, sizeof(processedMessage), customValue);
                 }
-                if (!strncmp(&message[i + 1], "lvl", 3)) {
-                    Q_strcat(processedMessage, sizeof(processedMessage), va("%i", playerLevel));
-                    i += 3;
-                    continue;
+                i += 11;
+                placeholderFound = qtrue;
+            }
+            else if (prefix == '@' && i + 8 < msgLen && !strncmp(&message[i + 1], "password", 8) && 
+                     entity && entity->client && entity->s.number < MAX_CLIENTS && target2)
+            {
+                const char* password = GetPasswordByIndex(target2);
+                if (password) {
+                    Q_strcat(processedMessage, sizeof(processedMessage), password);
                 }
-                if (!strncmp(&message[i + 1], "tle", 3)) {
-                    Q_strcat(processedMessage, sizeof(processedMessage), playerTitle);
+                i += 8;
+                placeholderFound = qtrue;
+            }
+            // \aid, \lvl, \tle
+            else if (i + 3 < msgLen) {
+                if (prefix == '\\' && !strncmp(&message[i + 1], "aid", 3) && entityName)
+                {
+                    Q_strcat(processedMessage, sizeof(processedMessage), entityName);
                     i += 3;
-                    continue;
+                    placeholderFound = qtrue;
+                }
+                else if (prefix == '\\' && !strncmp(&message[i + 1], "lvl", 3))
+                {
+                    Q_strcat(processedMessage, sizeof(processedMessage), va("%i", entityLevel));
+                    i += 3;
+                    placeholderFound = qtrue;
+                }
+                else if (prefix == '\\' && !strncmp(&message[i + 1], "tle", 3) && entityTitle)
+                {
+                    Q_strcat(processedMessage, sizeof(processedMessage), entityTitle);
+                    i += 3;
+                    placeholderFound = qtrue;
                 }
             }
+            
+            // \id, \cs, \pw
+            if (!placeholderFound && entity && entity->client && 
+                entity->s.number < MAX_CLIENTS && i + 2 < msgLen)
+            {
+                
+                if (prefix == '\\' && !strncmp(&message[i + 1], "id", 2))
+                {
+                    Q_strcat(processedMessage, sizeof(processedMessage), entity->client->pers.netname);
+                    i += 2;
+                    placeholderFound = qtrue;
+                }
+                else if (prefix == '\\' && !strncmp(&message[i + 1], "cs", 2) && target2)
+                {
+                    const char* customValue = Accounts_Custom_GetValue(entity->client->pers.Lmd.account, target2);
+                    if (customValue) {
+                        Q_strcat(processedMessage, sizeof(processedMessage), customValue);
+                    }
+                    i += 2;
+                    placeholderFound = qtrue;
+                }
+                else if (prefix == '\\' && !strncmp(&message[i + 1], "pw", 2) && target2)
+                {
+                    const char* password = GetPasswordByIndex(target2);
+                    if (password)
+                    {
+                        Q_strcat(processedMessage, sizeof(processedMessage), password);
+                    }
+                    i += 2;
+                    placeholderFound = qtrue;
+                }
+            }
+            
+            // \h, \a
+            if (!placeholderFound && prefix == '\\' && entity && entity->client && 
+                entity->s.number < MAX_CLIENTS && i + 1 < msgLen)
+            {
+                
+                if (message[i + 1] == 'h' && (i + 2 >= msgLen || !isalnum(message[i + 2])))
+                {
+                    Q_strcat(processedMessage, sizeof(processedMessage), va("%d", entity->client->ps.stats[STAT_HEALTH]));
+                    i += 1;
+                    placeholderFound = qtrue;
+                }
+                else if (message[i + 1] == 'a' && (i + 2 >= msgLen || !isalnum(message[i + 2])))
+                {
+                    Q_strcat(processedMessage, sizeof(processedMessage), va("%d", entity->client->ps.stats[STAT_ARMOR]));
+                    i += 1;
+                    placeholderFound = qtrue;
+                }
+            }
+            
+            if (!placeholderFound)
+            {
+                char buf[2] = { message[i], '\0' };
+                Q_strcat(processedMessage, sizeof(processedMessage), buf);
+            }
         }
-        
-        char buf[2] = { message[i], '\0' };
-        Q_strcat(processedMessage, sizeof(processedMessage), buf);
+        else
+        {
+            char buf[2] = { message[i], '\0' };
+            Q_strcat(processedMessage, sizeof(processedMessage), buf);
+        }
     }
-
+    
     return processedMessage;
 }
 
@@ -1641,7 +1781,7 @@ void lmd_menu_show(gentity_t* player, gentity_t* menu)
         Q_strcat(msg, sizeof(msg), va("  %sCancel\n", menu->Lmd.color2));
     }
     
-    strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(player, msg));
+    strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(player, msg, NULL));
 
 
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
@@ -1909,7 +2049,7 @@ void lmd_terminal_use(gentity_t* self, gentity_t* other, gentity_t* activator)
     int i;
     if (self->message)
     {
-        strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(activator, self->message));
+        strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(activator, self->message, NULL));
         Q_strcat(msg, sizeof(msg), va("\n^5==============================\n", msg));
     }
 
@@ -2229,7 +2369,7 @@ void lmd_rentterminal_examine(gentity_t* self, gentity_t* activator)
     if (self->message)
     {
         char msgt[MAX_STRING_CHARS] = "";
-        strcpy_s(msgt, sizeof(msgt), lmd_trainermenu_processMessagePlaceholders(activator, self->message));
+        strcpy_s(msgt, sizeof(msgt), lmd_processMessagePlaceholders(activator, self->message, NULL));
         Disp(activator, msgt); //send this as a seperate disp, in case the msg makes us hit MAX_STRING_CHARS
     }
 
@@ -2326,7 +2466,7 @@ void lmd_rentterminal_use(gentity_t* self, gentity_t* other, gentity_t* activato
     int sec = 0, min = 0;
     if (self->message)
     {
-        strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(activator, self->message));
+        strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(activator, self->message, NULL));
         Q_strcat(msg, sizeof(msg), va("\n", msg));
     }
 
@@ -2372,7 +2512,7 @@ void lmd_rentterminal_think(gentity_t* ent)
             char msg[MAX_STRING_CHARS] = "";
             if (ent->message)
             {
-                strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(ent->activator, ent->message));
+                strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(ent->activator, ent->message, NULL));
                 Q_strncpyz(msg, va("%s\n", msg), sizeof(msg));
             }
             Q_strcat(msg, sizeof(msg), va("^3You have ^2%i^3 seconds left.", timeLeft));
@@ -2386,7 +2526,7 @@ void lmd_rentterminal_think(gentity_t* ent)
                 char msg[MAX_STRING_CHARS] = "";
                 if (ent->message)
                 {
-                    strcpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(ent->activator, ent->message));
+                    strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(ent->activator, ent->message, NULL));
                     Q_strncpyz(msg, va("%s\n", msg), sizeof(msg));
                 }
                 Q_strcat(msg, sizeof(msg), "^1Your rent has expired.");
@@ -3748,7 +3888,7 @@ void lmd_trainermenu_show(gentity_t* player, gentity_t* menu)
     const char* colorInfo = (menu->Lmd.color3 && *menu->Lmd.color3) ? menu->Lmd.color3 : "^5";
     const char* menuMessage;
     if (menu->message && *menu->message && Q_stricmp(menu->message, "") != 0) {
-        menuMessage = lmd_trainermenu_processMessagePlaceholders(player, menu->message);
+        menuMessage = lmd_processMessagePlaceholders(player, menu->message, NULL);
     } else {
         menuMessage = va("%s[%s ACCOUNT TERMINAL %s]\n"
                         "%sName: %s\n"

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -558,7 +558,7 @@ void misc_model_breakable_touch (gentity_t *self, gentity_t *other, trace_t *tra
 	G_UseTargets(self, other);
 }
 
-extern char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, const char* message);
+extern char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message);
 
 void misc_model_breakable_use (gentity_t *self, gentity_t *other, gentity_t *activator){
 	if (self->genericValue10 > level.time) {

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -558,6 +558,8 @@ void misc_model_breakable_touch (gentity_t *self, gentity_t *other, trace_t *tra
 	G_UseTargets(self, other);
 }
 
+extern char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, const char* message);
+
 void misc_model_breakable_use (gentity_t *self, gentity_t *other, gentity_t *activator){
 	if (self->genericValue10 > level.time) {
 		return;
@@ -583,8 +585,13 @@ void misc_model_breakable_use (gentity_t *self, gentity_t *other, gentity_t *act
 
 	//RoboPhred
 	if(self->message && !(self->spawnflags & 8192))
-		trap_SendServerCommand(activator->s.number, va("cp \"%s\"", self->message));
+	{
+		char msg[MAX_STRING_CHARS];
+		strncpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(activator, self->message), MAX_STRING_CHARS);
+		trap_SendServerCommand(activator->s.number, va("cp \"%s\"", msg));
+	}
 }
+
 
 void misc_model_breakable_pay (gentity_t *self, gentity_t *other, gentity_t *activator){
 	if (self->genericValue10 > level.time) {
@@ -604,8 +611,10 @@ void misc_model_breakable_pay (gentity_t *self, gentity_t *other, gentity_t *act
 
 	if (other->client->pers.cmd.buttons & BUTTON_USE ) {
 		if (self->message) {
+			char msg[MAX_STRING_CHARS];
+			strncpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(activator, self->message), MAX_STRING_CHARS);
 			trap_SendServerCommand(other-g_entities,
-				va("cp \"%s\nUse the command \\pay on this.\nThe cost is CR %i.\"", self->message,self->count));
+				va("cp \"%s\nUse the command \\pay on this.\nThe cost is CR %i.\"", msg,self->count));
 		} else {
 			trap_SendServerCommand(other-g_entities,
 				va("cp \"Use the command \\pay on this.\nThe cost is CR %i.\"", self->count));

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -558,7 +558,7 @@ void misc_model_breakable_touch (gentity_t *self, gentity_t *other, trace_t *tra
 	G_UseTargets(self, other);
 }
 
-extern char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message);
+extern char* lmd_processMessagePlaceholders(gentity_t* entity, char* message, char* target2);
 
 void misc_model_breakable_use (gentity_t *self, gentity_t *other, gentity_t *activator){
 	if (self->genericValue10 > level.time) {
@@ -587,7 +587,7 @@ void misc_model_breakable_use (gentity_t *self, gentity_t *other, gentity_t *act
 	if(self->message && !(self->spawnflags & 8192))
 	{
 		char msg[MAX_STRING_CHARS];
-		strncpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(activator, self->message), MAX_STRING_CHARS);
+		strncpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(activator, self->message, NULL), MAX_STRING_CHARS);
 		trap_SendServerCommand(activator->s.number, va("cp \"%s\"", msg));
 	}
 }
@@ -612,7 +612,7 @@ void misc_model_breakable_pay (gentity_t *self, gentity_t *other, gentity_t *act
 	if (other->client->pers.cmd.buttons & BUTTON_USE ) {
 		if (self->message) {
 			char msg[MAX_STRING_CHARS];
-			strncpy_s(msg, sizeof(msg), lmd_trainermenu_processMessagePlaceholders(activator, self->message), MAX_STRING_CHARS);
+			strncpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(activator, self->message, NULL), MAX_STRING_CHARS);
 			trap_SendServerCommand(other-g_entities,
 				va("cp \"%s\nUse the command \\pay on this.\nThe cost is CR %i.\"", msg,self->count));
 		} else {

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -219,7 +219,7 @@ char* GetPasswordByIndex(const char* index)
 	return "";
 }
 
-extern char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, const char* message);
+extern char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message);
 char* Accounts_Custom_GetValue(Account_t *acc, char *key);
 void Send_Target_Print(gentity_t *ent, int targ) {
 

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -219,6 +219,7 @@ char* GetPasswordByIndex(const char* index)
 	return "";
 }
 
+extern char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, const char* message);
 char* Accounts_Custom_GetValue(Account_t *acc, char *key);
 void Send_Target_Print(gentity_t *ent, int targ) {
 
@@ -255,6 +256,8 @@ void Send_Target_Print(gentity_t *ent, int targ) {
 			strncpy(buf, va("%s%s%s", buf, GetPasswordByIndex(ent->target2), ptr + 3), MAX_STRING_CHARS);
 		}
 	}
+
+	strncpy_s(buf, sizeof(buf), lmd_trainermenu_processMessagePlaceholders(ent->activator, buf), MAX_STRING_CHARS);
 
 	if(buf[0] == '@' && buf[1] != '@') { //Ufo: fixed, was buf[1] == '@' and it didn't happen at all
 		trap_SendServerCommand(targ, va("cps \"%s\"", buf));

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -219,74 +219,34 @@ char* GetPasswordByIndex(const char* index)
 	return "";
 }
 
-extern char* lmd_trainermenu_processMessagePlaceholders(gentity_t* player, char* message);
+extern char* lmd_processMessagePlaceholders(gentity_t* entity, char* message, char* target2);
 char* Accounts_Custom_GetValue(Account_t *acc, char *key);
-void Send_Target_Print(gentity_t *ent, int targ) {
-
+void Send_Target_Print(gentity_t *ent, int targ)
+{
 	char buf[MAX_STRING_CHARS];
 	strncpy(buf, ent->message, MAX_STRING_CHARS);
-	char* ptr;
-	if (ent->activator->m_pVehicle && ent->activator->m_pVehicle->m_pPilot)
-		ent->activator = (gentity_t*)ent->activator->m_pVehicle->m_pPilot;
-	if (ent->activator->s.number < MAX_CLIENTS)
-	{
-		if (ptr = strstr(buf, "\\id"))
-		{
-			*ptr = '\0';
-			strncpy(buf, va("%s%s%s", buf, ent->activator->client->pers.netname, ptr + 3), MAX_STRING_CHARS);
-		}
-		if (ptr = strstr(buf, "\\h"))
-		{
-			*ptr = '\0';
-			strncpy(buf, va("%s%d%s", buf, ent->activator->client->ps.stats[STAT_HEALTH], ptr + 2), MAX_STRING_CHARS);
-		}
-		if (ptr = strstr(buf, "\\a"))
-		{
-			*ptr = '\0';
-			strncpy(buf, va("%s%d%s", buf, ent->activator->client->ps.stats[STAT_ARMOR], ptr + 2), MAX_STRING_CHARS);
-		}
-		if (ptr = strstr(buf, "\\cs"))
-		{
-			*ptr = '\0';
-			strncpy(buf, va("%s%s%s", buf, Accounts_Custom_GetValue(ent->activator->client->pers.Lmd.account, ent->target2), ptr + 3), MAX_STRING_CHARS);
-		}
-		if (ptr = strstr(buf, "\\pw"))
-		{
-			*ptr = '\0';
-			strncpy(buf, va("%s%s%s", buf, GetPasswordByIndex(ent->target2), ptr + 3), MAX_STRING_CHARS);
-		}
+	
+	gentity_t* activator = ent->activator;
+	if (activator && activator->m_pVehicle && activator->m_pVehicle->m_pPilot) {
+		activator = (gentity_t*)activator->m_pVehicle->m_pPilot;
 	}
-
-	strncpy_s(buf, sizeof(buf), lmd_trainermenu_processMessagePlaceholders(ent->activator, buf), MAX_STRING_CHARS);
-
-	if(buf[0] == '@' && buf[1] != '@') { //Ufo: fixed, was buf[1] == '@' and it didn't happen at all
+	
+	char* processedMsg = lmd_processMessagePlaceholders(activator, buf, ent->target2);
+	strncpy_s(buf, sizeof(buf), processedMsg, MAX_STRING_CHARS);
+	
+	if (buf[0] == '@' && buf[1] != '@') {
 		trap_SendServerCommand(targ, va("cps \"%s\"", buf));
 	}
-	else if(ent->spawnflags & 8) {
+	else if (ent->spawnflags & 8) {
 		trap_SendServerCommand(targ, va("print \"%s\n\"", buf));
 	}
-	else if(ent->spawnflags & 16) {
+	else if (ent->spawnflags & 16) {
 		trap_SendServerCommand(targ, va("chat \"%s\"", buf));
 	}
-/*
-	else if(ent->spawnflags & 16) {
-		char msg[MAX_STRING_CHARS];
-		Q_strncpyz(msg, ent->message, sizeof(msg));
-		char *s = msg, *c = s;
-		while(c[0]) {
-			if(c[0] == '\n'){
-				c[0] = 0;
-				trap_SendServerCommand(targ, va("chat \"%s\"", s));
-				s = ++c;
-			}
-			c++;
-		}
-		if(s[0])
-			trap_SendServerCommand(targ, va("chat \"%s\"", s));
-	}
-*/
 	else
+	{
 		trap_SendServerCommand(targ, va("cp \"%s\n\"", buf));
+	}
 }
 
 void Use_Target_Print_Go (gentity_t *ent){


### PR DESCRIPTION
…akable and target_print.

With the new Lmd_Trainer in its message key taking arguments such as ".n" = account name, ".l" account level and ".t" Profession title. Expanded this to the entities named above.