### PR TITLE
Fix documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.sln.docstates
 .vs/
+.vscode/
 
 # Build results
 [Dd]ebug/

--- a/.gitignore
+++ b/.gitignore
@@ -247,3 +247,9 @@ $RECYCLE.BIN/
 
 # We can ignore *.txt files alright, but not CMakeLists.txt
 !CMakeLists.txt
+
+# Linux builds
+# =========================
+CMakeFiles
+cmake_install.cmake
+Makefile

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "files.associations": {
-        "lmd_commands_auths.h": "c"
+        "lmd_commands_auths.h": "c",
+        "lmd_accounts_stats.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "files.associations": {
         "lmd_commands_auths.h": "c",
-        "lmd_accounts_stats.h": "c"
+        "lmd_accounts_stats.h": "c",
+        "lmd_entities_public.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "files.associations": {
-        "lmd_commands_auths.h": "c",
-        "lmd_accounts_stats.h": "c",
-        "lmd_entities_public.h": "c"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "lmd_commands_auths.h": "c"
+    }
+}

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -1,0 +1,34 @@
+# Lugormod v3
+
+## Dependencies
+You will need `i386` build support for 32-bit builds. As an example using `dpkg` for debian based systems:
+```
+dpkg --add-architecture i386
+apt update
+```
+
+The required dependencies for building are as follows:
+- build-essential
+- cmake
+- gcc-multilib
+- g++-multilib
+
+Using `apt` as an example:
+```
+apt-get install build-essential cmake gcc-multilib g++-multilib
+```
+
+## Compilation
+
+Make a `build` folder located at the root of the project and move to it:
+```
+mkdir build
+cd build
+```
+
+Run `CMake` to make build scripts:
+```
+cmake ../
+```
+
+Run `make` to build the project. Specify `-j4` to use 4 cpu-cores and speed up the process.

--- a/game/Lmd_Creditshunt.c
+++ b/game/Lmd_Creditshunt.c
@@ -7,6 +7,8 @@ gentity_t *Lmd_logic_entity(int index);
 #include "Lmd_Professions.h"
 #include "Lmd_Prof_Merc.h"
 
+#include "Lmd_Entities_Public.h"
+
 //RoboPhred
 extern vmCvar_t lmd_stashdepotime;
 extern vmCvar_t lmd_stashrate;
@@ -435,6 +437,14 @@ void zone_think (gentity_t *ent){
 	ent->nextthink = level.time + 5000;
 }
 
+const entityInfoData_t money_dispenser_keys[] = {
+	{NULL, NULL},
+};
+entityInfo_t money_dispenser_info = {
+	"Spawns a money depo where players can deposit a stash at",
+	NULL,
+	money_dispenser_keys
+};
 
 void SP_money_dispenser (gentity_t *ent){
 	if (g_gametype.integer != GT_FFA) {

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -359,7 +359,7 @@ void use_lmd_light(gentity_t* self, gentity_t* other, gentity_t* activator)
 
 const entityInfoData_t lmd_light_keys[] = {
     {"Light", "The intensity of the light when turned on."},
-    {"Color", "The colors in decimal precent form (0 to 1, 0.5 would be 50%) for the color to display.  Values are red, green, and blue, in that order.  Example: color,1 0 1, would be yellow."},
+    {"Color", "The colors in decimal precent form (0 to 1, 0.5 would be 50 percent) for the color to display.  Values are red, green, and blue, in that order.  Example: color,1 0 1, would be yellow."},
     {"Offlight", "Same as light, but when toggled off."},
     {"Offcolor", "Same as color, but when toggled off."},
     {NULL, NULL}

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -359,10 +359,7 @@ void use_lmd_light(gentity_t* self, gentity_t* other, gentity_t* activator)
 
 const entityInfoData_t lmd_light_keys[] = {
     {"Light", "The intensity of the light when turned on."},
-    {
-        "Color",
-        "The colors in decimal precent form (0 to 1, 0.5 would be 50%) for the color to display.  Values are red, green, and blue, in that order.  Example: color,1 0 1, would be yellow."
-    },
+    {"Color", "The colors in decimal precent form (0 to 1, 0.5 would be 50%) for the color to display.  Values are red, green, and blue, in that order.  Example: color,1 0 1, would be yellow."},
     {"Offlight", "Same as light, but when toggled off."},
     {"Offcolor", "Same as color, but when toggled off."},
     {NULL, NULL}
@@ -606,6 +603,10 @@ void use_lmd_toggle(gentity_t* self, gentity_t* other, gentity_t* activator)
     self->painDebounceTime = level.time + self->wait;
 }
 
+const entityInfoData_t lmd_toggle_spawnflags[] = {
+  {NULL, NULL}
+};
+
 const entityInfoData_t lmd_toggle_keys[] = {
     {"Count", "The highest target number you are using.  Must be greater than 1."},
     {"Target-Target6", "Targets to fire."},
@@ -614,7 +615,7 @@ const entityInfoData_t lmd_toggle_keys[] = {
 
 entityInfo_t lmd_toggle_info = {
     "Targets 1 through \'count\' will be used in order.  One target will be fired per trigger.",
-    NULL,
+    lmd_toggle_spawnflags,
     lmd_toggle_keys
 };
 
@@ -718,6 +719,7 @@ entityInfo_t lmd_mover_info = {
     NULL,
     lmd_mover_keys
 };
+
 
 void lmd_mover(gentity_t* ent)
 {
@@ -1176,6 +1178,11 @@ void use_lmd_body(gentity_t* self, gentity_t* other, gentity_t* activator)
     self->nextthink = level.time + FRAMETIME; //give a delay so we dont instantly quit
     self->chain = body;
 }
+
+entityInfoData_t lmd_body_keys[] = {
+  {"targetname", "Activate the entity when targeted."},
+  {NULL, NULL}
+};
 
 entityInfo_t lmd_body_info = {
     "A false player body.  When a player uses this, a clone of their model will appear where they are, doing their last animation.  Damage to the body will transfer to the player.  If the player is not also teleported, they will be stuck inside the newly spawned body.\n"
@@ -3308,7 +3315,7 @@ entityInfo_t lmd_chance_info = {
     lmd_chance_keys
 };
 
-void lmd_chance(gentity_t* ent)
+oid lmd_chance(gentity_t* ent)
 {
     if (ent->count < 1)
     {
@@ -4764,6 +4771,7 @@ void lmd_forceskillmenu_key(gentity_t* player, usercmd_t* cmd)
     }
 }
 
+
 void lmd_filteredskillmenu_show(gentity_t* player, gentity_t* menu, int filterMode)
 {
     if (!player || !player->client || !menu || !player->client->pers.Lmd.account)
@@ -5618,6 +5626,9 @@ void lmd_cskill_compare_use(gentity_t* self, gentity_t* other, gentity_t* activa
         G_UseTargets2(self, activator, self->target3);
 }
 
+const entityInfoData_t lmd_cskill_compare_spawnflags[] = {
+  {NULL, NULL}
+};
 const entityInfoData_t lmd_cskill_compare_keys[] = {
     {"Skill1", "Skill to compare."},
     {"Skill2", "Skill to compare."},
@@ -5628,7 +5639,7 @@ const entityInfoData_t lmd_cskill_compare_keys[] = {
 };
 entityInfo_t lmd_cskill_compare_info = {
     "Compares values of two customskills, and fires respective target.",
-    NULL,
+    lmd_cskill_compare_spawnflags,
     lmd_cskill_compare_keys
 };
 
@@ -5752,6 +5763,10 @@ void lmd_iterateplayers_use(gentity_t* self, gentity_t* other, gentity_t* activa
     }
 }
 
+const entityInfoData_t lmd_iterateplayers_spawnflags[] = {
+  {"128", "Entity must be hit with a target_activate before it can be used."},
+  {NULL, NULL}
+};
 const entityInfoData_t lmd_iterateplayers_keys[] = {
     {"#UKEYS", NULL},
     {"#HITBOX", NULL},
@@ -5760,7 +5775,7 @@ const entityInfoData_t lmd_iterateplayers_keys[] = {
 };
 entityInfo_t lmd_iterateplayers_info = {
     "Iterates among all connected players and fires its target for them.",
-    NULL,
+    lmd_iterateplayers_spawnflags,
     lmd_iterateplayers_keys
 };
 

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3315,7 +3315,7 @@ entityInfo_t lmd_chance_info = {
     lmd_chance_keys
 };
 
-oid lmd_chance(gentity_t* ent)
+void lmd_chance(gentity_t* ent)
 {
     if (ent->count < 1)
     {

--- a/game/Lmd_RandomSpot.c
+++ b/game/Lmd_RandomSpot.c
@@ -1,6 +1,7 @@
 
 
 #include "g_local.h"
+#include "Lmd_Entities_Public.h" // for entityInfo_t
 
 int count_random_spots (void){
 	int c = 0;
@@ -54,6 +55,22 @@ void random_spot_think(gentity_t *ent) {
 		ent->enemy = NULL;
 	ent->nextthink = level.time + FRAMETIME;
 }
+
+
+const entityInfoData_t random_spot_spawnflags[] = {
+  {NULL, NULL}
+};
+
+const entityInfoData_t random_spot_keys[] = {
+  {"", ""},
+  {NULL, NULL}
+};
+
+const entityInfo_t random_spot_info = {
+  "A generic stash spawn point for credits. Only works in FFA, Team, Holocron gametypes.",
+  random_spot_spawnflags,
+  random_spot_keys
+};
 
 void SP_random_spot (gentity_t *ent) {
 	assert(ent && ent->inuse);

--- a/game/Lmd_RandomSpot.c
+++ b/game/Lmd_RandomSpot.c
@@ -62,12 +62,12 @@ const entityInfoData_t random_spot_spawnflags[] = {
 };
 
 const entityInfoData_t random_spot_keys[] = {
-  {"", ""},
+  {"origin", "Where the random spot is located (x y z)"},
   {NULL, NULL}
 };
 
 const entityInfo_t random_spot_info = {
-  "A generic stash spawn point for credits. Only works in FFA, Team, Holocron gametypes.",
+  "A location for a stash to randomly spawn. Only works in FFA, Team, Holocron gametypes. Once a stash has spawned it won't use the same spot for another 10 minutes.",
   random_spot_spawnflags,
   random_spot_keys
 };

--- a/game/NPC_spawn.c
+++ b/game/NPC_spawn.c
@@ -2646,6 +2646,30 @@ void NPC_VehicleSpawnUse( gentity_t *self, gentity_t *other, gentity_t *activato
 	}
 }
 
+const entityInfoData_t NPC_Vehicle_spawnflags[] = {
+	{"1", "die after certain amount of time of not having a pilot"},
+	{"2", "Fighters: Don't drop until someone gets in it. this only works if it's never been used. ships in trigger_space will never drop when unoccupied"},
+	{"16", "spawn on the floor instead of floating around in the air"},
+	{"32", "Will spawn with no default AI (BS_CINEMATIC) or won't blink when spawned"},
+	{"64", "Starts not solid"},
+	{"256", "Spawner is shy (wont spawn if a player is looking at it)"},
+	{NULL, NULL}
+};
+const entityInfoData_t NPC_Vehicle_keys[] = {
+	{"dropTime", "use with spawnflags 2, the vehicle will drop straight down for this number of seconds before flying forward"},
+	{"dmg", "use with spawnflags 1, delay in milliseconds for ship to explode if no pilot (default 10000)"},
+	{"speed", "se with spawnflags 1, distance for pilot to get away from ship after dismounting before it starts counting down the death timer"},
+	{"model2", "if the vehicle can have a droid, this NPC will be spawned and placed there"},
+	{"showhealth", "set to 1 to show health bar on this entity when crosshair is over it"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t NPC_Vehicle_info = {
+	"Spawns a NPC Vehicle, please note the entity name is case sensitive",
+	NPC_Vehicle_spawnflags,
+	NPC_Vehicle_keys
+};
+
 void SP_NPC_Vehicle( gentity_t *self)
 {
 	/* done in g_spawn now

--- a/game/NPC_spawn.c
+++ b/game/NPC_spawn.c
@@ -2448,6 +2448,43 @@ void NPC_PrecacheType( char *NPC_type )
 }
 //void SP_trigger_visible (gentity_t *ent);
 
+const entityInfoData_t NPC_spawner_spawnflags[] = {
+	{"16", "NPC can be in air, but will spawn on the closest floor surface below it"},
+	{"32", "Will spawn with no default AI (BS_CINEMATIC), or the blinking that happens when it spawns"},
+	{"256", "Spawner is shy (wont spawn if a player is looking at it)"},
+	{NULL, NULL}
+};
+const entityInfoData_t NPC_spawner_keys[] = {
+	{"NPC_type", "name of NPC to spawn"},
+	{"targetname", "name this NPC goes by for targeting"},
+	{"count", "how many npcs to spawn if targeted. set to -1 to spawn multiple times (default 1)"},
+	{"delay", "how long to wait to spawn after used"},
+	{"wait", "if trying to spawn and blocked, how many seconds to wait before trying again"},
+	{"NPC_target", "target to fire when killed"},
+	{"NPC_target2", "target to fire when knocked out"},
+	{"NPC_target4", "target to fire when killed by friendly fire"},
+	{"NPC_target5", "target to fire when killed for the player that killed the entity (target credits)"},
+	{"NPC_target6", "target to fire when npc kills a player"},
+	{"health", "starting health (default 100)"},
+	{"showhealth", "set to 1 to show health bar on this entity when crosshair is over it"},
+	{"noBasicSounds", "set to 1 to prevent loading and usage of basic sounds (pain, death, etc)"},
+	{"noCombatSounds", "set to 1 to prevent loading and usage of combat sounds (anger, victory, etc)"},
+	{"noExtraSounds", "set to 1 to prevent loading and usage of \'extra\' sounds (chasing the enemy, detecting, fleeing, jedi combat sounds)"},
+	{"spawnscript", "default script to run once spawned"},
+	{"usescript", "default script to run when used"},
+	{"awakescript", "default script to run once awoken"},
+	{"angerscript", "default script to run once angered"},
+	{"painscript", "default script to run when hit"},
+	{"fleescript", "default script to run when hit and below 50\% health"},
+	{"deathscript", "default script to run when killed"},
+	{NULL, NULL}
+};
+const entityInfo_t NPC_spawner_info = {
+	"Spawns a NPC that you specify, remember all keys are case sensative. (Its not npc_type, its NPC_type), if this is going to be used by a button add \'count,-1,\' so it can spawn more than once.",
+	NPC_spawner_spawnflags,
+	NPC_spawner_keys
+};
+
 void SP_NPC_spawner( gentity_t *self){
 	int t;
 	if ( !self->fullName || !self->fullName[0] )
@@ -4509,41 +4546,18 @@ gentity_t *NPC_SpawnType( gentity_t *ent, char *npc_type, char *targetname, qboo
 }
 qboolean isVehicleName (char *name);
 
-const entityInfoData_t NPC_spawner_spawnflags[] = {
-	{"16", "NPC can be in air, but will spawn on the closest floor surface below it"},
-	{"32", "Will spawn with no default AI (BS_CINEMATIC), or the blinking that happens when it spawns"},
-	{"256", "Spawner is shy (wont spawn if a player is looking at it)"},
+const entityInfoData_t LMD_spawner_spawnflags[] = {
 	{NULL, NULL}
 };
-const entityInfoData_t NPC_spawner_keys[] = {
-	{"NPC_type", "name of NPC to spawn"},
-	{"targetname", "name this NPC goes by for targeting"},
-	{"count", "how many npcs to spawn if targeted. set to -1 to spawn multiple times (default 1)"},
-	{"delay", "how long to wait to spawn after used"},
-	{"wait", "if trying to spawn and blocked, how many seconds to wait before trying again"},
-	{"NPC_target", "target to fire when killed"},
-	{"NPC_target2", "target to fire when knocked out"},
-	{"NPC_target4", "target to fire when killed by friendly fire"},
-	{"NPC_target5", "target to fire when killed for the player that killed the entity (target credits)"},
-	{"NPC_target6", "target to fire when npc kills a player"},
-	{"health", "starting health (default 100)"},
-	{"showhealth", "set to 1 to show health bar on this entity when crosshair is over it"},
-	{"noBasicSounds", "set to 1 to prevent loading and usage of basic sounds (pain, death, etc)"},
-	{"noCombatSounds", "set to 1 to prevent loading and usage of combat sounds (anger, victory, etc)"},
-	{"noExtraSounds", "set to 1 to prevent loading and usage of \'extra\' sounds (chasing the enemy, detecting, fleeing, jedi combat sounds)"},
-	{"spawnscript", "default script to run once spawned"},
-	{"usescript", "default script to run when used"},
-	{"awakescript", "default script to run once awoken"},
-	{"angerscript", "default script to run once angered"},
-	{"painscript", "default script to run when hit"},
-	{"fleescript", "default script to run when hit and below 50\% health"},
-	{"deathscript", "default script to run when killed"},
+const entityInfoData_t LMD_spawner_keys[] = {
+	{"customscale", "scale this npc/vehicle when it spawns"},
+	{"count", "amount of NPCs allowed to be on the map at once from this spawn"},
 	{NULL, NULL}
 };
-const entityInfo_t NPC_spawner_info = {
-	"Spawns a NPC that you specify, remember all keys are case sensative. (Its not npc_type, its NPC_type), if this is going to be used by a button add \'count,-1,\' so it can spawn more than once.",
-	NPC_spawner_spawnflags,
-	NPC_spawner_keys
+const entityInfo_t LMD_spawner_info = {
+	"This entity was implemented by Lugor, it should be able to use any of the keys provided for npc_spawner and one more, it also allows the NPC to respawn after it has been destroyed.",
+	LMD_spawner_spawnflags,
+	LMD_spawner_keys
 };
 
 void SP_LMD_spawner (gentity_t *NPCspawner){

--- a/game/NPC_spawn.c
+++ b/game/NPC_spawn.c
@@ -6,6 +6,7 @@
 #include "bg_saga.h"
 #include "bg_vehicles.h"
 #include "g_nav.h"
+#include "Lmd_Entities_Public.h"
 
 extern void G_DebugPrint( int level, const char *format, ... );
 
@@ -4507,6 +4508,43 @@ gentity_t *NPC_SpawnType( gentity_t *ent, char *npc_type, char *targetname, qboo
 	//}
 }
 qboolean isVehicleName (char *name);
+
+const entityInfoData_t NPC_spawner_spawnflags[] = {
+	{"16", "NPC can be in air, but will spawn on the closest floor surface below it"},
+	{"32", "Will spawn with no default AI (BS_CINEMATIC), or the blinking that happens when it spawns"},
+	{"256", "Spawner is shy (wont spawn if a player is looking at it)"},
+	{NULL, NULL}
+};
+const entityInfoData_t NPC_spawner_keys[] = {
+	{"NPC_type", "name of NPC to spawn"},
+	{"targetname", "name this NPC goes by for targeting"},
+	{"count", "how many npcs to spawn if targeted. set to -1 to spawn multiple times (default 1)"},
+	{"delay", "how long to wait to spawn after used"},
+	{"wait", "if trying to spawn and blocked, how many seconds to wait before trying again"},
+	{"NPC_target", "target to fire when killed"},
+	{"NPC_target2", "target to fire when knocked out"},
+	{"NPC_target4", "target to fire when killed by friendly fire"},
+	{"NPC_target5", "target to fire when killed for the player that killed the entity (target credits)"},
+	{"NPC_target6", "target to fire when npc kills a player"},
+	{"health", "starting health (default 100)"},
+	{"showhealth", "set to 1 to show health bar on this entity when crosshair is over it"},
+	{"noBasicSounds", "set to 1 to prevent loading and usage of basic sounds (pain, death, etc)"},
+	{"noCombatSounds", "set to 1 to prevent loading and usage of combat sounds (anger, victory, etc)"},
+	{"noExtraSounds", "set to 1 to prevent loading and usage of \'extra\' sounds (chasing the enemy, detecting, fleeing, jedi combat sounds)"},
+	{"spawnscript", "default script to run once spawned"},
+	{"usescript", "default script to run when used"},
+	{"awakescript", "default script to run once awoken"},
+	{"angerscript", "default script to run once angered"},
+	{"painscript", "default script to run when hit"},
+	{"fleescript", "default script to run when hit and below 50\% health"},
+	{"deathscript", "default script to run when killed"},
+	{NULL, NULL}
+};
+const entityInfo_t NPC_spawner_info = {
+	"Spawns a NPC that you specify, remember all keys are case sensative. (Its not npc_type, its NPC_type), if this is going to be used by a button add \'count,-1,\' so it can spawn more than once.",
+	NPC_spawner_spawnflags,
+	NPC_spawner_keys
+};
 
 void SP_LMD_spawner (gentity_t *NPCspawner){
 	//RoboPhred: apparently this is possible

--- a/game/NPC_spawn.c
+++ b/game/NPC_spawn.c
@@ -2475,7 +2475,7 @@ const entityInfoData_t NPC_spawner_keys[] = {
 	{"awakescript", "default script to run once awoken"},
 	{"angerscript", "default script to run once angered"},
 	{"painscript", "default script to run when hit"},
-	{"fleescript", "default script to run when hit and below 50\% health"},
+	{"fleescript", "default script to run when hit and below 50 percent health"},
 	{"deathscript", "default script to run when killed"},
 	{NULL, NULL}
 };

--- a/game/g_battleground.c
+++ b/game/g_battleground.c
@@ -289,7 +289,7 @@ const entityInfoData_t control_point_keys[] = {
 	{NULL, NULL},
 };
 entityInfo_t control_point_info = {
-	"For use in battle ground gametype. This is a capturable control point for a team. You must place at least one for each team. If you set the \'alliedTeam\' option on a NPC_Vehicle the control point will only spawn vehicles if owned by the selected team",
+	"For use in battle ground gametype. This is a capturable control point for a team. You must place at least one for each team. If you set the \'alliedTeam\' option on a NPC_Vehicle the control point will only spawn vehicles if owned by the selected team. Spawns a control_point_zone when placed. Recommended to save the map with extension \'battleground\' to be loaded by default when the gametype is selected",
 	control_point_spawnflags,
 	control_point_keys
 };

--- a/game/g_battleground.c
+++ b/game/g_battleground.c
@@ -1,4 +1,5 @@
 #include "g_local.h"
+#include "Lmd_Entities_Public.h"
 
 #define CP_TIME             500
 #define CP_RECOVER          250
@@ -275,6 +276,23 @@ int trap_RealTime( qtime_t *qtime );
 //void animate_model (gentity_t *self);
 void SP_misc_model_breakable(gentity_t *ent);
 
+const entityInfoData_t control_point_spawnflags[] = {
+	{"1","The control point cannot be taken. Only valid if \'alliedTeam\' is set to either 1 or 2 (red or blue)"},
+	{"2", "Important control point. Takes longer to hack and reduces the rate the points count down more when controlled"},
+	{NULL, NULL}
+};
+
+const entityInfoData_t control_point_keys[] = {
+	{"alliedTeam", "1 - red team, 2 - blue team"},
+	{"message", "set a message displayed to the owning alliedTeam when someone is trying to steal the control point"},
+	{"model", "optionally choose a model other than the default"},
+	{NULL, NULL},
+};
+entityInfo_t control_point_info = {
+	"For use in battle ground gametype. This is a capturable control point for a team. You must place at least one for each team. If you set the \'alliedTeam\' option on a NPC_Vehicle the control point will only spawn vehicles if owned by the selected team",
+	control_point_spawnflags,
+	control_point_keys
+};
 
 void SP_control_point (gentity_t *ent)
 {

--- a/game/g_client.c
+++ b/game/g_client.c
@@ -373,6 +373,20 @@ INITIAL - The first time a player enters the game, they will be at an 'initial' 
 "nobots" will prevent bots from using this spot.
 "nohumans" will prevent non-bots from using this spot.
 */
+const entityInfoData_t info_player_start_red_spawnflags[] = {
+	// {"1", "The first time a player enters the game, they will be at an \'initial\' spot."}, // pretty sure INITIAL is a spawnflag and it's not used?
+	{NULL, NULL}
+};
+const entityInfoData_t info_player_start_red_keys[] = {
+	{"nobots", "will prevent bots from using this spot"},
+	{"nohumans", "will prevent non-bots from using this spot"},
+	{NULL, NULL}
+};
+const entityInfo_t info_player_start_red_info = {
+	"For Red Team DM starts, equivalent to info_player_deathmatch. Targets will be fired when someone spawns in on them",
+	info_player_start_red_spawnflags,
+	info_player_start_red_keys
+};
 void SP_info_player_start_red(gentity_t *ent) {
 	//RoboPhred
 	if(g_gametype.integer == GT_FFA){
@@ -407,6 +421,20 @@ INITIAL - The first time a player enters the game, they will be at an 'initial' 
 "nobots" will prevent bots from using this spot.
 "nohumans" will prevent non-bots from using this spot.
 */
+const entityInfoData_t info_player_start_blue_spawnflags[] = {
+	// {"1", "The first time a player enters the game, they will be at an \'initial\' spot."}, // pretty sure INITIAL is a spawnflag and it's not used?
+	{NULL, NULL}
+};
+const entityInfoData_t info_player_start_blue_keys[] = {
+	{"nobots", "will prevent bots from using this spot"},
+	{"nohumans", "will prevent non-bots from using this spot"},
+	{NULL, NULL}
+};
+const entityInfo_t info_player_start_blue_info = {
+	"For Blue Team DM starts, equivalent to info_player_deathmatch. Targets will be fired when someone spawns in on them",
+	info_player_start_blue_spawnflags,
+	info_player_start_blue_keys
+};
 void SP_info_player_start_blue(gentity_t *ent) {
 	if(g_gametype.integer == GT_FFA){
 		if (disablesenabled && thereIsAPlayerSpawn()) { //Lugormod

--- a/game/g_client.c
+++ b/game/g_client.c
@@ -597,6 +597,19 @@ The intermission will be viewed from this point.  Target an info_notnull for the
 RED - In a Siege game, the intermission will happen here if the Red (attacking) team wins
 BLUE - In a Siege game, the intermission will happen here if the Blue (defending) team wins
 */
+const entityInfoData_t info_player_intermission_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t info_player_intermission_keys[] = {
+	{"target", "target an info_notnull for the view direction"},
+	{NULL, NULL}
+};
+const entityInfo_t info_player_intermission_info = {
+	"The intermission will be viewed from this point. Might be removed.",
+	info_player_intermission_spawnflags,
+	info_player_intermission_keys
+};
 void SP_info_player_intermission( gentity_t *ent ) {
 
 }
@@ -608,6 +621,20 @@ In a Siege game, the intermission will happen here if the Red (attacking) team w
 target - ent to look at
 target2 - ents to use when this intermission point is chosen
 */
+const entityInfoData_t info_player_intermission_red_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t info_player_intermission_red_keys[] = {
+	{"target", "target an info_notnull for the view direction"},
+	{"target2", "ents to use when this intermission point is chosen"},
+	{NULL, NULL}
+};
+const entityInfo_t info_player_intermission_red_info = {
+	"The intermission will be viewed from this point if red wins. Might be removed.",
+	info_player_intermission_red_spawnflags,
+	info_player_intermission_red_keys
+};
 void SP_info_player_intermission_red( gentity_t *ent ) {
 
 }
@@ -619,6 +646,20 @@ In a Siege game, the intermission will happen here if the Blue (defending) team 
 target - ent to look at
 target2 - ents to use when this intermission point is chosen
 */
+const entityInfoData_t info_player_intermission_blue_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t info_player_intermission_blue_keys[] = {
+	{"target", "target an info_notnull for the view direction"},
+	{"target2", "ents to use when this intermission point is chosen"},
+	{NULL, NULL}
+};
+const entityInfo_t info_player_intermission_blue_info = {
+	"The intermission will be viewed from this point if blue wins. Might be removed.",
+	info_player_intermission_blue_spawnflags,
+	info_player_intermission_blue_keys
+};
 void SP_info_player_intermission_blue( gentity_t *ent ) {
 
 }
@@ -864,6 +905,19 @@ gentity_t *gJMSaberEnt = NULL;
 /*QUAKED info_jedimaster_start (1 0 0) (-16 -16 -24) (16 16 32)
 "jedi master" saber spawn point
 */
+const entityInfoData_t info_jedimaster_start_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t info_jedimaster_start_keys[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t info_jedimaster_start_info = {
+	"Saber spawn point for \'Jedi Master\' gametype. If the gametype is something else the ent is removed.",
+	info_jedimaster_start_spawnflags,
+	info_jedimaster_start_keys
+};
 void SP_info_jedimaster_start(gentity_t *ent)
 {
 	if (g_gametype.integer != GT_JEDIMASTER)

--- a/game/g_client.c
+++ b/game/g_client.c
@@ -453,6 +453,23 @@ idealclass - if specified, this spawn point will be considered
 entry in the .scl (siege class) file.
 Targets will be fired when someone spawns in on them.
 */
+const entityInfoData_t info_player_siegeteam1_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t info_player_siegeteam1_keys[] = {
+	{"startoff", "if non-0 spawn point will be disabled until used"},
+	{"idealclass", "if specified, this spawn point will be considered \'ideal\' for players of this class. Corresponds to the name entry in the .scl (siege class) file"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t info_player_siegeteam1_info = {
+	"Siege team start point for team1. Name and behavior of team1 depends on what is defined in the .siege file for the level. If gametype is not siege this becomes a info_player_deathmatch.",
+	info_player_siegeteam1_spawnflags,
+	info_player_siegeteam1_keys
+};
+
 void SP_info_player_siegeteam1(gentity_t *ent) {
 	int soff = 0;
 
@@ -513,6 +530,22 @@ idealclass - if specified, this spawn point will be considered
 entry in the .scl (siege class) file.
 Targets will be fired when someone spawns in on them.
 */
+const entityInfoData_t info_player_siegeteam2_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t info_player_siegeteam2_keys[] = {
+	{"startoff", "if non-0 spawn point will be disabled until used"},
+	{"idealclass", "if specified, this spawn point will be considered \'ideal\' for players of this class. Corresponds to the name entry in the .scl (siege class) file"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t info_player_siegeteam2_info = {
+	"Siege team start point for team2. Name and behavior of team2 depends on what is defined in the .siege file for the level. If gametype is not siege this becomes a info_player_deathmatch.",
+	info_player_siegeteam2_spawnflags,
+	info_player_siegeteam2_keys
+};
 void SP_info_player_siegeteam2(gentity_t *ent) {
 	int soff = 0;
 

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -12,6 +12,8 @@
 #include "Lmd_EntityCore.h"
 #include "Lmd_EntityUtil.h"
 
+#include "Lmd_Entities_Public.h"
+
 #define HOLOCRON_RESPAWN_TIME 30000
 #define MAX_AMMO_GIVE 2
 #define STATION_RECHARGE_TIME 100
@@ -473,6 +475,25 @@ void misc_camera_use(gentity_t *self, gentity_t *other, gentity_t *activator){
 
 	return;
 }
+
+const entityInfoData_t misc_camera_spawnflags[] = {
+	{NULL, NULL}
+};
+
+const entityInfoData_t misc_camera_keys[] = {
+	{"wait", "time between the user being able to fire its targets by attacking.  (defaults to 1 second)"},
+	{"target2", "when the user attacks"},
+	{"target3", "fire when the user alt-attacks"},
+	{"model", "a .md3 to draw instead of the default camera model"},
+	{"targetname", "make the trigger target this value for the entity to be used."},
+	{NULL, NULL}
+};
+
+const entityInfo_t misc_camera_info = {
+	"A working camera that is similar to the single player camera system. the player is noclipped and teleported and frozen at the camera location, and a fake model is left behind where he was. Any damage given to the fake model is passed onto the player. The entity spawns a camera model by default at the origin/angle of the entity. You can turn off the model by setting model,null,",
+	misc_camera_spawnflags,
+	misc_camera_keys
+};
 
 void SP_misc_camera (gentity_t *ent){
 	//G_FreeEntity(ent);
@@ -3216,6 +3237,12 @@ This world effect will spawn space dust globally into the level.
 "count" the number of snow particles (default of 1000)
 */
 //----------------------------------------------------------
+
+const entityInfo_t fx_spacedust_info = {
+	"This world effect will spawn space dust globally into the level",
+	NULL,
+	{"count", "the number of space dust particles (default of 1000)"}
+};
 void SP_CreateSpaceDust( gentity_t *ent )
 {
 	G_EffectIndex(va("*spacedust %i", ent->count));
@@ -3228,6 +3255,11 @@ This world effect will spawn snow globally into the level.
 "count" the number of snow particles (default of 1000)
 */
 //----------------------------------------------------------
+const entityInfo_t fx_snow_info = {
+	"This world effect will spawn snow globally into the level",
+	NULL,
+	{"count", "the number of snow particles (default of 1000)"}
+};
 void SP_CreateSnow( gentity_t *ent )
 {
 	G_EffectIndex("*snow");
@@ -3241,6 +3273,11 @@ This world effect will spawn rain globally into the level.
 "count" the number of rain particles (default of 500)
 */
 //----------------------------------------------------------
+const entityInfo_t fx_rain_info = {
+	"This world effect will spawn rain globally into the level",
+	NULL,
+	{"count", "the number of rain particles (default of 500)"}
+};
 void SP_CreateRain( gentity_t *ent )
 {
 	if (g_dontLoadNPC.integer) {
@@ -3257,6 +3294,11 @@ void SP_CreateRain( gentity_t *ent )
 	G_EffectIndex(va("*rain init %i", ent->count));
 }
 
+const entityInfo_t fx_wind_info = {
+	"This world effect will spawn wind globally into the level",
+	{"2", "make a camera shake effect"},
+	{"speed", "speed at which wind is blowing (default 100)"}
+};
 void SP_CreateWind( gentity_t *ent )
 {
 	if (!ent->speed) { //Lugormod (where else would it be done???)

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -21,6 +21,22 @@
 void HolocronThink(gentity_t *ent);
 extern vmCvar_t g_MaxHolocronCarry;
 
+/*LMD Placeholder entityInfo objects
+const entityInfoData_t placeholder_spawnflags[] = {
+	{"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t placeholder_keys[] = {
+	{"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t placeholder_info = {
+	"",
+	placeholder_spawnflags,
+	placeholder_keys
+};
+*/
+
 /*QUAKED func_group (0 0 0) ?
 Used to group brushes together just for editor convenience.  They are turned into normal brushes by the utilities.
 */
@@ -28,6 +44,20 @@ Used to group brushes together just for editor convenience.  They are turned int
 /*QUAKED info_camp (0 0.5 0) (-4 -4 -4) (4 4 4)
 Used as a positional target for calculations in the utilities (spotlights, etc), but removed during gameplay.
 */
+
+const entityInfoData_t SP_info_camp_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t SP_info_camp_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t SP_info_camp_info = {
+	"Used as a positional target for calculations in the utilities (spotlights, etc), but removed during gameplay",
+	SP_info_camp_spawnflags,
+	SP_info_camp_keys
+};
 void SP_info_camp( gentity_t *self ) {
 	G_SetOrigin( self, self->s.origin );
 }
@@ -35,6 +65,20 @@ void SP_info_camp( gentity_t *self ) {
 /*QUAKED info_null (0 0.5 0) (-4 -4 -4) (4 4 4)
 Used as a positional target for calculations in the utilities (spotlights, etc), but removed during gameplay.
 */
+
+const entityInfoData_t SP_info_null_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t SP_info_null_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t SP_info_null_info = {
+	"Used as a positional target for calculations in the utilities (spotlights, etc), but removed during gameplay",
+	SP_info_null_spawnflags,
+	SP_info_null_keys
+};
 void SP_info_null( gentity_t *self ) {
 	G_FreeEntity( self );
 }
@@ -43,6 +87,20 @@ void SP_info_null( gentity_t *self ) {
 Used as a positional target for in-game calculation, like jumppad targets.
 target_position does the same thing
 */
+
+const entityInfoData_t SP_info_notnull_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t SP_info_notnull_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t SP_info_notnull_info = {
+	"Used as a positional target for in-game calculation, like jumppad targets. target_position does the same thing",
+	SP_info_notnull_spawnflags,
+	SP_info_notnull_keys
+};
 void SP_info_notnull( gentity_t *self ){
 	G_SetOrigin( self, self->s.origin );
 }
@@ -86,6 +144,30 @@ greater than 1 is brighter, between 0 and 1 is dimmer.
 12 FAST PULSE FOR JEREMY
 13 Test Blending
 */
+const entityInfoData_t SP_light_spawnflags[] = {
+	{"linear", ""},
+	{"noIncidence", ""},
+	{"START_OFF", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t SP_light_keys[] = {
+	{"light", "overrides the default 300 intensity - affects size a negative \'light\' will subtract the light\'s color"},
+	{"linear", "checkbox gives linear falloff instead of inverse square"},
+	{"noIncidence", "checkbox makes lighting smoother - lights pointed at a target will be spotlights"},
+	{"radius", "overrides the default 64 unit radius of a spotlight at the target point"},
+	{"scale", "multiplier for the light intensity - does not affect size (default 1) - greater than 1 is brighter, between 0 and 1 is dimmer"},
+	{"color", "sets the light\'s color (R G B)"},
+	{"targetname", "to indicate a switchable light - NOTE that all lights with the same targetname will be grouped together and act as one light (ie: don't mix colors, styles or start_off flag)"},
+	{"style", "to specify a specify light style, even for switchable lights"},
+	{"style_off", "light style to use when switched off (Only for switchable lights)"},
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t SP_light_info = {
+	"Non-displayed light",
+	SP_light_spawnflags,
+	SP_light_keys
+};
 static void misc_lightstyle_set ( gentity_t *ent)
 {
 	const int mLightStyle = ent->count;
@@ -247,6 +329,20 @@ Point teleporters at these.
 Now that we don't have teleport destination pads, this is just
 an info_notnull
 */
+
+const entityInfoData_t misc_teleporter_dest_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_teleporter_dest_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_teleporter_dest_info = {
+	"Point teleporters at these like misc_teleporter_dest. Now that we don't have teleport destination pads, this is just an info_notnull",
+	misc_teleporter_dest_spawnflags,
+	misc_teleporter_dest_keys
+};
 void SP_misc_teleporter_dest( gentity_t *ent ) {
 }
 
@@ -256,6 +352,20 @@ void SP_misc_teleporter_dest( gentity_t *ent ) {
 "model"		arbitrary .md3 or .ase file to display
 turns into map triangles - not solid
 */
+
+const entityInfoData_t misc_model_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_model_keys[] = {
+	{"model", "arbitrary .md3 or .ase file to display"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_model_info = {
+	"not used, turns into map triangles - not solid",
+	misc_model_spawnflags,
+	misc_model_keys
+};
 void SP_misc_model( gentity_t *ent ) {
 #if 0
 	ent->s.modelindex = G_ModelIndex( ent->model );
@@ -542,6 +652,19 @@ void misc_security_panel_use (gentity_t *self, gentity_t *other, gentity_t *acti
 	G_UseTargets(self, activator);
 }
 
+const entityInfoData_t misc_security_panel_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_security_panel_keys[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t misc_security_panel_info = {
+	"no info given but appears to be solid kejim/sec_panel.md3 that accepts player usable keys",
+	misc_security_panel_spawnflags,
+	misc_security_panel_keys
+};
 void SP_misc_security_panel (gentity_t *ent) {
 	VectorSet(ent->r.maxs, 8, 8, 8);
 	VectorSet(ent->r.mins, -8, -8, -8);
@@ -665,9 +788,10 @@ void animate_model (gentity_t *self);
 
 void FixBox(vec3_t mins,vec3_t maxs, vec3_t angles);
 
-/*
-misc_model_breakable
-spawnflags:
+/*QUAKED misc_model_breakable
+This will spawn a model in game that can either have no purpose and sit there, or it can fire a target, or it can even accept money to fire at its target.
+
+SPAWNFLAGS
 SOLID           1
 AUTOANIMATE     2
 DEAD SOLID      4
@@ -680,8 +804,107 @@ NO_EXPLOSION  256
 START_OFF     512
 ??           1024
 ??           2048
+??			 4096
+??			 8192
+
+1     - Makes the model solid. If maxs/mins are defined it will follow those.
+        Otherwise it will follow default maxs/mins, which go to the full extent size of the model
+2     - Will cycle its animation
+4     - Bounding Box will be there even when destroyed
+8     - Doesn't display damage model when destroyed
+16    - No smoke when used
+32    - When used, will toggle to it's usemodel (model + "_u1.md3")... this does nothing if spawnflags 64 is not checked.
+64    - When used it will not break
+128   - Player can use it will use button
+256   - No Explosion
+512   - Starts deactivated
+8192  - Payable button, use count and message keys
+
+Keys:
+customSkill        - The name of the skill to check. (see lmd_customskill for details).  
+customSkillCompare - Comparison type. -1 for direct compare (use this for text), 0 for greater or equal to, 1 for less than. 
+                     (default 0)  
+customSkillValue   - The value to compare to.  
+property    - this entity will only work for people with access to the property set here  
+playerFlags - gives access to this entity for players who have this set ammount of flags, see lmd_flagplayer for more information  
+useScript   - the script to use  
+parm1       - the movement distance for a movable model to move to, if spawnflags 2 is set it loops its movement.  
+              If not it only moves when something targets the entities targetname this only works if you have the usescript key set to something like:         
+              "usescript,common/switch_on".  
+parm2       - the delay to wait in milliseconds before moving again when the movement reaches its closed position or opened position  
+profession  - Sets it so only a person with a certain profession can use a button.   
+              Note that you can add these together: profession,3, = jedi and merc but tech can't access this button.
+              -1     - no profession  
+               1     - Jedi Profession  
+               2     - Mercenary Profession  
+               4     - Tech Profession  
+  
+level       - People with this level and above can use this, must be set to 1-40. So if you set it to 5, people level 5 and up can use it while people   
+              below level 5 cannot use it. However now if you set it to -5 people level's 5 and below will only be able to use this.  
+adminLevel  - People with this admin level and above can use this, must be set for 1-4, So if you set it to 2, admins level 2 and up can use it,   
+              while people with level 3 and below cannot.  
+count       - Only works when spawnflags are set to 8192, the amount of credits the person must pay for the entity to fire its target.  
+message     - The message that people will see when they press 'use' on the button.  
+gravity     - Add this key with the number one after it and make the z-axis to something above the ground and the model will be pushable and pullable.  
+target      - What to fire at when used  
+model       - the md3 model to draw  
+modelScale  - how much to scale the model, 1-10 for larger model, 0-1 for smaller, ex .5 for half the size.  
+targetName  - make the trigger target this value for the entity to be used  
+
+Example code:
+
+/place misc_model_breakable 0 model,models/map_objects/factory/f_con1,spawnflags,8193,message,Pay Up Yo,count,20,target,spawn_desann,
+
+    This will make a button that charges 20 Credits to fire its target
+
+/place misc_model_breakable 0 model,models/map_objects/roof_top/mech1,angle,90,usescript,common/switch_on,spawnflags,65,parm1,7,parm2,2000,
+
+    This will spawn a movable model that moves up and down with a 2 second delay between movements.
+
 */
 
+const entityInfoData_t misc_model_breakable_spawnflags[] = {
+	{"1", "Makes the model solid. if maxs/mins are defined it will follow those"},
+	{"2", "Will cycle its animation"},
+	{"4", "Bounding Box will be there even when destroyed"},
+	{"8", "Doesn't display damage model when destroyed"},
+	{"16", "No smoke when used"},
+	{"32", "When used, will toggle to it's usemodel (model + \'_u1.md3\')... this does nothing if spawnflags 64 is not checked."},
+	{"64", "When used it will not break"},
+	{"128", "Player can use it will use button"},
+	{"256", "No Explosion"},
+	{"512", "Starts deactivated"},
+	{"1024", "??"},
+	{"2048", "??"},
+	{"4096", "??"},
+	{"8192", "Payable button, use count and message keys"},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_model_breakable_keys[] = {
+	{"model", "the .md3 model to draw"},
+	{"modelscale", "how much to scale the model, 1-10 for larger model, 0-1 for smaller, ex .5 for half the size"},
+	{"target", "What to fire at when used"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{"parm1", "the movement distance for a movable model to move to, if spawnflags 2 is set it loops its movement. If not it only moves when something targets the entities targetname this only works if you have the usescript key set to something like: \'usescript,common/switch_on\'"},
+	{"parm2", "the delay to wait in milliseconds before moving again when the movement reaches its closed position or opened position"},
+	{"useScript", "the script to use"},
+	{"profession", "Sets it so only a person with a certain profession can use a button. you can add these together: \'profession,3,\' = jedi and merc (-1: no profession, 1: jedi, 2: merc, 4: tech)"},
+	{"count", "Only works when spawnflags are set to 8192, the amount of credits the person must pay for the entity to fire its target"},
+	{"message", "The message that people will see when they press \'use\' on the button"},
+	{"level", "People with this level and above/below only. range of 1-40. Set to 5, people level 5 and up. Set to -5, people level 5 and below."},
+	{"adminLevel", "People with this admin level and above can use this same as \'level\' usage"},
+	{"", ""},
+	{"", ""},
+	{"", ""},
+	{"", ""},
+	{"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t misc_model_breakable_info = {
+	"This will spawn a model in game that can either have no purpose and sit there, or it can fire a target, or it can even accept money to fire at its target.",
+	misc_model_breakable_spawnflags,
+	misc_model_breakable_keys
+};
 void SP_misc_model_breakable( gentity_t *ent ) {
 	qboolean gravity;
 	int t;
@@ -796,6 +1019,27 @@ void SP_misc_model_breakable( gentity_t *ent ) {
 	trap_LinkEntity(ent);
 }
 
+/*QUAKED misc_slotmachine *(L)
+An in game slot machine, 1 entity thats all it takes. Accepts /pay command with numbers from 10 - 200 all numbers have to be by 10, ex /pay 50.
+Keys
+
+count - the starting credit the machine comes with, once the total credit hits 0 the machine will say its out of credits when used.
+
+Example code: /place misc_slotmachine 0 count,5000,
+*/
+const entityInfoData_t misc_slotmachine_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_slotmachine_keys[] = {
+	{"count", "the starting credit the machine comes with, once the total credit hits 0 the machine will say its out of credits when used."},
+	{NULL, NULL}
+};
+const entityInfo_t misc_slotmachine_info = {
+	"An in game slot machine, 1 entity thats all it takes. Accepts /pay command with numbers from 10 - 200 all numbers have to be by 10, ex /pay 50.",
+	misc_slotmachine_spawnflags,
+	misc_slotmachine_keys
+};
 void misc_slotmachine_use (gentity_t *ent, gentity_t *other, gentity_t *activator){
 	vec3_t dir;
 	int diff;
@@ -895,6 +1139,37 @@ void SP_misc_slotmachine(gentity_t *ent){
 	trap_LinkEntity(ent);
 }
 
+/*QUAKED misc_exploding_crate (1 0 0) (-16 -16 0) (16 16 16)
+
+Spawns a crate that when hit by an attack will explode. You can change its default model by the model key, although its hitbox is hard coded.
+Keys
+
+dmg           - sets the damage that the entity will give
+model         - model
+splashRadius  - sets the damage radius around the origin of the entity
+splashDamage  - sets the splash damage (if you are inside the splash radius you will receive this damage amount)
+
+Example code:
+
+/place misc_exploding_crate 0
+    will spawn an exploding crate that loads every time the entities are loaded for that map. After being destroyed, it doesn't respawn.
+*/
+const entityInfoData_t misc_exploding_crate_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_exploding_crate_keys[] = {
+	{"model", "model"},
+	{"dmg", "sets the damage that the entity will give"},
+	{"splashRadius", "sets the damage radius around the origin of the entity"},
+	{"splashDamage", "sets the splash damage (if you are inside the splash radius you will receive this damage amount)"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_exploding_crate_info = {
+	"Spawns a crate that when hit by an attack will explode. You can change its default model by the model key, although its hitbox is hard coded",
+	misc_exploding_crate_spawnflags,
+	misc_exploding_crate_keys
+};
 void SP_misc_exploding_crate (gentity_t *ent){
 	//ent->model = "models/map_objects/imperial/crate_xplode.md3";
 	G_SpawnString("model","map_objects/imperial/crate_xplode",&ent->model);
@@ -924,6 +1199,23 @@ ground and whatnot.
 loaded as a model in the renderer - does not take up precious
 bsp space!
 */
+
+const entityInfoData_t misc_model_static_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_model_static_keys[] = {
+	{"model", "arbitrary .md3 file to display"},
+	{"zoffset", "units to offset vertical culling position by, can be negative or positive. This does not affect the actual position of the model, only the culling position. Use it for models with stupid origins that go below the ground and whatnot."},
+	{"modelscale", "scale on all axis"},
+	{"modelscale_vec", "scale difference axis"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_model_static_info = {
+	"Unused in LMD. Loaded as a model in the renderer - does not take up precious bsp space!",
+	misc_model_static_spawnflags,
+	misc_model_static_keys
+};
 void SP_misc_model_static(gentity_t *ent)
 {
 	G_FreeEntity( ent );
@@ -932,6 +1224,20 @@ void SP_misc_model_static(gentity_t *ent)
 /*QUAKED misc_G2model (1 0 0) (-16 -16 -16) (16 16 16)
 "model"		arbitrary .glm file to display
 */
+
+const entityInfoData_t misc_G2model_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_G2model_keys[] = {
+	{"model", "arbitrary .glm file to display"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_G2model_info = {
+	"Display a .glm model file. Removed in Lugormod.",
+	misc_G2model_spawnflags,
+	misc_G2model_keys
+};
 void SP_misc_G2model( gentity_t *ent ) {
 #if 0
 	char name1[200] = "models/players/kyle/modelmp.glm";
@@ -1001,6 +1307,20 @@ void locateCamera( gentity_t *ent ) {
 The portal surface nearest this entity will show a view from the targeted misc_portal_camera, or a mirror view if untargeted.
 This must be within 64 world units of the surface!
 */
+
+const entityInfoData_t misc_portal_surface_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_portal_surface_keys[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t misc_portal_surface_info = {
+	"The portal surface nearest this entity will show a view from the targeted misc_portal_camera, or a mirror view if untargeted. This must be within 64 world units of the surface!",
+	misc_portal_surface_spawnflags,
+	misc_portal_surface_keys
+};
 void SP_misc_portal_surface(gentity_t *ent) {
 	VectorClear( ent->r.mins );
 	VectorClear( ent->r.maxs );
@@ -1021,6 +1341,22 @@ void SP_misc_portal_surface(gentity_t *ent) {
 The target for a misc_portal_director.  You can set either angles or target another entity to determine the direction of view.
 "roll" an angle modifier to orient the camera around the target vector;
 */
+
+const entityInfoData_t misc_portal_camera_spawnflags[] = {
+	{"slowrotate", "unknown"},
+	{"fastrotate", "unknown"},
+	{"noswing", "unknown"},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_portal_camera_keys[] = {
+	{"roll", "an angle modifier to orient the camera around the target vector"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_portal_camera_info = {
+	"The target for a misc_portal_director. You can set either angles or target another entity to determine the direction of view. Might be unusable in LMD.",
+	misc_portal_camera_spawnflags,
+	misc_portal_camera_keys
+};
 void SP_misc_portal_camera(gentity_t *ent) {
 	float	roll;
 
@@ -1038,6 +1374,15 @@ void SP_misc_portal_camera(gentity_t *ent) {
 /*QUAKED misc_bsp (1 0 0) (-16 -16 -16) (16 16 16)
 "bspmodel"		arbitrary .bsp file to display
 */
+const entityInfoData_t misc_bsp_keys[] = {
+	{"bspmodel", "arbitrary .bsp file to display"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_bsp_info = {
+	"put a map inside a map. the misc_bsp brush models start at the last brush model number of the original map. so if you expect to use *55 from one map, guess randomly or find the last brush model and do the math",
+	NULL,
+	misc_bsp_keys
+};
 //RoboPhred
 void G_SubBSP_SpawnEntitiesFromString(void);
 extern qboolean disablesenabled;
@@ -1142,6 +1487,28 @@ miscentDef - defines which client models spawn on the terrain (file is base/ext_
 densityMap - how dense the client models are packed
 
 */
+
+const entityInfoData_t terrain_spawnflags[] = {
+	{"NOVEHDMG", "don\'t damage vehicles upon impact with this terrain"},
+	{NULL, NULL}
+};
+const entityInfoData_t terrain_keys[] = {
+	{"numPatches", "integer number of patches to split the terrain brush into (default 200)"},
+	{"terxels", "integer number of terxels on a patch side (default 4) (2 <= count <= 8)"},
+	{"seed", "integer seed for random terrain generation (default 0)"},
+	{"textureScale", "float scale of texture (default 0.005)"},
+	{"heightmap", "name of heightmap data image to use, located in heightmaps/*.png. (must be PNG format)"},
+	{"terrainDef", "defines how the game textures the terrain (file is base/ext_data/rmg/*.terrain - default is grassyhills)"},
+	{"instanceDef", "defines which bsp instances appear"},
+	{"miscentDef", "defines which client models spawn on the terrain (file is base/ext_data/rmg/*.miscents)"},
+	{"densityMap", "how dense the client models are packed"},
+	{NULL, NULL}
+};
+const entityInfo_t terrain_info = {
+	"(untested) Terrain entity - It will stretch to the full height of the brush",
+	terrain_spawnflags,
+	terrain_keys
+};
 void AddSpawnField(char *field, char *value);
 #define MAX_INSTANCE_TYPES		16
 void SP_terrain(gentity_t *ent)
@@ -1339,6 +1706,15 @@ to the regular view position.
 
 "modelscale"			the scale at which to scale positions
 */
+const entityInfoData_t misc_skyportal_orient_keys[] = {
+	{"modelscale", "the scale at which to scale positions"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_skyportal_orient_info = {
+	"removed per RoboPhred. originally: point from which to orient the sky portal cam in relation to the regular view position",
+	NULL,
+	misc_skyportal_orient_keys
+};
 void SP_misc_skyportal_orient (gentity_t *ent)
 {
 	//RoboPhred: not anymore, we want to save
@@ -1358,6 +1734,23 @@ is in the same PVS as them (only once otherwise, but still once no matter
 where the client is). In other words, don't go overboard with it or everything
 will explode.
 */
+const entityInfoData_t misc_skyportal_keys[] = {
+	{"fov", "for the skybox default is 80"},
+	{"onlyfoghere", "if non-0 allows you to set a global fog, but will only use that fog within this sky portal."},
+	{NULL, NULL}
+};
+const entityInfo_t misc_skyportal_info = {
+	"Will take a snapshot of wherever you place one of these and put it in the sky. The snapshot is a whole 360 around the origin of this entity, place on on the map and look at the sky"
+	"\nNote that entities in the same PVS and visible (via point trace) from this"
+	"\nobject will be flagged as portal entities. This means they will be sent and"
+	"\nupdated from the server for every client every update regardless of where"
+	"\nthey are, and they will essentially be added to the scene twice if the client"
+	"\nis in the same PVS as them (only once otherwise, but still once no matter"
+	"\nwhere the client is). In other words, don't go overboard with it or everything will explode"
+	,
+	NULL,
+	misc_skyportal_keys
+};
 void SP_misc_skyportal (gentity_t *ent)
 {
 	char	*fov = NULL;
@@ -1402,6 +1795,22 @@ SABERATTACK = 15
 SABERDEFEND = 16
 SABERTHROW = 17
 */
+const entityInfoData_t misc_holocron_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_holocron_keys[] = {
+	{"count", "set to type of holocron (based on force power value)"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_holocron_info = {
+	"HEAL = 0, JUMP = 1, SPEED = 2, PUSH = 3, PULL = 4, TELEPATHY = 5"
+	"\nGRIP = 6, LIGHTNING = 7, RAGE = 8, PROTECT = 9, ABSORB = 10"
+	"\nTEAM HEAL = 11, TEAM FORCE = 12, DRAIN = 13, SEE = 14"
+	"\nSABERATTACK = 15, SABERDEFEND = 16, SABERTHROW = 17",
+	misc_holocron_spawnflags,
+	misc_holocron_keys
+};
 
 char *holocronTypeModels[] = {
 	"models/map_objects/mp/lt_heal.md3",//FP_HEAL,
@@ -1866,6 +2275,19 @@ void InitShooter( gentity_t *ent, int weapon ) {
 Fires at either the target or the current direction.
 "random" is the number of degrees of deviance from the taget. (1.0 default)
 */
+const entityInfoData_t shooter_blaster_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t shooter_blaster_keys[] = {
+	{"random", "the number of degrees of deviance from the taget. (1.0 default)"},
+	{NULL, NULL}
+};
+const entityInfo_t shooter_blaster_info = {
+	"Fires at either the target or the current direction",
+	shooter_blaster_spawnflags,
+	shooter_blaster_keys
+};
 void SP_shooter_blaster( gentity_t *ent ) {
 	InitShooter( ent, WP_BLASTER);
 }
@@ -2231,6 +2653,17 @@ Gives generic ammo when used
 "chargerate" - rechage 1 point every this many milliseconds (default 2000)
 "nodrain" - don't drain power from station if 1
 */
+const entityInfoData_t misc_ammo_floor_unit_keys[] = {
+	{"count", "max charge value (default 200)"},
+	{"chargerate", "recharge 1 point every this many milliseconds (default 2000)"},
+	{"nodrain", "don\'t drain power from station if 1"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_ammo_floor_unit_info = {
+	"Gives generic ammo when used",
+	NULL,
+	misc_ammo_floor_unit_keys
+};
 void SP_misc_ammo_floor_unit(gentity_t *ent)
 {
 	vec3_t dest;
@@ -2325,6 +2758,17 @@ Gives shield energy when used.
 "chargerate" - rechage 1 point every this many milliseconds (default 3000)
 "nodrain" - don't drain power from me
 */
+const entityInfoData_t misc_shield_floor_unit_keys[] = {
+	{"count", "max charge value (default 50)"},
+	{"chargerate", "rechage 1 point every this many milliseconds (default 3000)"},
+	{"nodrain", "don\'t drain power from me"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_shield_floor_unit_info = {
+	"Gives shield energy when used.",
+	NULL,
+	misc_shield_floor_unit_keys
+};
 void SP_misc_shield_floor_unit( gentity_t *ent )
 {
 	/* Lugormod no, why ??
@@ -2422,6 +2866,15 @@ Gives shield energy when used.
 "count" - the amount of ammo given when used (default 200)
 */
 //------------------------------------------------------------
+const entityInfoData_t misc_model_shield_power_converter_keys[] = {
+	{"count", "the amount of shield given when used (default unknown)"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_model_shield_power_converter_info = {
+	"Gives shield energy when used",
+	NULL,
+	misc_model_shield_power_converter_keys
+};
 void SP_misc_model_shield_power_converter( gentity_t *ent )
 {
 	if (!ent->health)
@@ -2588,6 +3041,16 @@ Gives ammo energy when used.
 "nodrain" - don't drain power from me
 */
 //------------------------------------------------------------
+const entityInfoData_t misc_model_ammo_power_converter_keys[] = {
+	{"count", "the amount of ammo given when used (default 200)"},
+	{"nodrain", "don\'t drain power from me"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_model_ammo_power_converter_info = {
+	"Gives ammo energy when used",
+	NULL,
+	misc_model_ammo_power_converter_keys
+};
 void SP_misc_model_ammo_power_converter( gentity_t *ent )
 {
 	if (!ent->health)
@@ -2708,6 +3171,15 @@ Gives ammo energy when used.
 "count" - the amount of ammo given when used (default 200)
 */
 //------------------------------------------------------------
+const entityInfoData_t misc_model_health_power_converter_keys[] = {
+	{"count", "the amount of health given when used (default 200)"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_model_health_power_converter_info = {
+	"Gives health energy when used",
+	NULL,
+	misc_model_health_power_converter_keys
+};
 void SP_misc_model_health_power_converter( gentity_t *ent )
 {
 	if (!ent->health)
@@ -2989,6 +3461,27 @@ DAMAGE - does radius damage around effect every "delay" milliseonds
 "splashDamage" - only works when damage is checked ( default 5 )
 "soundset"	- bmodel set to use, plays start sound when toggled on, loop sound while on ( doesn't play on a oneshot), and a stop sound when turned off
 */
+const entityInfoData_t fx_runner_spawnflags[] = {
+	{"1", "effect will start in the off state"},
+	{"2", "effect fires once and that's when it\'s used"},
+	{"4", "does radius damage around effect"},
+	{NULL, NULL}
+};
+const entityInfoData_t fx_runner_keys[] = {
+	{"fxFile", "name of the effect file to play"},
+	{"target", "direction to aim the effect in (default to up)"},
+	{"target2", "uses its target2 when the fx gets triggered"},
+	{"splashRadius", "the radius around the origin that the fx is located (default 16)"},
+	{"splashDamage", "the damage to give everything in the splash radius (default is 5)"},
+	{"soundSet", "plays start sound when toggled on, loop sound while on, and a stop sound when turned off"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t fx_runner_info = {
+	"Runs the specified effect. If used it will toggle on/off",
+	fx_runner_spawnflags,
+	fx_runner_keys
+};
 #define FX_RUNNER_RESERVED 0x800000
 #define FX_ENT_RADIUS 32
 extern int	BMS_START;
@@ -3185,27 +3678,6 @@ void fx_runner_link( gentity_t *ent )
 }
 
 //----------------------------------------------------------
-const entityInfoData_t fx_runner_spawnflags[] = {
-	{"1", "effect will start in the off state"},
-	{"2", "effect fires once and that's when it\'s used"},
-	{"4", "does radius damage around effect"},
-	{NULL, NULL}
-};
-const entityInfoData_t fx_runner_keys[] = {
-	{"fxFile", "name of the effect file to play"},
-	{"target", "direction to aim the effect in (default to up)"},
-	{"target2", "uses its target2 when the fx gets triggered"},
-	{"splashRadius", "the radius around the origin that the fx is located (default 16)"},
-	{"splashDamage", "the damage to give everything in the splash radius (default is 5)"},
-	{"soundSet", "plays start sound when toggled on, loop sound while on, and a stop sound when turned off"},
-	{"targetname", "make the trigger target this value for the entity to be used"},
-	{NULL, NULL}
-};
-const entityInfo_t fx_runner_info = {
-	"Runs the specified effect. If used it will toggle on/off",
-	fx_runner_spawnflags,
-	fx_runner_keys
-};
 void SP_fx_runner( gentity_t *ent )
 {
 	char *fxFile;
@@ -3354,6 +3826,28 @@ void SP_CreateWind( gentity_t *ent )
 	G_EffectIndex(va("*constantwind %s", vtos(dir)));
 }
 
+/*QUAKED target_screenshake
+anyone near this entity has their screen shake around, in Lugormod T2 it is bugged and always does global
+
+"intensity"     intensity of the shake
+"duration"      how long the shake lasts
+"globalshake"   if set to anything > 0, then everyone in the server will have this effect them.
+                (default 0)
+"targetname"    make the trigger target this value for the entity to be used
+*/
+//----------------------------------------------------------
+const entityInfoData_t target_screenshake_keys[] = {
+	{"intensity", "intensity of the shake"},
+	{"duration", "how long the shake lasts"},
+	{"globalshake", "if set to anything greater than 0, everyone in the server will experience the shake (default 0)"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_screenshake_info = {
+	"anyone near this entity has their screen shake around, in Lugormod T2 it is bugged and always does global",
+	NULL,
+	target_screenshake_keys
+};
 void Use_Target_Screenshake( gentity_t *ent, gentity_t *other, gentity_t *activator )
 {
 	qboolean bGlobal = qfalse;
@@ -3365,6 +3859,7 @@ void Use_Target_Screenshake( gentity_t *ent, gentity_t *other, gentity_t *activa
 
 	G_ScreenShake(ent->s.origin, NULL, ent->speed, ent->genericValue5, bGlobal);
 }
+
 
 void SP_target_screenshake(gentity_t *ent)
 {
@@ -3378,6 +3873,11 @@ void SP_target_screenshake(gentity_t *ent)
 	ent->use = Use_Target_Screenshake;
 }
 
+/*QUAKED target_escapetrig
+SP only per phred
+
+*/
+//----------------------------------------------------------
 void LogExit( const char *string );
 qboolean gEscaping = qfalse;
 int gEscapeTime = 0;
@@ -3441,6 +3941,16 @@ NOTE: place these half-way in the door to make it flush with the door's surface.
 "target"	thing to use when destoryed (not doors - it automatically unlocks the door it was angled at)
 "health"	default is 10
 */
+const entityInfoData_t misc_maglock_keys[] = {
+	{"target", "thing to use when destoryed (not doors - it automatically unlocks the door it was angled at)"},
+	{"health", "default is 10"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_maglock_info = {
+	"Place facing a door (using the angle, not a targetname) and it will lock that door. Can only be destroyed by lightsaber and will automatically unlock the door it\'s attached to. NOTE: place these half-way in the door to make it flush with the door surface",
+	NULL,
+	misc_maglock_keys
+};
 void maglock_die(gentity_t *self, gentity_t *inflictor, gentity_t *attacker, int damage, int mod)
 {
 	//unlock our door if we're the last lock pointed at the door
@@ -4100,6 +4610,30 @@ ownername	- the owner of this tag
 target		- use to point the tag at something for angles
 */
 
+const entityInfoData_t ref_tag_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t ref_tag_keys[] = {
+	{"targetname", "the name of this tag"},
+	{"ownername", "the owner of this tag"},
+	{"target", "use to point the tag at something for angles"},
+	{NULL, NULL}
+};
+const entityInfo_t ref_tag_info = {
+	"Reference tags which can be positioned throughout the level. These tags can later be refered to by the scripting system so that their origins and angles can be referred to"
+	"\nIf you set angles on the tag, these will be retained"
+	"\nIf you target a ref_tag at an entity, that will set the ref_tag\'s angles toward that entity."
+	"\nIf you set the ref_tag's ownername to the ownername of an entity, it makes that entity is the owner of the ref_tag. This means"
+    "that the owner, and only the owner, may refer to that tag"
+	"\nTags may not have the same name as another tag with the same owner. However, tags with different owners may have the same"
+	"name as one another.  In this way, scripts can generically"
+	"refer to tags by name, and their owners will automatically"
+	"specifiy which tag is being referred to."
+	,
+	ref_tag_spawnflags,
+	ref_tag_keys
+};
 void ref_link ( gentity_t *ent )
 {
 	reference_tag_t	*tag;
@@ -4179,6 +4713,28 @@ WP_TIE_FIGHTER
 WP_RAPID_FIRE_CONC
 WP_BLASTER_PISTOL
 */
+
+const entityInfoData_t misc_weapon_shooter_spawnflags[] = {
+	{"1", "fire the alt-fire of the chosen weapon"},
+	{"2", "keep firing until used again (fires at intervals of \'wait\')"},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_weapon_shooter_keys[] = {
+	{"wait", "debounce time between refires (defaults to 500)"},
+	{"target", "what to aim at (will update aim every frame if it\'s a moving target. if you target a door it will always shoot the door, even if the door moves)"},
+	{"weapon", "specify the weapon to use. Some of these are unstable, or will shut down the server when used, careful with them (default is WP_BLASTER)"},
+	{"targetname", "make the trigger target this value for the entity to be used."},
+	{"", ""},
+	{"", ""},
+	{"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t misc_weapon_shooter_info = {
+	"fires weapon projectiles when used",
+	misc_weapon_shooter_spawnflags,
+	misc_weapon_shooter_keys
+};
+
 //kind of hacky, but we have to do this with no dynamic allocation
 /*
 #define MAX_SHOOTERS		16
@@ -4306,27 +4862,6 @@ void misc_weapon_shooter_aim( gentity_t *self )
 extern stringID_table_t WPTable[];
 #include "../namespace_end.h"
 
-const entityInfoData_t misc_weapon_shooter_spawnflags[] = {
-	{"1", "fire the alt-fire of the chosen weapon"},
-	{"2", "keep firing until used again (fires at intervals of \'wait\')"},
-	{NULL, NULL}
-};
-const entityInfoData_t misc_weapon_shooter_keys[] = {
-	{"wait", "debounce time between refires (defaults to 500)"},
-	{"target", "what to aim at (will update aim every frame if it\'s a moving target. if you target a door it will always shoot the door, even if the door moves)"},
-	{"weapon", "specify the weapon to use. Some of these are unstable, or will shut down the server when used, careful with them (default is WP_BLASTER)"},
-	{"targetname", "make the trigger target this value for the entity to be used."},
-	{"", ""},
-	{"", ""},
-	{"", ""},
-	{NULL, NULL}
-};
-const entityInfo_t misc_weapon_shooter_info = {
-	"fires weapon projectiles when used",
-	misc_weapon_shooter_spawnflags,
-	misc_weapon_shooter_keys
-};
-
 void SP_misc_weapon_shooter( gentity_t *self )
 {
 	char *s = NULL;
@@ -4375,6 +4910,20 @@ void SP_misc_weapon_shooter( gentity_t *self )
 /*QUAKED misc_weather_zone (0 .5 .8) ?
 Determines a region to check for weather contents - will significantly reduce load time
 */
+
+const entityInfoData_t misc_weather_zone_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_weather_zone_keys[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t misc_weather_zone_info = {
+	"(removed) Determines a region to check for weather contents - will significantly reduce load time",
+	misc_weather_zone_spawnflags,
+	misc_weather_zone_keys
+};
 void SP_misc_weather_zone( gentity_t *ent )
 {
 	G_FreeEntity(ent);

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -3237,11 +3237,14 @@ This world effect will spawn space dust globally into the level.
 "count" the number of snow particles (default of 1000)
 */
 //----------------------------------------------------------
-
+const entityInfoData_t fx_spacedust_keys[] = {
+	{"count", "the number of space dust particles (default of 1000)"},
+	{NULL, NULL}
+};
 const entityInfo_t fx_spacedust_info = {
 	"This world effect will spawn space dust globally into the level",
 	NULL,
-	{"count", "the number of space dust particles (default of 1000)"}
+	fx_spacedust_keys
 };
 void SP_CreateSpaceDust( gentity_t *ent )
 {
@@ -3255,10 +3258,14 @@ This world effect will spawn snow globally into the level.
 "count" the number of snow particles (default of 1000)
 */
 //----------------------------------------------------------
+const entityInfoData_t fx_snow_keys[] = {
+	{"count", "the number of snow particles (default of 1000)"},
+	{NULL, NULL}
+};
 const entityInfo_t fx_snow_info = {
 	"This world effect will spawn snow globally into the level",
 	NULL,
-	{"count", "the number of snow particles (default of 1000)"}
+	fx_snow_keys
 };
 void SP_CreateSnow( gentity_t *ent )
 {
@@ -3273,10 +3280,14 @@ This world effect will spawn rain globally into the level.
 "count" the number of rain particles (default of 500)
 */
 //----------------------------------------------------------
+const entityInfoData_t fx_rain_keys[] = {
+	{"count", "the number of rain particles (default of 500)"},
+	{NULL, NULL}
+};
 const entityInfo_t fx_rain_info = {
 	"This world effect will spawn rain globally into the level",
 	NULL,
-	{"count", "the number of rain particles (default of 500)"}
+	fx_rain_keys
 };
 void SP_CreateRain( gentity_t *ent )
 {
@@ -3294,10 +3305,18 @@ void SP_CreateRain( gentity_t *ent )
 	G_EffectIndex(va("*rain init %i", ent->count));
 }
 
+const entityInfoData_t fx_wind_spawnflags[] = {
+	{"2", "make a camera shake effect"},
+	{NULL, NULL}
+};
+const entityInfoData_t fx_wind_keys[] = {
+	{"speed", "speed at which wind is blowing (default 100)"},
+	{NULL, NULL}
+};
 const entityInfo_t fx_wind_info = {
 	"This world effect will spawn wind globally into the level",
-	{"2", "make a camera shake effect"},
-	{"speed", "speed at which wind is blowing (default 100)"}
+	fx_wind_spawnflags,
+	fx_wind_keys
 };
 void SP_CreateWind( gentity_t *ent )
 {

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -3185,6 +3185,27 @@ void fx_runner_link( gentity_t *ent )
 }
 
 //----------------------------------------------------------
+const entityInfoData_t fx_runner_spawnflags[] = {
+	{"1", "effect will start in the off state"},
+	{"2", "effect fires once and that's when it\'s used"},
+	{"4", "does radius damage around effect"},
+	{NULL, NULL}
+};
+const entityInfoData_t fx_runner_keys[] = {
+	{"fxFile", "name of the effect file to play"},
+	{"target", "direction to aim the effect in (default to up)"},
+	{"target2", "uses its target2 when the fx gets triggered"},
+	{"splashRadius", "the radius around the origin that the fx is located (default 16)"},
+	{"splashDamage", "the damage to give everything in the splash radius (default is 5)"},
+	{"soundSet", "plays start sound when toggled on, loop sound while on, and a stop sound when turned off"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t fx_runner_info = {
+	"Runs the specified effect. If used it will toggle on/off",
+	fx_runner_spawnflags,
+	fx_runner_keys
+};
 void SP_fx_runner( gentity_t *ent )
 {
 	char *fxFile;
@@ -3641,6 +3662,21 @@ targetname	- if specified, will only spawn when used
 interval	- spawn every so often (milliseconds)
 fudgefactor	- milliseconds between 0 and this number randomly added to interval
 */
+const entityInfoData_t misc_faller_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t misc_faller_keys[] = {
+	{"targetname", "if specified, will only spawn when used"},
+	{"interval", "spawn every so often (milliseconds)"},
+	{"fudgefactor", "milliseconds between 0 and this number randomly added to interval"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_faller_info = {
+	"Raining Stormtroopers?? spawned every interval+random fudgefactor, or if specified, when used. This takes up a lot of temp ents if you let them rain freely.",
+	misc_faller_spawnflags,
+	misc_faller_keys
+};
+
 void SP_misc_faller(gentity_t *ent)
 {
 	G_ModelIndex("models/players/stormtrooper/model.glm");
@@ -4269,6 +4305,27 @@ void misc_weapon_shooter_aim( gentity_t *self )
 #include "../namespace_begin.h"
 extern stringID_table_t WPTable[];
 #include "../namespace_end.h"
+
+const entityInfoData_t misc_weapon_shooter_spawnflags[] = {
+	{"1", "fire the alt-fire of the chosen weapon"},
+	{"2", "keep firing until used again (fires at intervals of \'wait\')"},
+	{NULL, NULL}
+};
+const entityInfoData_t misc_weapon_shooter_keys[] = {
+	{"wait", "debounce time between refires (defaults to 500)"},
+	{"target", "what to aim at (will update aim every frame if it\'s a moving target. if you target a door it will always shoot the door, even if the door moves)"},
+	{"weapon", "specify the weapon to use. Some of these are unstable, or will shut down the server when used, careful with them (default is WP_BLASTER)"},
+	{"targetname", "make the trigger target this value for the entity to be used."},
+	{"", ""},
+	{"", ""},
+	{"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t misc_weapon_shooter_info = {
+	"fires weapon projectiles when used",
+	misc_weapon_shooter_spawnflags,
+	misc_weapon_shooter_keys
+};
 
 void SP_misc_weapon_shooter( gentity_t *self )
 {

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -50,7 +50,7 @@ const entityInfoData_t SP_info_camp_spawnflags[] = {
 	{NULL, NULL}
 };
 const entityInfoData_t SP_info_camp_keys[] = {
-	{"targetname", "make the trigger target this value for the entity to be used"},
+	 "make the trigger target this value for the entity to be used"},
 	{NULL, NULL}
 };
 const entityInfo_t SP_info_camp_info = {

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -50,7 +50,7 @@ const entityInfoData_t SP_info_camp_spawnflags[] = {
 	{NULL, NULL}
 };
 const entityInfoData_t SP_info_camp_keys[] = {
-	 "make the trigger target this value for the entity to be used"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
 	{NULL, NULL}
 };
 const entityInfo_t SP_info_camp_info = {

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -1645,6 +1645,40 @@ INACTIVE	must be used by a target_activate before it can be used
 //RoboPhred
 qboolean G_FindEntityTeam(gentity_t *e);
 
+const entityInfoData_t func_door_spawnflags[] = {
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_door_keys[] = {
+  {"target", "Door fires this when it starts moving from it\'s closed position to it\'s open position"},
+  {"opentarget", "Door fires this after reaching it\'s \'open\' position"},
+  {"target2", "Door fires this when it starts moving from it\'s open position to it\'s closed position"},
+  {"closetarget", "Door fires this after reaching it\'s \'closed\' position"},
+  {"model2" ".md3 model to also draw"},
+  {"angle", "determines the opening direction"},
+  {"targetname", "if set, no touch field will be spawned and a remote button or trigger field activates the door."},
+  {"speed", "movement speed (100 default)"},
+  {"wait", "wait before returning (3 default, -1 = never return)"},
+  {"lip", "lip remaining at the end of move (8 default)"},
+  {"dmg", "damage to inflict when blocked (2 default, set to negative for no damage)"},
+  {"color", "constantLight color"},
+  {"light", "constantLight color"},
+  {"health", "if set, the door must be shot open"},
+  {"linear", "set to 1 and it will move linearly rather than with accelleration (default is 0)"},
+  {"teamallow", "even if locked, this team can always open and close it just by walking up to it"},
+  {"", "0 - none (locked to everyone)"},
+  {"", "1 - red"},
+  {"", "2 = blue"},
+  {"vehopen", "if non-0 vehicles/players riding vehicles can open"},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_door_info = {
+  "",
+  func_door_spawnflags,
+  func_door_keys
+};
+
 void SP_func_door (gentity_t *ent) 
 {
 	//Lugormod

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -2625,6 +2625,38 @@ Applicable only during Siege gametype:
 teamnodmg - if 1, team 1 can't damage this. If 2, team 2 can't damage this.
 
 */
+const entityInfoData_t func_rotating_spawnflags[] = {
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_rotating_keys[] = {
+  {"model", "The bmodel to draw"},
+  {"model2", ".md3 model to also draw"},
+  {"model2scale", "percent of normal scale (on all x y and z axii) to scale the model2 if there is one. 100 is normal scale, min is 1 (100 times smaller than normal), max is 1000 (ten times normal)"},
+  {"speed", "determines how fast it moves (100 default)"},
+  {"dmg", "damage to inflict when blocked (2 default)"},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {"spinangles", "instead of using \'speed\' you can use this to set rotation on all 3 axes (pitch yaw and roll)"},
+  {"health", "default is 0. if health is set, the follow key/values are available:"},
+  {"", "\'numchunks\' multiplies the number of chunks spawned. (1 default, .5 is half as many chunks, 2 is twice as many chunks)"},
+  {"", "\'chunksize\' scales up/down the chunk size (1 default)"},
+  {"", "\'showhealth\' if non-0, will display the health bar on the hud when crosshair is over this entity in seige"},
+  {"", "\'teamowner\' in seige this will specify which team this thing is owned by. Crosshair changes green/red"},
+  {"", "\'splashDamage\' damage to do"},
+  {"", "\'splashRadius\' radius for above damage"},
+  {"team", "if set, only this team can trip this trigger. (0 - any, 1 - red, 2 - blue)"},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+
+  {NULL, NULL}
+};
+const entityInfo_t func_rotating_info = {
+  "You need to have an origin brush as part of this entity. The center of that brush will be the point around which it is rotated. It will rotate around the Z axis by default. You can check either the X_AXIS or Y_AXIS box to change that.",
+  func_rotating_spawnflags,
+  func_rotating_keys
+};
+
 void SP_func_breakable( gentity_t *self );
 void SP_func_rotating (gentity_t *ent) {
 	vec3_t spinangles;

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -2821,6 +2821,37 @@ Normally bobs on the Z axis
 "color"		constantLight color
 "light"		constantLight radius
 */
+
+const entityInfoData_t func_bobbing_spawnflags[] = {
+  {"1", "?"},
+  {"2", "?"},
+  {"4", "Move on X-Axis"},
+  {"8", "Move on Y-Axis"},
+  {"16", "Make it do damage when it hits any entity"},
+//  {"32", "Player can use it with the use button"},
+  {"64", "Player can use it with the use button"},
+  {"128", "must be used by a target_activate before it can be used"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_bobbing_keys[] = {
+  {"model", "The bmodel to use"},
+  {"model2","A .md3 model to also draw"},
+  {"model2scale","Precent of normal scale (on all x y z axii) to scale the model2"},
+  {"speed", "seconds to complete a bob cycle (4 default)"},
+  {"phase", "damage to inflict when blocked (2 default)"},
+  {"dmg", "how much damage to do when it crushes (use with spawnflags )"},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_bobbing_info = {
+  "Normally bobs on the z-axis",
+  func_bobbing_spawnflags,
+  func_bobbing_keys
+};
+
 void SP_func_bobbing (gentity_t *ent) {
 	float		height;
 	float		phase;

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -2341,6 +2341,29 @@ entities and damage them on contact as well.
 "color"		constantLight color
 "light"		constantLight radius
 */
+
+const entityInfoData_t func_train_spawnflags[] = {
+  {"1", "Start on"},
+  {"2", "?"},
+  {"4", "?"},
+  {"8", "?"},
+  {"16", "Damages anything in it\'s path"},
+  {"32", "?"},
+  {"64", "Can be used"},
+  {"128", "Starts deactivated"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_train_keys[] = {
+  {NULL, NULL}
+};
+
+const entityInfo_t func_train_info = {
+  "A train is a mover that moves between path_corner target points.",
+  func_train_spawnflags,
+  func_train_keys
+};
+
 void SP_func_train (gentity_t *self) {
 
 	//RoboPhred

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -1841,6 +1841,17 @@ void SP_func_door (gentity_t *ent)
 	}
 }
 
+const entityInfoData_t target_fixdoor_keys[] = {
+	{"target", "targetname of the func_door to fix"},
+	{NULL, NULL}
+};
+
+const entityInfo_t target_fixdoor_info = {
+	"Spawns a trigger_door for all func_doors with the specified targetname.",
+	target_fixdoor_keys,
+	NULL
+};
+
 void fixdoor(gentity_t *self){
 	//void fixdoor ( gentity_t *self, gentity_t *other, gentity_t *activator ){
 	if (!self->target) {

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -2317,6 +2317,24 @@ Target: next path corner and other targets to fire
 "speed" speed to move to the next corner
 "wait" seconds to wait before behining move to next corner
 */
+const entityInfoData_t path_corner_spawnflags[] = {
+  {NULL, NULL}
+};
+
+const entityInfoData_t path_corner_keys[] = {
+  {"target", "the next path_corner to go to (required) and other targets to fire"},
+  {"targetname", "make the previus path_corner target this, if it is the first path_corner the func_train needs to target this. If it is the first path corner, the last path_corner needs to also target this"},
+  {"speed", "speed to move to the next corner"},
+  {"wait", "seconds to wait before begining move to the next corner"},
+  {NULL, NULL}
+};
+
+const entityInfo_t path_corner_info = {
+  "func_train path corners. These are the waypoints the train travels to.",
+  path_corner_spawnflags,
+  path_corner_keys
+};
+
 void SP_path_corner( gentity_t *self ) {
 	if ( !self->targetname ) {
 		G_Printf ("path_corner with no targetname at %s\n", vtos(self->s.origin));

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -3473,6 +3473,52 @@ Applicable only during Siege gametype:
 teamnodmg - if 1, team 1 can't damage this. If 2, team 2 can't damage this.
 
 */
+
+const entityInfoData_t func_breakable_spawnflags[] = {
+  {"1", "can only be broken by being used"},
+  {"2", "does damage on impact"},
+  {"4", "won\'t reverse movement when hit an obstacle"},
+  {"8", "can be broken by impact damage, like glass"},
+  {"16", "only takes damage from sabers"},
+  {"32", "only takes damage by a heavy weapon, like an emplaced gun or AT-ST gun."},
+  {"64", "Using it doesn't make it break, still can be destroyed by damage"},
+  {"128", "Player can use it with the use button"},
+  {"256", "Does not play an explosion effect, though will still create chunks if specified"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_breakable_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"model2", ".md3 to also draw"},
+  {"model2scale", ""},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {"target", "all entities with a matching targetname will be used when this is destoryed"},
+  {"targetname", "entities with matching target will fire it"},
+  {"paintaget", "target to fire when hit (but not destroyed)"},
+  {"wait", "how long minimum to wait between firing paintarget each time hit"},
+  {"delay", "When killed or used, how long (in seconds) to wait before blowing up (none by default)"},
+  {"health", "default is 10"},
+  {"numchunks", "Multiplies the number of chunks spawned.  Chunk code tries to pick a good volume of chunks, but you can alter this to scale the number of spawned chunks. (default 1)  (.5) is half as many chunks, (2) is twice as many chunks"},
+  {"chunksize", "scales up/down the chunk size by this number (default is 1)"},
+  {"playfx", "path of effect to play on death"},
+  {"showhealth", "if non-0, will display the health bar on the hud when the crosshair is over this ent (in siege)"},
+  {"teamowner", "in siege this will specify which team this thing is \'owned\' by. To that team the crosshair will be green, the other red."},
+  {"splashDamage", "damage to do (default none)"},
+  {"splashRadius", "radius for damage"},
+  {"team", "If set, only this team can trip this trigger. 0 - any, 1 - red, 2 - blue"},
+  {"material", "default is 0. 17 choices available (0-16)"},
+  {"teamnodmg", "Applicable only during siege gametype. If 1, team 1 can\'t damage this. If 2, team 2 can\'t damage this."},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_breakable_info = {
+  "When destroyed, fires it's trigger and chunks and plays sound \'noise\' or sound for type if no noise specified",
+  func_breakable_spawnflags,
+  func_breakable_keys
+};
+
+
 void SP_func_breakable( gentity_t *self ) 
 {
 	int t;

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -2373,6 +2373,35 @@ A bmodel that just sits there, doing nothing.  Can be used for conditional walls
 "linear" set to 1 and it will move linearly rather than with acceleration (default is 0)
 */
 
+const entityInfoData_t func_static_spawnflags[] = {
+  {"1", "Will be used when you Force-Push it"},
+  {"2", "Will be used when you force-Pull it"},
+  {"4", "Toggle the shader anim frame between 1 and 2 when used"},
+  {"8", "Make it do damage when it's blocked"},
+  {"16", "Make it do damage when it hits any entity"},
+//  {"32", "Player can use it with the use button"},
+  {"64", "Player can use it with the use button"},
+  {"128", "must be used by a target_activate before it can be used"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_static_keys[] = {
+  {"model", "The bmodel to use"},
+  {"model2","A .md3 model to also draw"},
+  {"model2scale","Precent of normal scale (on all x y z axii) to scale the model2"},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {"dmg", "how much damage to do when it crushes (use with spawnflags )"},
+  {"linear", "set to 1 and it will move linearly rather than with acceleration"},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_static_info = {
+  "A bmodel that just sits there, does nothing. Can be used for conditional walls and models. On some levels like t2_rogue it can be used with a script to move.",
+  func_static_spawnflags,
+  func_static_keys
+};
+
 void SP_func_static( gentity_t *ent ) 
 {
 

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -1663,7 +1663,7 @@ const entityInfoData_t func_door_keys[] = {
   {"opentarget", "Door fires this after reaching it\'s \'open\' position"},
   {"target2", "Door fires this when it starts moving from it\'s open position to it\'s closed position"},
   {"closetarget", "Door fires this after reaching it\'s \'closed\' position"},
-  {"model2" ".md3 model to also draw"},
+  {"model2", ".md3 model to also draw"},
   {"angle", "determines the opening direction"},
   {"targetname", "if set, no touch field will be spawned and a remote button or trigger field activates the door."},
   {"speed", "movement speed (100 default)"},

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -4001,8 +4001,8 @@ const entityInfoData_t func_usable_keys[] = {
 
 const entityInfo_t func_usable_info = {
   "A bmodel that just sits there, doing nothing. Can be used for conditional walls and models. Disappears when used and reappears when used again.",
-  placeholder_spawnflags,
-  placeholder_keys
+  func_usable_spawnflags,
+  func_usable_keys
 };
 
 //Lugormod

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -4334,6 +4334,32 @@ void rail_mover_init (gentity_t *ent) {
 }
 
 
+const entityInfoData_t rail_mover_spawnflags[] = {
+  {"1", ""},
+  {"2", ""},
+  {"4", ""},
+  {"8", ""},
+  {"16", ""},
+  {"32", ""},
+  {"64", ""},
+  {"128", "Starts deactivated, is invisible until used"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t rail_mover_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"model2", ".md3 to also draw"},
+  {"model2scale", ""},
+  {"target", "target a rail_track or rail_lane or something"},
+  {"targetname", "use this to activate or deactivate the rail_mover ent"},
+  {NULL, NULL}
+};
+
+const entityInfo_t rail_mover_info = {
+  "A bmodel that\'s supposed to behave like the background skyscrapers in t1_rail. The entity that is drawn as a skyscraper passing y.",
+  rail_mover_spawnflags,
+  rail_mover_keys
+};
 void SP_rail_mover ( gentity_t *ent ) {
 	trap_SetBrushModel( ent, ent->model );
 	ent->reached = 0;
@@ -4544,6 +4570,32 @@ void rail_lane_use (gentity_t *self, gentity_t *other, gentity_t *activator) {
 	other->flags |= FL_INACTIVE;
 	t->nextTrain = other;
 }
+
+
+const entityInfoData_t rail_track_spawnflags[] = {
+  {"1", "Starts deactivated"},
+  {"2", ""},
+  {"4", ""},
+  {"8", ""},
+  {"16", ""},
+  {"32", ""},
+  {"64", ""},
+  {"128", ""},
+  {NULL, NULL}
+};
+
+const entityInfoData_t rail_track_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"target", "the next something"},
+  {"targetname", "the targetname for the track"},
+  {NULL, NULL}
+};
+
+const entityInfo_t rail_track_info = {
+  "Looks to be the physical track model to draw for a rail_mover. Can be passed through, is not physical.",
+  rail_track_spawnflags,
+  rail_track_keys
+};
 
 void SP_rail_track ( gentity_t *ent ) {
 	ent->s.eFlags |= EF_NODRAW;

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -6,30 +6,6 @@
 #include "Lmd_EntityCore.h"
 #include "Lmd_Entities_Public.h"
 
-
-const entityInfoData_t placeholder_spawnflags[] = {
-  {"1", ""},
-  {"2", ""},
-  {"4", ""},
-  {"8", ""},
-  {"16", ""},
-  {"32", ""},
-  {"64", ""},
-  {"128", ""},
-  {NULL, NULL}
-};
-
-const entityInfoData_t placeholder_keys[] = {
-  {"", ""},
-  {NULL, NULL}
-};
-
-const entityInfo_t placeholder_info = {
-  "",
-  placeholder_spawnflags,
-  placeholder_keys
-};
-
 /*
 ===============================================================================
 
@@ -4335,13 +4311,6 @@ void rail_mover_init (gentity_t *ent) {
 
 
 const entityInfoData_t rail_mover_spawnflags[] = {
-  {"1", ""},
-  {"2", ""},
-  {"4", ""},
-  {"8", ""},
-  {"16", ""},
-  {"32", ""},
-  {"64", ""},
   {"128", "Starts deactivated, is invisible until used"},
   {NULL, NULL}
 };
@@ -4611,6 +4580,24 @@ void SP_rail_track ( gentity_t *ent ) {
 	ent->think = rail_track_init;
 	ent->nextthink = level.time + 100;
 }
+
+const entityInfoData_t rail_lane_spawnflags[] = {
+  {"1", "Starts deactivated"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t rail_lane_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"target", "the next something"},
+  {"targetname", "the targetname for the track"},
+  {NULL, NULL}
+};
+
+const entityInfo_t rail_lane_info = {
+  "A bmodel entity that's used in t1_rail to spawn the rail_mover entities. Looks to use a bmodel but not render it.",
+  rail_lane_spawnflags,
+  rail_lane_keys
+};
 
 void SP_rail_lane ( gentity_t *ent ){
 	ent->s.eFlags |= EF_NODRAW;

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -2355,6 +2355,14 @@ const entityInfoData_t func_train_spawnflags[] = {
 };
 
 const entityInfoData_t func_train_keys[] = {
+  {"model", "The bmodel to draw"},
+  {"model2", ".md3 model to also draw"},
+  {"model2scale", "Scale the model2"},
+  {"speed", "default 100"},
+  {"dmg", "default 2"},
+  {"target", "next path corner (required)"},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
   {NULL, NULL}
 };
 

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -5,6 +5,31 @@
 
 #include "Lmd_EntityCore.h"
 #include "Lmd_Entities_Public.h"
+
+
+const entityInfoData_t placeholder_spawnflags[] = {
+  {"1", ""},
+  {"2", ""},
+  {"4", ""},
+  {"8", ""},
+  {"16", ""},
+  {"32", ""},
+  {"64", ""},
+  {"128", ""},
+  {NULL, NULL}
+};
+
+const entityInfoData_t placeholder_keys[] = {
+  {"", ""},
+  {NULL, NULL}
+};
+
+const entityInfo_t placeholder_info = {
+  "",
+  placeholder_spawnflags,
+  placeholder_keys
+};
+
 /*
 ===============================================================================
 
@@ -2094,6 +2119,39 @@ When a button is touched, it moves some distance in the direction of it's angle,
 "color"		constantLight color
 "light"		constantLight radius
 */
+
+const entityInfoData_t func_button_spawnflags[] = {
+//  {"1", ""},
+//  {"2", ""},
+//  {"4", ""},
+//  {"8", ""},
+//  {"16", ""},
+//  {"32", ""},
+  {"64", "Player can use it with the use button"},
+  {"128", "must be used by a target_activate before it can be used"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_button_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"model2", ".md3 model to also draw"},
+  {"angle", "determines the opening direction"},
+  {"target", "all entities with a matching targetname will be used"},
+  {"speed", "override the default 40 speed"},
+  {"wait", "override the default 1 second wait (-1 = never return)"},
+  {"lip", "override the default 4 pixel lip remaining at end of move"},
+  {"health", "if set, the button must be killed instead of touched"},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_button_info = {
+  "When a button is touched, it moves some distance in the direction of it\'s angle, triggers all of it\'s targets, waits some time, then returns to it\'s original position where it can be triggered again.",
+  func_button_spawnflags,
+  func_button_keys
+};
+
 void SP_func_button( gentity_t *ent ) {
 	vec3_t		abs_movedir;
 	float		distance;

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -2626,6 +2626,14 @@ teamnodmg - if 1, team 1 can't damage this. If 2, team 2 can't damage this.
 
 */
 const entityInfoData_t func_rotating_spawnflags[] = {
+  {"1", "?"},
+  {"2", "?"},
+  {"4", "Moves on X-Axis"},
+  {"8", "Moves on Y-Axis"},
+  {"16", "Will hurt a player if blocked"},
+  {"32", "?"},
+  {"64", "Can be used"},
+  {"128", "Start deactivated"},
   {NULL, NULL}
 };
 

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -2965,6 +2965,41 @@ Pendulum frequency is a physical constant based on the length of the beam and gr
 "color"		constantLight color
 "light"		constantLight radius
 */
+
+
+const entityInfoData_t func_pendulum_spawnflags[] = {
+//  {"1", ""},
+//  {"2", ""},
+//  {"4", ""},
+//  {"8", ""},
+//  {"16", ""},
+//  {"32", ""},
+  {"64", "Player can use it with the use button"},
+  {"128", "must be used by a target_activate before it can be used"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_pendulum_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"model2", ".md3 model to also draw"},
+  {"model2scale", ""},
+  {"speed", "the number of degrees each way the pendulum swings, (30 default)"},
+  {"phase", "the 0.0 to 1.0 offset in the cycle to start at"},
+  {"dmg", "damage to inflict when blocked (2 default)"},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_pendulum_info = {
+  "You need to have an origin brush as part of this entity. " 
+  "Pendulums always swing north / south on unrotated models. " 
+  "Add an angles field to the model to allow rotation in other directions. " 
+  "Pendulum frequency is a physical constant based on the length of the beam and gravity.",
+  func_pendulum_spawnflags,
+  func_pendulum_keys
+};
+
 void SP_func_pendulum(gentity_t *ent) {
 	float		freq;
 	float		length;

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -4116,6 +4116,34 @@ A bmodel that just sits there, doing nothing.  Can be used for conditional walls
 
 START_OFF - the wall will not be there
 */
+
+const entityInfoData_t func_wall_spawnflags[] = {
+//  {"1", ""},
+//  {"2", ""},
+//  {"4", ""},
+//  {"8", ""},
+//  {"16", ""},
+//  {"32", ""},
+  {"64", "Player can use it with the use button"},
+  {"128", "must be used by a target_activate before it can be used"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_wall_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"model2", ".md3 model to also draw"},
+  {"model2scale", ""},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_wall_info = {
+  "A bmodel that just sits there, does nothing. can be used for conditional walls and models.",
+  func_wall_spawnflags,
+  func_wall_keys
+};
+
 void SP_func_wall( gentity_t *ent ) 
 {
 

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -3908,6 +3908,41 @@ teamuser - if 1, team 2 can't use this. If 2, team 1 can't use this.
 
 */
 
+const entityInfoData_t func_usable_spawnflags[] = {
+  {"1", "the wall will not be there"},
+  {"2", "doesn\'t toggle on and off when used, just runs usescript and fires target"},
+//  {"4", ""},
+//  {"8", ""},
+//  {"16", ""},
+//  {"32", ""},
+  {"64", "Can be used"},
+  {"128", "Start deactivated"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_usable_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"model2", ".md3 model to also draw"},
+  {"model2scale", ""},
+  {"targetname", "When used, will toggle on and off"},
+  {"target", "Will fire this target every time it is toggled OFF"},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {"usescript", "script to run when turned on"},
+  {"deathscript", "script to run when turned off"},
+  {"wait", "amount of time before the object is usable again (only valid with ALWAYS_ON flag)"},
+  {"health", "if it has health, it will be used whenever shot at/killed - if you want it to only be used once this way, set health to 1"},
+  {"endframe", "Will make it animate to next shader frame when used, not turn on/off... set this to number of frames in the shader, minus 1"},
+  {"teamuser", "Applicable only during Siege gametype: if 1, team 2 can't use this. If 2, team 1 can't use this."},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_usable_info = {
+  "A bmodel that just sits there, doing nothing. Can be used for conditional walls and models. Disappears when used and reappears when used again.",
+  placeholder_spawnflags,
+  placeholder_keys
+};
+
 //Lugormod
 /*
 void Touch_func_usable( gentity_t *ent, gentity_t *other, trace_t *trace ) 

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -3714,6 +3714,35 @@ Breakable glass
 "light"		constantLight radius
 "maxshards"	Max number of shards to spawn on glass break
 */
+
+const entityInfoData_t func_glass_spawnflags[] = {
+ // {"1", ""},
+ // {"2", ""},
+ // {"4", ""},
+ // {"8", ""},
+ // {"16", ""},
+ // {"32", ""},
+  {"64", "Player can use"},
+  {"128", "Starts deactivated"},
+  {NULL, NULL}
+};
+
+const entityInfoData_t func_glass_keys[] = {
+  {"model", "the bmodel to draw"},
+  {"model2", ".md3 model to also draw"},
+  {"model2scale", ""},
+  {"color", "constantLight color"},
+  {"light", "constantLight radius"},
+  {"maxshards", "max number of shards to spawn on glass break"},
+  {NULL, NULL}
+};
+
+const entityInfo_t func_glass_info = {
+  "Breakable glass",
+  func_glass_spawnflags,
+  func_glass_keys
+};
+
 void SP_func_glass( gentity_t *ent ) {
 
 	//RoboPhred

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -1847,7 +1847,7 @@ const entityInfoData_t target_fixdoor_keys[] = {
 };
 
 const entityInfo_t target_fixdoor_info = {
-	"Spawns a trigger_door for all func_doors with the specified targetname.",
+	"Spawns a trigger_door for a func_door that has no trigger to open it. Useful on SP maps for quick fixes.",
 	target_fixdoor_keys,
 	NULL
 };

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -1646,6 +1646,14 @@ INACTIVE	must be used by a target_activate before it can be used
 qboolean G_FindEntityTeam(gentity_t *e);
 
 const entityInfoData_t func_door_spawnflags[] = {
+  {"1", "Start open"},
+  {"2", "Moves when push/pull is used on it"},
+  {"4", "Crushes anything in it\'s path, instead of returning to it\'s position it came from"}, 
+  {"8", "Stops at the end of it\'s movement and doesn\'t return unless used again"},
+  {"16", "Starts locked with the shader animap at the first frame and inactive. Once used, the shader animap changes to the second frame and the door operates normally"},
+  {"", "Note that you cannot use the door again after this."},
+  {"64", "Player can use it with the use button"},
+  {"128", "must be used by a target_activate before it can be used"},
   {NULL, NULL}
 };
 
@@ -1674,7 +1682,7 @@ const entityInfoData_t func_door_keys[] = {
 };
 
 const entityInfo_t func_door_info = {
-  "",
+  "A bmodel that opens and closes, can fire targets along the way. When this entity doesn\'t have a targetname it will autospawn another entity to trigger it called a \'trigger_door\'. To delete the trigger_door entity edit the func_door to have a targetname.",
   func_door_spawnflags,
   func_door_keys
 };

--- a/game/g_saga.c
+++ b/game/g_saga.c
@@ -11,6 +11,7 @@
  *****************************************************************************/
 #include "g_local.h"
 #include "bg_saga.h"
+#include "Lmd_Entities_Public.h" // for entityInfo_t
 
 #define SIEGEITEM_STARTOFFRADAR 8
 
@@ -1137,6 +1138,21 @@ STARTOFFRADAR - start not displaying on radar, don't display until used.
 "side" - set to 1 to specify an imperial goal, 2 to specify rebels
 "icon" - icon that represents the objective on the radar
 */
+const entityInfoData_t info_siege_objective_spawnflags[] = {
+	{"8", "start not displaying on radar, don't display until used"}, // STARTOFFRADAR at top of file
+	{NULL, NULL}
+};
+const entityInfoData_t info_siege_objective_keys[] = {
+	{"objective", "specifies the objective to complete upon activation"},
+	{"side", "set to 1 to specify an imperial goal, 2 to specify rebels"},
+	{"icon", "icon that represents the objective on the radar"},
+	{NULL, NULL}
+};
+const entityInfo_t info_siege_objective_info = {
+	"An objective to complete in a siege.",
+	info_siege_objective_spawnflags,
+	info_siege_objective_keys
+};
 void SP_info_siege_objective (gentity_t *ent)
 {
 	char* s = NULL;
@@ -1203,6 +1219,21 @@ to toggle on and off.
 "icon" - icon that represents the objective on the radar
 "startoff" - if 1 start off
 */
+const entityInfoData_t info_siege_radaricon_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t info_siege_radaricon_keys[] = {
+	{"icon", "icon that represents the objective on the radar"},
+	{"startoff", "if 1 start off"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t info_siege_radaricon_info = {
+	"Used to arbitrarily display radar icons at placed location. Can be used to toggle on and off.",
+	info_siege_radaricon_spawnflags,
+	info_siege_radaricon_keys
+};
 void SP_info_siege_radaricon (gentity_t *ent)
 {
 	char* s;
@@ -1297,6 +1328,20 @@ void decompTriggerUse(gentity_t *ent, gentity_t *other, gentity_t *activator)
 "objective" - specifies the objective to decomplete upon activation
 "side" - set to 1 to specify an imperial (team1) goal, 2 to specify rebels (team2)
 */
+const entityInfoData_t info_siege_decomplete_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t info_siege_decomplete_keys[] = {
+	{"objective", "specifies the objective to decomplete upon activation"},
+	{"side", "set to 1 to specify an imperial (team1) goal, 2 to specify rebels (team2)"},
+	{NULL, NULL}
+};
+const entityInfo_t info_siege_decomplete_info = {
+	"QUAKED info_siege_decomplete (1 0 1) (-16 -16 -24) (16 16 32)",
+	info_siege_decomplete_spawnflags,
+	info_siege_decomplete_keys
+};
 void SP_info_siege_decomplete (gentity_t *ent)
 {
 	if (!siege_valid || g_gametype.integer != GT_SIEGE)
@@ -1325,6 +1370,19 @@ void siegeEndUse(gentity_t *ent, gentity_t *other, gentity_t *activator)
 /*QUAKED target_siege_end (1 0 1) (-16 -16 -24) (16 16 32)
 Do a logexit for siege when used.
 */
+const entityInfoData_t target_siege_end_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t target_siege_end_keys[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfo_t target_siege_end_info = {
+	"Do a logexit (Round Ended) for siege when used",
+	target_siege_end_spawnflags,
+	target_siege_end_keys
+};
 void SP_target_siege_end (gentity_t *ent)
 {
 	if (!siege_valid || g_gametype.integer != GT_SIEGE)
@@ -1675,6 +1733,48 @@ health charge things only work with showhealth 1 on siege items that take damage
 "health_chargeamt"	if non-0 will recharge this much health every...
 "health_chargerate"	...this many milliseconds
 */
+const entityInfoData_t misc_siege_item_spawnflags[] = {
+	{"8", "start not displaying on radar, don't display until used"}, // STARTOFFRADAR at top of file
+	{NULL, NULL}
+};
+const entityInfoData_t misc_siege_item_keys[] = {
+	{"model", "Name of model to use for the object"},
+	{"mins", "Default is -16 -16 -24"},
+	{"maxs", "Default value is 16 16 32"},
+	{"usephysics", "If non-0, run standard physics on the object. Default is 1"},
+	{"mass", "If usephysics, this will be the factored object mass. Default is 0.09"},
+	{"gravity", "If usephysics, this will be the factored gravitational pull. Default is 3.0"},
+	{"bounce", "If usephysics, this will be the factored bounce amount. Default is 1.3"},
+	{"goaltarget", "Must be the targetname of a trigger_multi/trigger_once. Once a player carrying this object is brought inside the specified trigger, then that trigger will be allowed to fire. Ideally it will target a siege objective or something like that"},
+	{"target2", "Target to fire upon pickup"},
+	{"target3", "Target to fire upon delivery of the item to the goal point. If none, nothing will happen. (but you should always want something to happen)"},
+	{"target4", "Target to fire upon death, if damageable. Default is none"},
+	{"target5", "target to fire when respawning"},
+	{"target6", "target to fire when dropped by someone carrying this item"},
+	{"targetname", "If it has a targetname, it will only spawn upon being used"},
+	{"paintarget", "plop self on top of this guy\'s origin when we are used (only applies if the siege item has a targetname)"},
+	{"noradar", "if non-0 this thing iwll not show up on radar"},
+	{"forcelimit", "if non-0, while carrying this item the carrier\'s force powers will be crippled"},
+	{"canpickup", "If non-0, item can be picked up. Otherwise it will just be solid and sit on the ground. Default is 1"},
+	{"pickuponlyonce", "If non-0, target2 will only be fired on the first pickup. If the item is dropped and picked up again later, the target will not be fired off on the sequential pickup. Default value is 1"},
+	{"pickupsound", "Sound to play on pickup, if any"},
+	{"teamowner", "Which team owns this item, used only for deciding what color to make health meter"},
+	{"teamnotouch", "If 1 don't let team 1 pickup, if 2 don't let team 2. By default both teams can pick this object up and carry it around until death."},
+	{"teamnocomplete", "Same values as above, but controls if this object can be taken into the objective area by said team"},
+	{"deathfx", "Effect to play on death, if damageable. Default is none"},
+	{"respawnfx", "Plays this effect when respawning (if left in an unknown area too long and goes back to the original spot)"},
+	{"icon", "icon that represents the gametype item on the radar"},
+	{"health", "If > 0, object can be damaged and will die once health reaches 0. Default is 0"},
+	{"showhealth", "if health > 0, will show a health meter for this item"},
+	{"health_chargeamt", "if non-0 will charge this much health (requires showhealth 1)"},
+	{"health_chargerate", "this many milliseconds (requires showhealth 1)"},
+	{NULL, NULL}
+};
+const entityInfo_t misc_siege_item_info = {
+	"An item spawned in siege that can be picked up or captured. Must be siege gametype, must have a model.",
+	misc_siege_item_spawnflags,
+	misc_siege_item_keys
+};
 void SP_misc_siege_item (gentity_t *ent)
 {
 	int		canpickup;

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -338,6 +338,7 @@ extern entityInfo_t func_bobbing_info;
 void SP_func_pendulum( gentity_t *ent );
 
 void SP_func_button (gentity_t *ent);
+extern entityInfo_t func_button_info;
 
 void SP_func_door (gentity_t *ent);
 extern entityInfo_t func_door_info;
@@ -794,11 +795,11 @@ spawn_t	spawnInitValues[] = {
 
   // TODO: Info keys
 	{"func_plat", SP_func_plat, Logical_False, &func_plat_info},
-	{"func_button", SP_func_button, Logical_False},
+	{"func_button", SP_func_button, Logical_False, &func_button_info},
 	{"func_door", SP_func_door, Logical_False, &func_door_info},
 	{"func_static", SP_func_static, Logical_False, &func_static_info},
 	{"func_rotating", SP_func_rotating, Logical_False, &func_rotating_info},
-	{"func_bobbing", SP_func_bobbing, Logical_False, &func_bobbing_info},
+	{"func_bobbing", SP_func_bobbing, Logical_False},
 	{"func_pendulum", SP_func_pendulum, Logical_False},
 	{"func_train", SP_func_train, Logical_False, &func_train_info},
 	{"func_group", SP_info_null, Logical_False},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -345,6 +345,7 @@ extern entityInfo_t func_train_info;
 
 void SP_func_timer (gentity_t *self);
 void SP_func_breakable (gentity_t *ent);
+extern entityInfo_t func_breakable_info;
 void SP_func_glass (gentity_t *ent);
 extern entityInfo_t func_glass_info;
 void SP_func_usable( gentity_t *ent);
@@ -804,7 +805,7 @@ spawn_t	spawnInitValues[] = {
 	{"func_train", SP_func_train, Logical_False, &func_train_info},
 	{"func_group", SP_info_null, Logical_False},
 	{"func_timer", SP_func_timer, Logical_False},			// rename trigger_timer?
-	{"func_breakable", SP_func_breakable, Logical_False},
+	{"func_breakable", SP_func_breakable, Logical_False, &func_breakable_info},
 	{"func_glass", SP_func_glass, Logical_False, &func_glass_info},
 	{"func_usable", SP_func_usable, Logical_False, &func_usable_info},
 	{"func_wall", SP_func_wall, Logical_False, &func_wall_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -465,6 +465,7 @@ void SP_NPC_spawner( gentity_t *self );
 extern entityInfo_t NPC_spawner_info;
 
 void SP_LMD_spawner( gentity_t *NPCspawner );
+extern entityInfo_t LMD_spawner_info;
 
 void SP_NPC_Vehicle( gentity_t *self);
 
@@ -917,7 +918,7 @@ spawn_t	spawnInitValues[] = {
 
 	{"misc_weapon_shooter", SP_misc_weapon_shooter, Logical_True},
 
-	{"lmd_spawner", SP_LMD_spawner, Logical_True},
+	{"lmd_spawner", SP_LMD_spawner, Logical_True, &LMD_spawner_info},
 
 	//new NPC ents
 	{"NPC_spawner", SP_NPC_spawner, Logical_True, &NPC_spawner_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -561,6 +561,7 @@ void SP_misc_turretG2( gentity_t *base );
 void SP_misc_slotmachine (gentity_t *ent);//Lugormod
 void SP_ghost_exit (gentity_t *ent);//Lugormod
 void SP_target_fixdoor (gentity_t *ent); //Lugormod
+extern entityInfo_t target_fixdoor_info;
 
 //RoboPhred
 
@@ -1022,14 +1023,14 @@ spawn_t	spawnInitValues[] = {
 
 	{"emplaced_gun", SP_emplaced_gun, Logical_False},
 
-	{ "misc_turret", SP_misc_turret, Logical_False, &misc_turret_info },
+	{"misc_turret", SP_misc_turret, Logical_False, &misc_turret_info },
 	{"misc_turretG2", SP_misc_turretG2, Logical_False},
 	{"misc_camera", SP_misc_camera, Logical_False},//Lugormod
 	{"random_spot", SP_random_spot, Logical_True, &random_spot_info},//Lugormod
 	{"money_dispenser", SP_money_dispenser, Logical_False},//Lugormod
 	{"control_point", SP_control_point, Logical_False},//Lugormod
 	{"emplaced_eweb", SP_emplaced_gun, Logical_False},//Lugormod
-	{"target_fixdoor", SP_target_fixdoor, Logical_False}, //Lugormod
+	{"target_fixdoor", SP_target_fixdoor, Logical_False, &target_fixdoor_info}, //Lugormod
 	{"target_credits", SP_target_credits, Logical_True}, //Lugormod
 	{"rail_mover", SP_rail_mover, Logical_False, &rail_mover_info}, //Lugormod
 	{"rail_track", SP_rail_track, Logical_True, &rail_track_info}, //Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -332,6 +332,7 @@ extern entityInfo_t func_plat_info;
 void SP_func_static (gentity_t *ent);
 extern entityInfo_t func_static_info;
 void SP_func_rotating (gentity_t *ent);
+extern entityInfo_t func_rotating_info;
 void SP_func_bobbing (gentity_t *ent);
 void SP_func_pendulum( gentity_t *ent );
 void SP_func_button (gentity_t *ent);
@@ -786,8 +787,8 @@ spawn_t	spawnInitValues[] = {
 	{"func_plat", SP_func_plat, Logical_False, &func_plat_info},
 	{"func_button", SP_func_button, Logical_False},
 	{"func_door", SP_func_door, Logical_False, &func_door_info},
-	{"func_static", SP_func_static, Logical_False},
-	{"func_rotating", SP_func_rotating, Logical_False},
+	{"func_static", SP_func_static, Logical_False, &func_static_info},
+	{"func_rotating", SP_func_rotating, Logical_False, &func_rotating_info},
 	{"func_bobbing", SP_func_bobbing, Logical_False},
 	{"func_pendulum", SP_func_pendulum, Logical_False},
 	{"func_train", SP_func_train, Logical_False},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -416,50 +416,77 @@ void SP_target_play_music( gentity_t *self );
 void SP_target_push (gentity_t *ent);
 
 void SP_light (gentity_t *self);
+extern entityInfo_t SP_light_info;
 void SP_info_null (gentity_t *self);
+extern entityInfo_t SP_info_null_info;
 void SP_info_notnull (gentity_t *self);
+extern entityInfo_t SP_info_notnull_info;
 void SP_info_camp (gentity_t *self);
+extern entityInfo_t SP_info_camp_info;
 
 extern entityInfo_t path_corner_info;
 void SP_path_corner (gentity_t *self);
 
 void SP_misc_teleporter_dest (gentity_t *self);
+extern entityInfo_t misc_teleporter_dest_info;
 void SP_misc_model_breakable(gentity_t *ent); //Lugormod
+extern entityInfo_t misc_model_breakable_info;
 void SP_misc_exploding_crate(gentity_t *ent); //Lugormod
+extern entityInfo_t misc_exploding_crate_info;
 void SP_misc_security_panel(gentity_t *ent);
+extern entityInfo_t misc_security_panel_info;
 void SP_defender(gentity_t *ent);
 void SP_misc_model(gentity_t *ent);
+extern entityInfo_t misc_model_info;
 void SP_misc_model_static(gentity_t *ent);
+extern entityInfo_t misc_model_static_info;
 void SP_misc_G2model(gentity_t *ent);
+extern entityInfo_t misc_G2model_info;
 void SP_misc_portal_camera(gentity_t *ent);
+extern entityInfo_t misc_portal_camera_info;
 void SP_misc_portal_surface(gentity_t *ent);
+extern entityInfo_t misc_portal_surface_info;
 void SP_misc_weather_zone( gentity_t *ent );
+extern entityInfo_t misc_weather_zone_info;
 
 void SP_misc_bsp (gentity_t *ent);
+extern entityInfo_t misc_bsp_info;
 void SP_terrain (gentity_t *ent);
+extern entityInfo_t terrain_info;
 void SP_misc_skyportal_orient (gentity_t *ent);
+extern entityInfo_t misc_skyportal_orient_info;
 void SP_misc_skyportal (gentity_t *ent);
+extern entityInfo_t misc_skyportal_info;
 
 void SP_misc_ammo_floor_unit(gentity_t *ent);
+extern entityInfo_t misc_ammo_floor_unit_info;
 void SP_misc_shield_floor_unit( gentity_t *ent );
+extern entityInfo_t misc_shield_floor_unit_info;
 void SP_misc_model_shield_power_converter( gentity_t *ent );
+extern entityInfo_t misc_model_shield_power_convert_info;
 void SP_misc_model_ammo_power_converter( gentity_t *ent );
+extern entityInfo_t misc_model_ammo_power_converter_info;
 void SP_misc_model_health_power_converter( gentity_t *ent );
+extern entityInfo_t misc_model_health_power_converter_info;
 
 void SP_fx_runner( gentity_t *ent );
 extern entityInfo_t fx_runner_info;
 
 void SP_target_screenshake(gentity_t *ent);
+extern entityInfo_t target_screenshake_info;
 void SP_target_escapetrig(gentity_t *ent);
 
 void SP_misc_maglock ( gentity_t *self );
+extern entityInfo_t misc_maglock_info;
 
 void SP_misc_faller(gentity_t *ent);
 extern entityInfo_t misc_faller_info;
 
 void SP_misc_holocron(gentity_t *ent);
+extern entityInfo_t misc_holocron_info;
 
 void SP_reference_tag ( gentity_t *ent );
+extern entityInfo_t ref_tag_info;
 
 void SP_misc_weapon_shooter( gentity_t *self );
 extern entityInfo_t misc_weapon_shooter_info;
@@ -562,6 +589,7 @@ extern entityInfo_t fx_wind_info; // Lugormod, unused not spawnable
 void SP_point_combat( gentity_t *self );
 
 void SP_shooter_blaster( gentity_t *ent );
+extern entityInfo_t shooter_blaster_info;
 
 void SP_team_CTF_redplayer( gentity_t *ent );
 void SP_team_CTF_blueplayer( gentity_t *ent );
@@ -574,6 +602,7 @@ extern entityInfo_t misc_turret_info;
 void SP_misc_turretG2( gentity_t *base );
 extern entityInfo_t misc_turretG2_info;
 void SP_misc_slotmachine (gentity_t *ent);//Lugormod
+extern entityInfo_t misc_slotmachine_info;
 void SP_ghost_exit (gentity_t *ent);//Lugormod
 void SP_target_fixdoor (gentity_t *ent); //Lugormod
 extern entityInfo_t target_fixdoor_info;
@@ -804,9 +833,9 @@ spawn_t	spawnInitValues[] = {
 	{"info_jedimaster_start", SP_info_jedimaster_start, Logical_True},
 	{"info_player_start_red", SP_info_player_start_red, Logical_True},
 	{"info_player_start_blue", SP_info_player_start_blue, Logical_True},
-	{"info_null", SP_info_null, Logical_True},
-	{"info_notnull", SP_info_notnull, Logical_True},		// use target_position instead
-	{"info_camp", SP_info_camp, Logical_True},
+	{"info_null", SP_info_null, Logical_True, &SP_info_null_info},
+	{"info_notnull", SP_info_notnull, Logical_True, &SP_info_notnull_info},		// use target_position instead
+	{"info_camp", SP_info_camp, Logical_True, &SP_info_camp_info},
 
 	{"info_siege_objective", SP_info_siege_objective, Logical_False},
 	{"info_siege_radaricon", SP_info_siege_radaricon, Logical_False},
@@ -823,7 +852,7 @@ spawn_t	spawnInitValues[] = {
 	{"func_bobbing", SP_func_bobbing, Logical_False, &func_bobbing_info},
 	{"func_pendulum", SP_func_pendulum, Logical_False, &func_pendulum_info},
 	{"func_train", SP_func_train, Logical_False, &func_train_info},
-	{"func_group", SP_info_null, Logical_False},
+	{"func_group", SP_info_null, Logical_False, &SP_info_null_info},
 	{"func_timer", SP_func_timer, Logical_False},			// rename trigger_timer?
 	{"func_breakable", SP_func_breakable, Logical_False, &func_breakable_info},
 	{"func_glass", SP_func_glass, Logical_False, &func_glass_info},
@@ -877,47 +906,47 @@ spawn_t	spawnInitValues[] = {
 	{"target_push", SP_target_push, Logical_True},
 	{"target_powerup", SP_target_powerup, Logical_True}, //Lugormod
 
-	{"light", SP_light, Logical_True},
+	{"light", SP_light, Logical_True, &SP_light_info},
 	{"path_corner", SP_path_corner, Logical_True, &path_corner_info},
 		
-	{"misc_teleporter_dest", SP_misc_teleporter_dest, Logical_True},
+	{"misc_teleporter_dest", SP_misc_teleporter_dest, Logical_True, &misc_teleporter_dest_info},
 	{"defender", SP_defender, Logical_False},
-	{"misc_security_panel", SP_misc_security_panel, Logical_False},
+	{"misc_security_panel", SP_misc_security_panel, Logical_False, &misc_security_panel_info},
 	{"misc_stuff", SP_misc_model_breakable, Logical_False}, //Lugormod
-	{"misc_exploding_crate", SP_misc_exploding_crate, Logical_False}, //Lugormod
-	{"misc_model", SP_misc_model, Logical_False},
-	{"misc_model_static", SP_misc_model_static, Logical_False},
-	{"misc_model_breakable", SP_misc_model_breakable, Logical_False},
+	{"misc_exploding_crate", SP_misc_exploding_crate, Logical_False, &misc_exploding_crate_info}, //Lugormod
+	{"misc_model", SP_misc_model, Logical_False, &misc_model_info},
+	{"misc_model_static", SP_misc_model_static, Logical_False, &misc_model_static_info},
+	{"misc_model_breakable", SP_misc_model_breakable, Logical_False, &misc_model_breakable_info},
 	//{"misc_model_breakable", SP_misc_model_static},
-	{"misc_G2model", SP_misc_G2model, Logical_False},
-	{"misc_portal_surface", SP_misc_portal_surface, Logical_False},
-	{"misc_portal_camera", SP_misc_portal_camera, Logical_False},
-	{"misc_weather_zone", SP_misc_weather_zone, Logical_False},
+	{"misc_G2model", SP_misc_G2model, Logical_False, &misc_G2model_info},
+	{"misc_portal_surface", SP_misc_portal_surface, Logical_False, &misc_portal_surface_info},
+	{"misc_portal_camera", SP_misc_portal_camera, Logical_False, &misc_portal_camera_info},
+	{"misc_weather_zone", SP_misc_weather_zone, Logical_False, &misc_weather_zone_info},
 
-	{"misc_bsp", SP_misc_bsp, Logical_False},
-	{"terrain", SP_terrain, Logical_False},
-	{"misc_skyportal_orient", SP_misc_skyportal_orient, Logical_True},
-	{"misc_skyportal", SP_misc_skyportal, Logical_True},
+	{"misc_bsp", SP_misc_bsp, Logical_False, &misc_bsp_info},
+	{"terrain", SP_terrain, Logical_False, &terrain_info},
+	{"misc_skyportal_orient", SP_misc_skyportal_orient, Logical_True, &misc_skyportal_orient_info},
+	{"misc_skyportal", SP_misc_skyportal, Logical_True, &misc_skyportal_info},
 
 	//rwwFIXMEFIXME: only for testing rmg team stuff
 	{"gametype_item", SP_gametype_item, Logical_False},
 
-	{"misc_ammo_floor_unit", SP_misc_ammo_floor_unit, Logical_False},
-	{"misc_shield_floor_unit", SP_misc_shield_floor_unit, Logical_False},
-	{"misc_model_shield_power_converter", SP_misc_model_shield_power_converter, Logical_False},
-	{"misc_model_ammo_power_converter", SP_misc_model_ammo_power_converter, Logical_False},
-	{"misc_model_health_power_converter", SP_misc_model_health_power_converter, Logical_False},
+	{"misc_ammo_floor_unit", SP_misc_ammo_floor_unit, Logical_False, &misc_ammo_floor_unit_info},
+	{"misc_shield_floor_unit", SP_misc_shield_floor_unit, Logical_False, &misc_shield_floor_unit_info},
+	{"misc_model_shield_power_converter", SP_misc_model_shield_power_converter, Logical_False, &misc_model_shield_power_convert_info},
+	{"misc_model_ammo_power_converter", SP_misc_model_ammo_power_converter, Logical_False, &misc_model_ammo_power_converter_info},
+	{"misc_model_health_power_converter", SP_misc_model_health_power_converter, Logical_False, &misc_model_health_power_converter_info},
 
 	{"fx_runner", SP_fx_runner, Logical_False, &fx_runner_info},
 
-	{"target_screenshake", SP_target_screenshake, Logical_True},
+	{"target_screenshake", SP_target_screenshake, Logical_True, &target_screenshake_info},
 	{"target_escapetrig", SP_target_escapetrig, Logical_True},
 
-	{"misc_maglock", SP_misc_maglock, Logical_False},
+	{"misc_maglock", SP_misc_maglock, Logical_False, &misc_maglock_info},
 
 	{"misc_faller", SP_misc_faller, Logical_True, &misc_faller_info},
 
-	{"ref_tag",	SP_reference_tag, Logical_True},
+	{"ref_tag",	SP_reference_tag, Logical_True, &ref_tag_info},
 	{"ref_tag_huge", SP_reference_tag, Logical_True},
 
 	{"misc_weapon_shooter", SP_misc_weapon_shooter, Logical_True, &misc_weapon_shooter_info},
@@ -1026,9 +1055,9 @@ spawn_t	spawnInitValues[] = {
 
 	{"point_combat", SP_point_combat, Logical_True},
 
-	{"misc_holocron", SP_misc_holocron, Logical_False},
+	{"misc_holocron", SP_misc_holocron, Logical_False, &misc_holocron_info},
 
-	{"shooter_blaster", SP_shooter_blaster, Logical_True},
+	{"shooter_blaster", SP_shooter_blaster, Logical_True, &shooter_blaster_info},
 
 	{"team_CTF_redplayer", SP_team_CTF_redplayer, Logical_True},
 	{"team_CTF_blueplayer", SP_team_CTF_blueplayer, Logical_True},
@@ -1052,7 +1081,7 @@ spawn_t	spawnInitValues[] = {
 	{"rail_mover", SP_rail_mover, Logical_False, &rail_mover_info}, //Lugormod
 	{"rail_track", SP_rail_track, Logical_True, &rail_track_info}, //Lugormod
 	{"rail_lane", SP_rail_lane, Logical_True, &rail_lane_info}, //Lugormod
-	{"misc_slotmachine", SP_misc_slotmachine, Logical_False}, //Lugormod
+	{"misc_slotmachine", SP_misc_slotmachine, Logical_False, &misc_slotmachine_info}, //Lugormod
 	{"ghost_exit_red", SP_ghost_exit, Logical_True}, //Lugormod
 	{"ghost_exit_blue", SP_ghost_exit, Logical_True}, //Lugormod
 	

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -847,9 +847,9 @@ spawn_t	spawnInitValues[] = {
 	{"info_player_intermission", SP_info_player_intermission, Logical_True, &info_player_intermission_info},
 	{"info_player_intermission_red", SP_info_player_intermission_red, Logical_True, &info_player_intermission_red_info},
 	{"info_player_intermission_blue", SP_info_player_intermission_blue, Logical_True, &info_player_intermission_blue_info},
-	{"info_jedimaster_start", SP_info_jedimaster_start, Logical_True, &info_jedimaster_start_info,
+	{"info_jedimaster_start", SP_info_jedimaster_start, Logical_True, &info_jedimaster_start_info},
 	{"info_player_start_red", SP_info_player_start_red, Logical_True, &info_player_start_red_info},
-	{"info_player_start_blue", SP_info_player_start_blue, Logical_True}, &info_player_start_blue_info,
+	{"info_player_start_blue", SP_info_player_start_blue, Logical_True, &info_player_start_blue_info},
 	{"info_null", SP_info_null, Logical_True, &SP_info_null_info},
 	{"info_notnull", SP_info_notnull, Logical_True, &SP_info_notnull_info},		// use target_position instead
 	{"info_camp", SP_info_camp, Logical_True, &SP_info_camp_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -285,6 +285,7 @@ void SP_emplaced_gun( gentity_t *ent );
 
 void SP_target_credits( gentity_t *ent ); //Lugormod
 void SP_random_spot (gentity_t *ent); //Lugormod
+extern entityInfo_t random_spot_info; //Lugormod
 void SP_money_dispenser (gentity_t *ent);//Lugormod
 void SP_control_point (gentity_t *ent);//Lugormod
 void SP_misc_camera (gentity_t *ent); //Lugormod
@@ -353,8 +354,11 @@ extern entityInfo_t func_usable_info;
 void SP_func_wall( gentity_t *ent );
 extern entityInfo_t func_wall_info;
 void SP_rail_mover (gentity_t *ent); //Lugormod
+extern entityInfo_t rail_mover_info;
 void SP_rail_track (gentity_t *ent); //Lugormod
+extern entityInfo_t rail_track_info;
 void SP_rail_lane (gentity_t *ent); //Lugormod
+extern entityInfo_t rail_lane_info;
 
 void SP_trigger_lightningstrike( gentity_t *ent );
 extern entityInfo_t trigger_lightningstrike_info;
@@ -1021,15 +1025,15 @@ spawn_t	spawnInitValues[] = {
 	{ "misc_turret", SP_misc_turret, Logical_False, &misc_turret_info },
 	{"misc_turretG2", SP_misc_turretG2, Logical_False},
 	{"misc_camera", SP_misc_camera, Logical_False},//Lugormod
-	{"random_spot", SP_random_spot, Logical_True},//Lugormod
+	{"random_spot", SP_random_spot, Logical_True, &random_spot_info},//Lugormod
 	{"money_dispenser", SP_money_dispenser, Logical_False},//Lugormod
 	{"control_point", SP_control_point, Logical_False},//Lugormod
 	{"emplaced_eweb", SP_emplaced_gun, Logical_False},//Lugormod
 	{"target_fixdoor", SP_target_fixdoor, Logical_False}, //Lugormod
 	{"target_credits", SP_target_credits, Logical_True}, //Lugormod
-	{"rail_mover", SP_rail_mover, Logical_False}, //Lugormod
-	{"rail_track", SP_rail_track, Logical_True}, //Lugormod
-	{"rail_lane", SP_rail_lane, Logical_True}, //Lugormod
+	{"rail_mover", SP_rail_mover, Logical_False, &rail_mover_info}, //Lugormod
+	{"rail_track", SP_rail_track, Logical_True, &rail_track_info}, //Lugormod
+	{"rail_lane", SP_rail_lane, Logical_True, &rail_lane_info}, //Lugormod
 	{"misc_slotmachine", SP_misc_slotmachine, Logical_False}, //Lugormod
 	{"ghost_exit_red", SP_ghost_exit, Logical_True}, //Lugormod
 	{"ghost_exit_blue", SP_ghost_exit, Logical_True}, //Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -425,8 +425,9 @@ void SP_target_print (gentity_t *ent);
 extern entityInfo_t target_print_info;
 void SP_target_laser (gentity_t *self);
 extern entityInfo_t target_laser_info;
-void SP_target_character (gentity_t *ent);
+void SP_target_character (gentity_t *ent); // no doc
 void SP_target_score( gentity_t *ent );
+extern entityInfo_t target_score_info;
 void SP_target_teleporter( gentity_t *ent );
 void SP_target_relay (gentity_t *ent);
 void SP_target_kill (gentity_t *ent);
@@ -916,7 +917,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_speaker", SP_target_speaker, {qtrue, target_speaker_allowlogical}, &target_speaker_info},
 	{"target_print", SP_target_print, Logical_True, &target_print_info},
 	{"target_laser", SP_target_laser, Logical_True, &target_laser_info},
-	{"target_score", SP_target_score, Logical_True},
+	{"target_score", SP_target_score, Logical_True, &target_score_info},
 	{"target_teleporter", SP_target_teleporter, Logical_True},
 	{"target_relay", SP_target_relay, Logical_True},
 	{"target_kill", SP_target_kill, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -358,6 +358,7 @@ void SP_trigger_lightningstrike( gentity_t *ent );
 extern entityInfo_t trigger_lightningstrike_info;
 
 void SP_trigger_once( gentity_t *ent );
+extern entityInfo_t trigger_once_info;
 
 qboolean trigger_multiple_allowlogical();
 void SP_trigger_multiple (gentity_t *ent);
@@ -814,7 +815,7 @@ spawn_t	spawnInitValues[] = {
 	// could not be client side predicted (push and teleport).
 
 	{"trigger_lightningstrike", SP_trigger_lightningstrike, Logical_True, &trigger_lightningstrike_info},
-	{"trigger_once", SP_trigger_once, Logical_False},
+	{"trigger_once", SP_trigger_once, Logical_False, &trigger_once_info},
 	{"trigger_multiple", SP_trigger_multiple, {qtrue, trigger_multiple_allowlogical}, &trigger_multiple_info},
 	{"trigger_push", SP_trigger_push, Logical_False, &trigger_push_info},
 

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -325,7 +325,9 @@ extern entityInfo_t info_player_intermission_blue_info;
 void SP_info_jedimaster_start (gentity_t *ent);
 extern entityInfo_t info_jedimaster_start_info;
 void SP_info_player_start_red (gentity_t *ent);
+extern entityInfo_t info_player_start_red_info;
 void SP_info_player_start_blue (gentity_t *ent);
+extern entityInfo_t info_player_start_blue_info;
 void SP_info_firstplace(gentity_t *ent);
 void SP_info_secondplace(gentity_t *ent);
 void SP_info_thirdplace(gentity_t *ent);
@@ -837,8 +839,8 @@ spawn_t	spawnInitValues[] = {
 	{"info_player_intermission_red", SP_info_player_intermission_red, Logical_True, &info_player_intermission_red_info},
 	{"info_player_intermission_blue", SP_info_player_intermission_blue, Logical_True, &info_player_intermission_blue_info},
 	{"info_jedimaster_start", SP_info_jedimaster_start, Logical_True, &info_jedimaster_start_info,
-	{"info_player_start_red", SP_info_player_start_red, Logical_True},
-	{"info_player_start_blue", SP_info_player_start_blue, Logical_True},
+	{"info_player_start_red", SP_info_player_start_red, Logical_True, &info_player_start_red_info},
+	{"info_player_start_blue", SP_info_player_start_blue, Logical_True}, &info_player_start_blue_info,
 	{"info_null", SP_info_null, Logical_True, &SP_info_null_info},
 	{"info_notnull", SP_info_notnull, Logical_True, &SP_info_notnull_info},		// use target_position instead
 	{"info_camp", SP_info_camp, Logical_True, &SP_info_camp_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -447,6 +447,7 @@ void SP_misc_model_ammo_power_converter( gentity_t *ent );
 void SP_misc_model_health_power_converter( gentity_t *ent );
 
 void SP_fx_runner( gentity_t *ent );
+extern entityInfo_t fx_runner_info;
 
 void SP_target_screenshake(gentity_t *ent);
 void SP_target_escapetrig(gentity_t *ent);
@@ -454,12 +455,14 @@ void SP_target_escapetrig(gentity_t *ent);
 void SP_misc_maglock ( gentity_t *self );
 
 void SP_misc_faller(gentity_t *ent);
+extern entityInfo_t misc_faller_info;
 
 void SP_misc_holocron(gentity_t *ent);
 
 void SP_reference_tag ( gentity_t *ent );
 
 void SP_misc_weapon_shooter( gentity_t *self );
+extern entityInfo_t misc_weapon_shooter_info;
 
 void SP_NPC_spawner( gentity_t *self );
 extern entityInfo_t NPC_spawner_info;
@@ -905,19 +908,19 @@ spawn_t	spawnInitValues[] = {
 	{"misc_model_ammo_power_converter", SP_misc_model_ammo_power_converter, Logical_False},
 	{"misc_model_health_power_converter", SP_misc_model_health_power_converter, Logical_False},
 
-	{"fx_runner", SP_fx_runner, Logical_False},
+	{"fx_runner", SP_fx_runner, Logical_False, &fx_runner_info},
 
 	{"target_screenshake", SP_target_screenshake, Logical_True},
 	{"target_escapetrig", SP_target_escapetrig, Logical_True},
 
 	{"misc_maglock", SP_misc_maglock, Logical_False},
 
-	{"misc_faller", SP_misc_faller, Logical_True},
+	{"misc_faller", SP_misc_faller, Logical_True, &misc_faller_info},
 
 	{"ref_tag",	SP_reference_tag, Logical_True},
 	{"ref_tag_huge", SP_reference_tag, Logical_True},
 
-	{"misc_weapon_shooter", SP_misc_weapon_shooter, Logical_True},
+	{"misc_weapon_shooter", SP_misc_weapon_shooter, Logical_True, &misc_weapon_shooter_info},
 
 	{"lmd_spawner", SP_LMD_spawner, Logical_True, &LMD_spawner_info},
 
@@ -1017,7 +1020,7 @@ spawn_t	spawnInitValues[] = {
 	{"fx_spacedust", SP_CreateSpaceDust, Logical_True, &fx_spacedust_info},
 	{"fx_rain", SP_CreateRain, Logical_True, &fx_rain_info},
 	{"fx_snow", SP_CreateSnow, Logical_True, &fx_snow_info},
-	//{"fx_wind", SP_CreateWind}, //Lugormod
+	//{"fx_wind", SP_CreateWind, Logical_True, &fx_wind_info}, //Lugormod
 	// if ever used in the future
 
 

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -1025,7 +1025,7 @@ spawn_t	spawnInitValues[] = {
 
 	{"item_botroam", SP_item_botroam, Logical_True},
 
-	{"emplaced_gun", SP_emplaced_gun, Logical_False},
+	{"emplaced_gun", SP_emplaced_gun, Logical_False, &emplaced_gun_info},
 
 	{"misc_turret", SP_misc_turret, Logical_False, &misc_turret_info },
 	{"misc_turretG2", SP_misc_turretG2, Logical_False},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -293,6 +293,7 @@ extern entityInfo_t money_dispenser_info; //Lugormod
 void SP_control_point (gentity_t *ent); //Lugormod
 extern entityInfo_t control_point_info; //Lugormod
 void SP_misc_camera (gentity_t *ent); //Lugormod
+extern entityInfo_t misc_camera_info;
 void SP_info_player_jail (gentity_t *ent); //Lugormod
 extern entityInfo_t info_player_jail_info; //Lugormod
 
@@ -461,6 +462,7 @@ void SP_reference_tag ( gentity_t *ent );
 void SP_misc_weapon_shooter( gentity_t *self );
 
 void SP_NPC_spawner( gentity_t *self );
+extern entityInfo_t NPC_spawner_info;
 
 void SP_LMD_spawner( gentity_t *NPCspawner );
 
@@ -544,9 +546,13 @@ void SP_waypoint_navgoal_2 (gentity_t *ent);
 void SP_waypoint_navgoal_1 (gentity_t *ent);
 
 void SP_CreateSpaceDust( gentity_t *ent );
+extern entityInfo_t fx_spacedust_info;
 void SP_CreateSnow( gentity_t *ent );
+extern entityInfo_t fx_snow_info;
 void SP_CreateRain( gentity_t *ent );
-void SP_CreateWind( gentity_t *ent ); //Lugormod
+extern entityInfo_t fx_rain_info;
+void SP_CreateWind( gentity_t *ent ); //Lugormod, unused not spawnable
+extern entityInfo_t fx_wind_info; // Lugormod, unused not spawnable
 
 void SP_point_combat( gentity_t *self );
 
@@ -914,7 +920,7 @@ spawn_t	spawnInitValues[] = {
 	{"lmd_spawner", SP_LMD_spawner, Logical_True},
 
 	//new NPC ents
-	{"NPC_spawner", SP_NPC_spawner, Logical_True},
+	{"NPC_spawner", SP_NPC_spawner, Logical_True, &NPC_spawner_info},
 	{"NPC_Vehicle", SP_NPC_Vehicle, Logical_True},
 	{"NPC_Kyle", SP_NPC_Kyle, Logical_True},
 	{"NPC_Lando", SP_NPC_Lando, Logical_True},
@@ -1006,10 +1012,12 @@ spawn_t	spawnInitValues[] = {
 	{"waypoint_navgoal_2", SP_waypoint_navgoal_2, Logical_True},
 	{"waypoint_navgoal_1", SP_waypoint_navgoal_1, Logical_True},
 
-	{"fx_spacedust", SP_CreateSpaceDust, Logical_True},
-	{"fx_rain", SP_CreateRain, Logical_True},
-	{"fx_snow", SP_CreateSnow, Logical_True},
+	{"fx_spacedust", SP_CreateSpaceDust, Logical_True, &fx_spacedust_info},
+	{"fx_rain", SP_CreateRain, Logical_True, &fx_rain_info},
+	{"fx_snow", SP_CreateSnow, Logical_True, &fx_snow_info},
 	//{"fx_wind", SP_CreateWind}, //Lugormod
+	// if ever used in the future
+
 
 	{"point_combat", SP_point_combat, Logical_True},
 
@@ -1029,7 +1037,7 @@ spawn_t	spawnInitValues[] = {
 
 	{"misc_turret", SP_misc_turret, Logical_False, &misc_turret_info},
 	{"misc_turretG2", SP_misc_turretG2, Logical_False, &misc_turretG2_info},
-	{"misc_camera", SP_misc_camera, Logical_False},//Lugormod
+	{"misc_camera", SP_misc_camera, Logical_False, &misc_camera_info},//Lugormod
 	{"random_spot", SP_random_spot, Logical_True, &random_spot_info},//Lugormod
 	{"money_dispenser", SP_money_dispenser, Logical_False, &money_dispenser_info},//Lugormod
 	{"control_point", SP_control_point, Logical_False, &control_point_info},//Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -437,6 +437,7 @@ extern entityInfo_t target_kill_info;
 void SP_target_position (gentity_t *ent);
 extern entityInfo_t target_position_info;
 void SP_target_location (gentity_t *ent);
+extern entityInfo_t target_location_info;
 void SP_target_counter (gentity_t *self);
 void SP_target_random (gentity_t *self);
 void SP_target_scriptrunner( gentity_t *self );
@@ -926,7 +927,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_relay", SP_target_relay, Logical_True, &target_relay_info},
 	{"target_kill", SP_target_kill, Logical_True, &target_kill_info},
 	{"target_position", SP_target_position, Logical_True, &target_position_info},
-	{"target_location", SP_target_location, Logical_True},
+	{"target_location", SP_target_location, Logical_True, &target_location_info},
 	{"target_counter", SP_target_counter, Logical_True},
 	{"target_random", SP_target_random, Logical_True},
 	{"target_scriptrunner", SP_target_scriptrunner, qfalse},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -407,6 +407,8 @@ void SP_light (gentity_t *self);
 void SP_info_null (gentity_t *self);
 void SP_info_notnull (gentity_t *self);
 void SP_info_camp (gentity_t *self);
+
+extern entityInfo_t path_corner_info;
 void SP_path_corner (gentity_t *self);
 
 void SP_misc_teleporter_dest (gentity_t *self);
@@ -853,7 +855,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_powerup", SP_target_powerup, Logical_True}, //Lugormod
 
 	{"light", SP_light, Logical_True},
-	{"path_corner", SP_path_corner, Logical_True},
+	{"path_corner", SP_path_corner, Logical_True, &path_corner_info},
 		
 	{"misc_teleporter_dest", SP_misc_teleporter_dest, Logical_True},
 	{"defender", SP_defender, Logical_False},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -1033,7 +1033,7 @@ spawn_t	spawnInitValues[] = {
 	{"random_spot", SP_random_spot, Logical_True, &random_spot_info},//Lugormod
 	{"money_dispenser", SP_money_dispenser, Logical_False, &money_dispenser_info},//Lugormod
 	{"control_point", SP_control_point, Logical_False, &control_point_info},//Lugormod
-	{"emplaced_eweb", SP_emplaced_gun, Logical_False},//Lugormod
+	{"emplaced_eweb", SP_emplaced_gun, Logical_False, &emplaced_gun_info},//Lugormod
 	{"target_fixdoor", SP_target_fixdoor, Logical_False, &target_fixdoor_info}, //Lugormod
 	{"target_credits", SP_target_credits, Logical_True, &target_credits_info}, //Lugormod
 	{"rail_mover", SP_rail_mover, Logical_False, &rail_mover_info}, //Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -313,7 +313,9 @@ void SP_info_player_deathmatch (gentity_t *ent);
 extern entityInfo_t info_player_deathmatch_info;
 
 void SP_info_player_siegeteam1 (gentity_t *ent);
+extern entityInfo_t info_player_siegeteam1_info;
 void SP_info_player_siegeteam2 (gentity_t *ent);
+extern entityInfo_t info_player_siegeteam2_info;
 void SP_info_player_intermission (gentity_t *ent);
 void SP_info_player_intermission_red (gentity_t *ent);
 void SP_info_player_intermission_blue (gentity_t *ent);
@@ -825,8 +827,8 @@ spawn_t	spawnInitValues[] = {
 	{"info_player_deathmatch", SP_info_player_deathmatch, Logical_True, &info_player_deathmatch_info},
 	
   // TODO: Info keys
-  {"info_player_siegeteam1", SP_info_player_siegeteam1, Logical_True},
-	{"info_player_siegeteam2", SP_info_player_siegeteam2, Logical_True},
+  	{"info_player_siegeteam1", SP_info_player_siegeteam1, Logical_True, &info_player_siegeteam1_info},
+	{"info_player_siegeteam2", SP_info_player_siegeteam2, Logical_True, &info_player_siegeteam2_info},
 	{"info_player_intermission", SP_info_player_intermission, Logical_True},
 	{"info_player_intermission_red", SP_info_player_intermission_red, Logical_True},
 	{"info_player_intermission_blue", SP_info_player_intermission_blue, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -349,6 +349,7 @@ void SP_func_glass (gentity_t *ent);
 void SP_func_usable( gentity_t *ent);
 extern entityInfo_t func_usable_info;
 void SP_func_wall( gentity_t *ent );
+extern entityInfo_t func_wall_info;
 void SP_rail_mover (gentity_t *ent); //Lugormod
 void SP_rail_track (gentity_t *ent); //Lugormod
 void SP_rail_lane (gentity_t *ent); //Lugormod
@@ -805,7 +806,7 @@ spawn_t	spawnInitValues[] = {
 	{"func_breakable", SP_func_breakable, Logical_False},
 	{"func_glass", SP_func_glass, Logical_False},
 	{"func_usable", SP_func_usable, Logical_False, &func_usable_info},
-	{"func_wall", SP_func_wall, Logical_False},
+	{"func_wall", SP_func_wall, Logical_False, &func_wall_info},
 
 	// Triggers are brush objects that cause an effect when contacted
 	// by a living player, usually involving firing targets.

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -454,6 +454,7 @@ extern entityInfo_t target_level_change_info;
 void SP_target_play_music( gentity_t *self );
 extern entityInfo_t target_play_music_info;
 void SP_target_push (gentity_t *ent);
+extern entityInfo_t target_push_info;
 
 void SP_light (gentity_t *self);
 extern entityInfo_t SP_light_info;
@@ -943,7 +944,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_deactivate", SP_target_deactivate, Logical_True, &target_deactivate_info},
 	{"target_level_change", SP_target_level_change, Logical_True, &target_level_change_info},
 	{"target_play_music", SP_target_play_music, Logical_True, &target_play_music_info},
-	{"target_push", SP_target_push, Logical_True},
+	{"target_push", SP_target_push, Logical_True, &target_push_info},
 	{"target_powerup", SP_target_powerup, Logical_True}, //Lugormod
 
 	{"light", SP_light, Logical_True, &SP_light_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -441,7 +441,9 @@ extern entityInfo_t target_location_info;
 void SP_target_counter (gentity_t *self);
 extern entityInfo_t target_counter_info;
 void SP_target_random (gentity_t *self);
+extern entityInfo_t target_random_info;
 void SP_target_scriptrunner( gentity_t *self );
+extern entityInfo_t target_scriptrunner_info;
 void SP_target_interest (gentity_t *self);
 void SP_target_activate (gentity_t *self);
 void SP_target_deactivate (gentity_t *self);
@@ -930,8 +932,8 @@ spawn_t	spawnInitValues[] = {
 	{"target_position", SP_target_position, Logical_True, &target_position_info},
 	{"target_location", SP_target_location, Logical_True, &target_location_info},
 	{"target_counter", SP_target_counter, Logical_True, &target_counter_info},
-	{"target_random", SP_target_random, Logical_True},
-	{"target_scriptrunner", SP_target_scriptrunner, qfalse},
+	{"target_random", SP_target_random, Logical_True, &target_random_info},
+	{"target_scriptrunner", SP_target_scriptrunner, qfalse, &target_scriptrunner_info},
 	{"target_interest", SP_target_interest, Logical_True},
 	{"target_activate", SP_target_activate, Logical_True},
 	{"target_deactivate", SP_target_deactivate, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -424,6 +424,7 @@ extern entityInfo_t target_speaker_info;
 void SP_target_print (gentity_t *ent);
 extern entityInfo_t target_print_info;
 void SP_target_laser (gentity_t *self);
+extern entityInfo_t target_laser_info;
 void SP_target_character (gentity_t *ent);
 void SP_target_score( gentity_t *ent );
 void SP_target_teleporter( gentity_t *ent );
@@ -914,7 +915,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_delay", SP_target_delay, Logical_True, &target_delay_info},
 	{"target_speaker", SP_target_speaker, {qtrue, target_speaker_allowlogical}, &target_speaker_info},
 	{"target_print", SP_target_print, Logical_True, &target_print_info},
-	{"target_laser", SP_target_laser, Logical_True},
+	{"target_laser", SP_target_laser, Logical_True, &target_laser_info},
 	{"target_score", SP_target_score, Logical_True},
 	{"target_teleporter", SP_target_teleporter, Logical_True},
 	{"target_relay", SP_target_relay, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -334,10 +334,15 @@ void SP_info_thirdplace(gentity_t *ent);
 void SP_info_podium(gentity_t *ent);
 
 void SP_info_siege_objective (gentity_t *ent);
+extern entityInfo_t info_siege_objective_info;
 void SP_info_siege_radaricon (gentity_t *ent);
+extern entityInfo_t info_siege_radaricon_info;
 void SP_info_siege_decomplete (gentity_t *ent);
+extern entityInfo_t info_siege_decomplete_info;
 void SP_target_siege_end (gentity_t *ent);
+extern entityInfo_t target_siege_end_info;
 void SP_misc_siege_item (gentity_t *ent);
+extern entityInfo_t misc_siege_item_info;
 void SP_target_powerup (gentity_t *ent);
 
 void SP_func_plat (gentity_t *ent);
@@ -845,11 +850,11 @@ spawn_t	spawnInitValues[] = {
 	{"info_notnull", SP_info_notnull, Logical_True, &SP_info_notnull_info},		// use target_position instead
 	{"info_camp", SP_info_camp, Logical_True, &SP_info_camp_info},
 
-	{"info_siege_objective", SP_info_siege_objective, Logical_False},
-	{"info_siege_radaricon", SP_info_siege_radaricon, Logical_False},
-	{"info_siege_decomplete", SP_info_siege_decomplete, Logical_True},
-	{"target_siege_end", SP_target_siege_end, Logical_True},
-	{"misc_siege_item", SP_misc_siege_item, Logical_False},
+	{"info_siege_objective", SP_info_siege_objective, Logical_False, &info_siege_objective_info},
+	{"info_siege_radaricon", SP_info_siege_radaricon, Logical_False, &info_siege_radaricon_info},
+	{"info_siege_decomplete", SP_info_siege_decomplete, Logical_True, &info_siege_decomplete_info},
+	{"target_siege_end", SP_target_siege_end, Logical_True, &target_siege_end_info},
+	{"misc_siege_item", SP_misc_siege_item, Logical_False, &misc_siege_item_info},
 
   // TODO: Info keys
 	{"func_plat", SP_func_plat, Logical_False, &func_plat_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -288,6 +288,7 @@ extern entityInfo_t target_credits_info; // Lugormod
 void SP_random_spot (gentity_t *ent); //Lugormod
 extern entityInfo_t random_spot_info; //Lugormod
 void SP_money_dispenser (gentity_t *ent); //Lugormod
+extern entityInfo_t money_dispenser_info; //Lugormod
 void SP_control_point (gentity_t *ent); //Lugormod
 void SP_misc_camera (gentity_t *ent); //Lugormod
 void SP_info_player_jail (gentity_t *ent); //Lugormod
@@ -1028,7 +1029,7 @@ spawn_t	spawnInitValues[] = {
 	{"misc_turretG2", SP_misc_turretG2, Logical_False},
 	{"misc_camera", SP_misc_camera, Logical_False},//Lugormod
 	{"random_spot", SP_random_spot, Logical_True, &random_spot_info},//Lugormod
-	{"money_dispenser", SP_money_dispenser, Logical_False},//Lugormod
+	{"money_dispenser", SP_money_dispenser, Logical_False, &money_dispenser_info},//Lugormod
 	{"control_point", SP_control_point, Logical_False},//Lugormod
 	{"emplaced_eweb", SP_emplaced_gun, Logical_False},//Lugormod
 	{"target_fixdoor", SP_target_fixdoor, Logical_False, &target_fixdoor_info}, //Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -429,6 +429,7 @@ void SP_target_character (gentity_t *ent); // no doc
 void SP_target_score( gentity_t *ent );
 extern entityInfo_t target_score_info;
 void SP_target_teleporter( gentity_t *ent );
+extern entityInfo_t target_teleporter_info;
 void SP_target_relay (gentity_t *ent);
 void SP_target_kill (gentity_t *ent);
 void SP_target_position (gentity_t *ent);
@@ -918,7 +919,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_print", SP_target_print, Logical_True, &target_print_info},
 	{"target_laser", SP_target_laser, Logical_True, &target_laser_info},
 	{"target_score", SP_target_score, Logical_True, &target_score_info},
-	{"target_teleporter", SP_target_teleporter, Logical_True},
+	{"target_teleporter", SP_target_teleporter, Logical_True, &target_teleporter_info},
 	{"target_relay", SP_target_relay, Logical_True},
 	{"target_kill", SP_target_kill, Logical_True},
 	{"target_position", SP_target_position, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -404,6 +404,7 @@ extern entityInfo_t trigger_asteroid_field_info;
 void SP_trigger_always (gentity_t *ent);
 extern entityInfo_t trigger_always_info;
 void SP_trigger_visible (gentity_t *ent);
+extern entityInfo_t trigger_visible_info;
 void SP_trigger_teleport (gentity_t *ent);
 extern entityInfo_t trigger_teleport_info;
 void SP_trigger_hurt (gentity_t *ent);
@@ -898,7 +899,7 @@ spawn_t	spawnInitValues[] = {
 	{"trigger_teleport", SP_trigger_teleport, Logical_False, &trigger_teleport_info},
 	{"trigger_hurt", SP_trigger_hurt, Logical_False, &trigger_hurt_info},
 	{"trigger_always", SP_trigger_always, Logical_True, &trigger_always_info},
-	{"trigger_visible", SP_trigger_visible, Logical_True},
+	{"trigger_visible", SP_trigger_visible, Logical_True, &trigger_visible_info},
 
 
 	// targets perform no action by themselves, but must be triggered

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -558,10 +558,10 @@ void SP_team_CTF_blueplayer( gentity_t *ent );
 void SP_team_CTF_redspawn( gentity_t *ent );
 void SP_team_CTF_bluespawn( gentity_t *ent );
 
-extern entityInfo_t misc_turret_info;
 void SP_misc_turret( gentity_t *ent );
-
+extern entityInfo_t misc_turret_info;
 void SP_misc_turretG2( gentity_t *base );
+extern entityInfo_t misc_turretG2_info;
 void SP_misc_slotmachine (gentity_t *ent);//Lugormod
 void SP_ghost_exit (gentity_t *ent);//Lugormod
 void SP_target_fixdoor (gentity_t *ent); //Lugormod
@@ -1027,8 +1027,8 @@ spawn_t	spawnInitValues[] = {
 
 	{"emplaced_gun", SP_emplaced_gun, Logical_False, &emplaced_gun_info},
 
-	{"misc_turret", SP_misc_turret, Logical_False, &misc_turret_info },
-	{"misc_turretG2", SP_misc_turretG2, Logical_False},
+	{"misc_turret", SP_misc_turret, Logical_False, &misc_turret_info},
+	{"misc_turretG2", SP_misc_turretG2, Logical_False, &misc_turretG2_info},
 	{"misc_camera", SP_misc_camera, Logical_False},//Lugormod
 	{"random_spot", SP_random_spot, Logical_True, &random_spot_info},//Lugormod
 	{"money_dispenser", SP_money_dispenser, Logical_False, &money_dispenser_info},//Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -290,6 +290,7 @@ extern entityInfo_t random_spot_info; //Lugormod
 void SP_money_dispenser (gentity_t *ent); //Lugormod
 extern entityInfo_t money_dispenser_info; //Lugormod
 void SP_control_point (gentity_t *ent); //Lugormod
+extern entityInfo_t control_point_info; //Lugormod
 void SP_misc_camera (gentity_t *ent); //Lugormod
 void SP_info_player_jail (gentity_t *ent); //Lugormod
 extern entityInfo_t info_player_jail_info; //Lugormod
@@ -1030,7 +1031,7 @@ spawn_t	spawnInitValues[] = {
 	{"misc_camera", SP_misc_camera, Logical_False},//Lugormod
 	{"random_spot", SP_random_spot, Logical_True, &random_spot_info},//Lugormod
 	{"money_dispenser", SP_money_dispenser, Logical_False, &money_dispenser_info},//Lugormod
-	{"control_point", SP_control_point, Logical_False},//Lugormod
+	{"control_point", SP_control_point, Logical_False, &control_point_info},//Lugormod
 	{"emplaced_eweb", SP_emplaced_gun, Logical_False},//Lugormod
 	{"target_fixdoor", SP_target_fixdoor, Logical_False, &target_fixdoor_info}, //Lugormod
 	{"target_credits", SP_target_credits, Logical_True, &target_credits_info}, //Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -404,7 +404,9 @@ extern entityInfo_t trigger_asteroid_field_info;
 void SP_trigger_always (gentity_t *ent);
 void SP_trigger_visible (gentity_t *ent);
 void SP_trigger_teleport (gentity_t *ent);
+extern entityInfo_t trigger_teleport_info;
 void SP_trigger_hurt (gentity_t *ent);
+extern entityInfo_t trigger_hurt_info;
 
 void SP_target_remove_powerups( gentity_t *ent );
 void SP_target_give (gentity_t *ent);
@@ -892,8 +894,8 @@ spawn_t	spawnInitValues[] = {
 	{"trigger_hyperspace", SP_trigger_hyperspace, Logical_False, &trigger_hyperspace_info},
 	{"trigger_asteroid_field", SP_trigger_asteroid_field, Logical_False, &trigger_asteroid_field_info},
 
-	{"trigger_teleport", SP_trigger_teleport, Logical_False},
-	{"trigger_hurt", SP_trigger_hurt, Logical_False},
+	{"trigger_teleport", SP_trigger_teleport, Logical_False, &trigger_teleport_info},
+	{"trigger_hurt", SP_trigger_hurt, Logical_False, &trigger_hurt_info},
 	{"trigger_always", SP_trigger_always, Logical_True},
 	{"trigger_visible", SP_trigger_visible, Logical_True},
 

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -281,6 +281,7 @@ void SP_gametype_item ( gentity_t* ent )
 }
 
 void SP_emplaced_gun( gentity_t *ent );
+extern entityInfo_t emplaced_gun_info;
 #define SP (~(1 << GT_SINGLE_PLAYER) & ~(1 << GT_SIEGE))
 
 void SP_target_credits( gentity_t *ent ); //Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -431,6 +431,7 @@ extern entityInfo_t target_score_info;
 void SP_target_teleporter( gentity_t *ent );
 extern entityInfo_t target_teleporter_info;
 void SP_target_relay (gentity_t *ent);
+extern entityInfo_t target_relay_info;
 void SP_target_kill (gentity_t *ent);
 void SP_target_position (gentity_t *ent);
 void SP_target_location (gentity_t *ent);
@@ -920,7 +921,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_laser", SP_target_laser, Logical_True, &target_laser_info},
 	{"target_score", SP_target_score, Logical_True, &target_score_info},
 	{"target_teleporter", SP_target_teleporter, Logical_True, &target_teleporter_info},
-	{"target_relay", SP_target_relay, Logical_True},
+	{"target_relay", SP_target_relay, Logical_True, &target_relay_info},
 	{"target_kill", SP_target_kill, Logical_True},
 	{"target_position", SP_target_position, Logical_True},
 	{"target_location", SP_target_location, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -328,15 +328,15 @@ void SP_target_powerup (gentity_t *ent);
 
 void SP_func_plat (gentity_t *ent);
 extern entityInfo_t func_plat_info;
-
 void SP_func_static (gentity_t *ent);
 extern entityInfo_t func_static_info;
-
 void SP_func_rotating (gentity_t *ent);
 extern entityInfo_t func_rotating_info;
-
 void SP_func_bobbing (gentity_t *ent);
+extern entityInfo_t func_bobbing_info;
+
 void SP_func_pendulum( gentity_t *ent );
+
 void SP_func_button (gentity_t *ent);
 
 void SP_func_door (gentity_t *ent);
@@ -798,7 +798,7 @@ spawn_t	spawnInitValues[] = {
 	{"func_door", SP_func_door, Logical_False, &func_door_info},
 	{"func_static", SP_func_static, Logical_False, &func_static_info},
 	{"func_rotating", SP_func_rotating, Logical_False, &func_rotating_info},
-	{"func_bobbing", SP_func_bobbing, Logical_False},
+	{"func_bobbing", SP_func_bobbing, Logical_False, &func_bobbing_info},
 	{"func_pendulum", SP_func_pendulum, Logical_False},
 	{"func_train", SP_func_train, Logical_False, &func_train_info},
 	{"func_group", SP_info_null, Logical_False},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -468,6 +468,7 @@ void SP_LMD_spawner( gentity_t *NPCspawner );
 extern entityInfo_t LMD_spawner_info;
 
 void SP_NPC_Vehicle( gentity_t *self);
+extern entityInfo_t NPC_Vehicle_info;
 
 void SP_NPC_Kyle( gentity_t *self );
 void SP_NPC_Lando( gentity_t *self );
@@ -922,7 +923,7 @@ spawn_t	spawnInitValues[] = {
 
 	//new NPC ents
 	{"NPC_spawner", SP_NPC_spawner, Logical_True, &NPC_spawner_info},
-	{"NPC_Vehicle", SP_NPC_Vehicle, Logical_True},
+	{"NPC_Vehicle", SP_NPC_Vehicle, Logical_True, &NPC_Vehicle_info},
 	{"NPC_Kyle", SP_NPC_Kyle, Logical_True},
 	{"NPC_Lando", SP_NPC_Lando, Logical_True},
 	{"NPC_Jan", SP_NPC_Jan, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -331,14 +331,20 @@ extern entityInfo_t func_plat_info;
 
 void SP_func_static (gentity_t *ent);
 extern entityInfo_t func_static_info;
+
 void SP_func_rotating (gentity_t *ent);
 extern entityInfo_t func_rotating_info;
+
 void SP_func_bobbing (gentity_t *ent);
 void SP_func_pendulum( gentity_t *ent );
 void SP_func_button (gentity_t *ent);
+
 void SP_func_door (gentity_t *ent);
 extern entityInfo_t func_door_info;
+
 void SP_func_train (gentity_t *ent);
+extern entityInfo_t func_train_info;
+
 void SP_func_timer (gentity_t *self);
 void SP_func_breakable (gentity_t *ent);
 void SP_func_glass (gentity_t *ent);
@@ -791,7 +797,7 @@ spawn_t	spawnInitValues[] = {
 	{"func_rotating", SP_func_rotating, Logical_False, &func_rotating_info},
 	{"func_bobbing", SP_func_bobbing, Logical_False},
 	{"func_pendulum", SP_func_pendulum, Logical_False},
-	{"func_train", SP_func_train, Logical_False},
+	{"func_train", SP_func_train, Logical_False, &func_train_info},
 	{"func_group", SP_info_null, Logical_False},
 	{"func_timer", SP_func_timer, Logical_False},			// rename trigger_timer?
 	{"func_breakable", SP_func_breakable, Logical_False},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -448,6 +448,7 @@ void SP_target_interest (gentity_t *self);
 void SP_target_activate (gentity_t *self);
 extern entityInfo_t target_activate_info;
 void SP_target_deactivate (gentity_t *self);
+extern entityInfo_t target_deactivate_info;
 void SP_target_level_change( gentity_t *self );
 void SP_target_play_music( gentity_t *self );
 void SP_target_push (gentity_t *ent);
@@ -937,7 +938,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_scriptrunner", SP_target_scriptrunner, qfalse, &target_scriptrunner_info},
 	{"target_interest", SP_target_interest, Logical_True},
 	{"target_activate", SP_target_activate, Logical_True, &target_activate_info},
-	{"target_deactivate", SP_target_deactivate, Logical_True},
+	{"target_deactivate", SP_target_deactivate, Logical_True, &target_deactivate_info},
 	{"target_level_change", SP_target_level_change, Logical_True},
 	{"target_play_music", SP_target_play_music, Logical_True},
 	{"target_push", SP_target_push, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -446,6 +446,7 @@ void SP_target_scriptrunner( gentity_t *self );
 extern entityInfo_t target_scriptrunner_info;
 void SP_target_interest (gentity_t *self);
 void SP_target_activate (gentity_t *self);
+extern entityInfo_t target_activate_info;
 void SP_target_deactivate (gentity_t *self);
 void SP_target_level_change( gentity_t *self );
 void SP_target_play_music( gentity_t *self );
@@ -935,7 +936,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_random", SP_target_random, Logical_True, &target_random_info},
 	{"target_scriptrunner", SP_target_scriptrunner, qfalse, &target_scriptrunner_info},
 	{"target_interest", SP_target_interest, Logical_True},
-	{"target_activate", SP_target_activate, Logical_True},
+	{"target_activate", SP_target_activate, Logical_True, &target_activate_info},
 	{"target_deactivate", SP_target_deactivate, Logical_True},
 	{"target_level_change", SP_target_level_change, Logical_True},
 	{"target_play_music", SP_target_play_music, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -346,6 +346,7 @@ extern entityInfo_t func_train_info;
 void SP_func_timer (gentity_t *self);
 void SP_func_breakable (gentity_t *ent);
 void SP_func_glass (gentity_t *ent);
+extern entityInfo_t func_glass_info;
 void SP_func_usable( gentity_t *ent);
 extern entityInfo_t func_usable_info;
 void SP_func_wall( gentity_t *ent );
@@ -804,7 +805,7 @@ spawn_t	spawnInitValues[] = {
 	{"func_group", SP_info_null, Logical_False},
 	{"func_timer", SP_func_timer, Logical_False},			// rename trigger_timer?
 	{"func_breakable", SP_func_breakable, Logical_False},
-	{"func_glass", SP_func_glass, Logical_False},
+	{"func_glass", SP_func_glass, Logical_False, &func_glass_info},
 	{"func_usable", SP_func_usable, Logical_False, &func_usable_info},
 	{"func_wall", SP_func_wall, Logical_False, &func_wall_info},
 

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -334,15 +334,12 @@ void SP_func_rotating (gentity_t *ent);
 extern entityInfo_t func_rotating_info;
 void SP_func_bobbing (gentity_t *ent);
 extern entityInfo_t func_bobbing_info;
-
 void SP_func_pendulum( gentity_t *ent );
-
+extern entityInfo_t func_pendulum_info;
 void SP_func_button (gentity_t *ent);
 extern entityInfo_t func_button_info;
-
 void SP_func_door (gentity_t *ent);
 extern entityInfo_t func_door_info;
-
 void SP_func_train (gentity_t *ent);
 extern entityInfo_t func_train_info;
 
@@ -799,8 +796,8 @@ spawn_t	spawnInitValues[] = {
 	{"func_door", SP_func_door, Logical_False, &func_door_info},
 	{"func_static", SP_func_static, Logical_False, &func_static_info},
 	{"func_rotating", SP_func_rotating, Logical_False, &func_rotating_info},
-	{"func_bobbing", SP_func_bobbing, Logical_False},
-	{"func_pendulum", SP_func_pendulum, Logical_False},
+	{"func_bobbing", SP_func_bobbing, Logical_False, &func_bobbing_info},
+	{"func_pendulum", SP_func_pendulum, Logical_False, &func_pendulum_info},
 	{"func_train", SP_func_train, Logical_False, &func_train_info},
 	{"func_group", SP_info_null, Logical_False},
 	{"func_timer", SP_func_timer, Logical_False},			// rename trigger_timer?

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -344,6 +344,7 @@ extern entityInfo_t target_siege_end_info;
 void SP_misc_siege_item (gentity_t *ent);
 extern entityInfo_t misc_siege_item_info;
 void SP_target_powerup (gentity_t *ent);
+extern entityInfo_t target_powerup_info;
 
 void SP_func_plat (gentity_t *ent);
 extern entityInfo_t func_plat_info;
@@ -945,7 +946,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_level_change", SP_target_level_change, Logical_True, &target_level_change_info},
 	{"target_play_music", SP_target_play_music, Logical_True, &target_play_music_info},
 	{"target_push", SP_target_push, Logical_True, &target_push_info},
-	{"target_powerup", SP_target_powerup, Logical_True}, //Lugormod
+	{"target_powerup", SP_target_powerup, Logical_True, &target_powerup_info}, //Lugormod
 
 	{"light", SP_light, Logical_True, &SP_light_info},
 	{"path_corner", SP_path_corner, Logical_True, &path_corner_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -419,8 +419,10 @@ extern entityInfo_t target_delay_info;
 
 qboolean target_speaker_allowlogical();
 void SP_target_speaker (gentity_t *ent);
+extern entityInfo_t target_speaker_info;
 
 void SP_target_print (gentity_t *ent);
+extern entityInfo_t target_print_info;
 void SP_target_laser (gentity_t *self);
 void SP_target_character (gentity_t *ent);
 void SP_target_score( gentity_t *ent );
@@ -910,8 +912,8 @@ spawn_t	spawnInitValues[] = {
 	{"target_give", SP_target_give, Logical_True, &target_give_info},
 	{"target_remove_powerups", SP_target_remove_powerups, Logical_True, &target_remove_powerups_info},
 	{"target_delay", SP_target_delay, Logical_True, &target_delay_info},
-	{"target_speaker", SP_target_speaker, {qtrue, target_speaker_allowlogical}},
-	{"target_print", SP_target_print, Logical_True},
+	{"target_speaker", SP_target_speaker, {qtrue, target_speaker_allowlogical}, &target_speaker_info},
+	{"target_print", SP_target_print, Logical_True, &target_print_info},
 	{"target_laser", SP_target_laser, Logical_True},
 	{"target_score", SP_target_score, Logical_True},
 	{"target_teleporter", SP_target_teleporter, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -411,8 +411,11 @@ void SP_trigger_hurt (gentity_t *ent);
 extern entityInfo_t trigger_hurt_info;
 
 void SP_target_remove_powerups( gentity_t *ent );
+extern entityInfo_t target_remove_powerups_info;
 void SP_target_give (gentity_t *ent);
+extern entityInfo_t target_give_info;
 void SP_target_delay (gentity_t *ent);
+extern entityInfo_t target_delay_info;
 
 qboolean target_speaker_allowlogical();
 void SP_target_speaker (gentity_t *ent);
@@ -904,9 +907,9 @@ spawn_t	spawnInitValues[] = {
 
 	// targets perform no action by themselves, but must be triggered
 	// by another entity
-	{"target_give", SP_target_give, Logical_True},
-	{"target_remove_powerups", SP_target_remove_powerups, Logical_True},
-	{"target_delay", SP_target_delay, Logical_True},
+	{"target_give", SP_target_give, Logical_True, &target_give_info},
+	{"target_remove_powerups", SP_target_remove_powerups, Logical_True, &target_remove_powerups_info},
+	{"target_delay", SP_target_delay, Logical_True, &target_delay_info},
 	{"target_speaker", SP_target_speaker, {qtrue, target_speaker_allowlogical}},
 	{"target_print", SP_target_print, Logical_True},
 	{"target_laser", SP_target_laser, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -330,11 +330,13 @@ void SP_func_plat (gentity_t *ent);
 extern entityInfo_t func_plat_info;
 
 void SP_func_static (gentity_t *ent);
+extern entityInfo_t func_static_info;
 void SP_func_rotating (gentity_t *ent);
 void SP_func_bobbing (gentity_t *ent);
 void SP_func_pendulum( gentity_t *ent );
 void SP_func_button (gentity_t *ent);
 void SP_func_door (gentity_t *ent);
+extern entityInfo_t func_door_info;
 void SP_func_train (gentity_t *ent);
 void SP_func_timer (gentity_t *self);
 void SP_func_breakable (gentity_t *ent);
@@ -731,6 +733,7 @@ spawn_t	spawnInitValues[] = {
 
 	{"lmd_scale", lmd_scale, Logical_True, &lmd_scale_info},
 
+  // TODO: info keys
 	{"lmd_stashdepo", lmd_stashdepo, Logical_False},
 	{"lmd_stashspawnpoint", lmd_stashspawnpoint, Logical_True},
 	{"lmd_stashzone", lmd_stashzone, Logical_False},
@@ -759,7 +762,9 @@ spawn_t	spawnInitValues[] = {
 	{"info_player_duel1", SP_info_player_duel1, Logical_True, &info_player_duel1_info},
 	{"info_player_duel2", SP_info_player_duel2, Logical_True, &info_player_duel2_info},
 	{"info_player_deathmatch", SP_info_player_deathmatch, Logical_True, &info_player_deathmatch_info},
-	{"info_player_siegeteam1", SP_info_player_siegeteam1, Logical_True},
+	
+  // TODO: Info keys
+  {"info_player_siegeteam1", SP_info_player_siegeteam1, Logical_True},
 	{"info_player_siegeteam2", SP_info_player_siegeteam2, Logical_True},
 	{"info_player_intermission", SP_info_player_intermission, Logical_True},
 	{"info_player_intermission_red", SP_info_player_intermission_red, Logical_True},
@@ -777,9 +782,10 @@ spawn_t	spawnInitValues[] = {
 	{"target_siege_end", SP_target_siege_end, Logical_True},
 	{"misc_siege_item", SP_misc_siege_item, Logical_False},
 
+  // TODO: Info keys
 	{"func_plat", SP_func_plat, Logical_False, &func_plat_info},
 	{"func_button", SP_func_button, Logical_False},
-	{"func_door", SP_func_door, Logical_False},
+	{"func_door", SP_func_door, Logical_False, &func_door_info},
 	{"func_static", SP_func_static, Logical_False},
 	{"func_rotating", SP_func_rotating, Logical_False},
 	{"func_bobbing", SP_func_bobbing, Logical_False},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -439,6 +439,7 @@ extern entityInfo_t target_position_info;
 void SP_target_location (gentity_t *ent);
 extern entityInfo_t target_location_info;
 void SP_target_counter (gentity_t *self);
+extern entityInfo_t target_counter_info;
 void SP_target_random (gentity_t *self);
 void SP_target_scriptrunner( gentity_t *self );
 void SP_target_interest (gentity_t *self);
@@ -928,7 +929,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_kill", SP_target_kill, Logical_True, &target_kill_info},
 	{"target_position", SP_target_position, Logical_True, &target_position_info},
 	{"target_location", SP_target_location, Logical_True, &target_location_info},
-	{"target_counter", SP_target_counter, Logical_True},
+	{"target_counter", SP_target_counter, Logical_True, &target_counter_info},
 	{"target_random", SP_target_random, Logical_True},
 	{"target_scriptrunner", SP_target_scriptrunner, qfalse},
 	{"target_interest", SP_target_interest, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -505,7 +505,7 @@ extern entityInfo_t misc_ammo_floor_unit_info;
 void SP_misc_shield_floor_unit( gentity_t *ent );
 extern entityInfo_t misc_shield_floor_unit_info;
 void SP_misc_model_shield_power_converter( gentity_t *ent );
-extern entityInfo_t misc_model_shield_power_convert_info;
+extern entityInfo_t misc_model_shield_power_converter_info;
 void SP_misc_model_ammo_power_converter( gentity_t *ent );
 extern entityInfo_t misc_model_ammo_power_converter_info;
 void SP_misc_model_health_power_converter( gentity_t *ent );
@@ -975,7 +975,7 @@ spawn_t	spawnInitValues[] = {
 
 	{"misc_ammo_floor_unit", SP_misc_ammo_floor_unit, Logical_False, &misc_ammo_floor_unit_info},
 	{"misc_shield_floor_unit", SP_misc_shield_floor_unit, Logical_False, &misc_shield_floor_unit_info},
-	{"misc_model_shield_power_converter", SP_misc_model_shield_power_converter, Logical_False, &misc_model_shield_power_convert_info},
+	{"misc_model_shield_power_converter", SP_misc_model_shield_power_converter, Logical_False, &misc_model_shield_power_converter_info},
 	{"misc_model_ammo_power_converter", SP_misc_model_ammo_power_converter, Logical_False, &misc_model_ammo_power_converter_info},
 	{"misc_model_health_power_converter", SP_misc_model_health_power_converter, Logical_False, &misc_model_health_power_converter_info},
 

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -402,6 +402,7 @@ void SP_trigger_asteroid_field(gentity_t *self);
 extern entityInfo_t trigger_asteroid_field_info;
 
 void SP_trigger_always (gentity_t *ent);
+extern entityInfo_t trigger_always_info;
 void SP_trigger_visible (gentity_t *ent);
 void SP_trigger_teleport (gentity_t *ent);
 extern entityInfo_t trigger_teleport_info;
@@ -896,7 +897,7 @@ spawn_t	spawnInitValues[] = {
 
 	{"trigger_teleport", SP_trigger_teleport, Logical_False, &trigger_teleport_info},
 	{"trigger_hurt", SP_trigger_hurt, Logical_False, &trigger_hurt_info},
-	{"trigger_always", SP_trigger_always, Logical_True},
+	{"trigger_always", SP_trigger_always, Logical_True, &trigger_always_info},
 	{"trigger_visible", SP_trigger_visible, Logical_True},
 
 

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -284,13 +284,14 @@ void SP_emplaced_gun( gentity_t *ent );
 #define SP (~(1 << GT_SINGLE_PLAYER) & ~(1 << GT_SIEGE))
 
 void SP_target_credits( gentity_t *ent ); //Lugormod
+extern entityInfo_t target_credits_info; // Lugormod
 void SP_random_spot (gentity_t *ent); //Lugormod
 extern entityInfo_t random_spot_info; //Lugormod
-void SP_money_dispenser (gentity_t *ent);//Lugormod
-void SP_control_point (gentity_t *ent);//Lugormod
+void SP_money_dispenser (gentity_t *ent); //Lugormod
+void SP_control_point (gentity_t *ent); //Lugormod
 void SP_misc_camera (gentity_t *ent); //Lugormod
 void SP_info_player_jail (gentity_t *ent); //Lugormod
-extern entityInfo_t info_player_jail_info;
+extern entityInfo_t info_player_jail_info; //Lugormod
 
 void SP_info_player_start (gentity_t *ent);
 extern entityInfo_t info_player_start_info;
@@ -1031,7 +1032,7 @@ spawn_t	spawnInitValues[] = {
 	{"control_point", SP_control_point, Logical_False},//Lugormod
 	{"emplaced_eweb", SP_emplaced_gun, Logical_False},//Lugormod
 	{"target_fixdoor", SP_target_fixdoor, Logical_False, &target_fixdoor_info}, //Lugormod
-	{"target_credits", SP_target_credits, Logical_True}, //Lugormod
+	{"target_credits", SP_target_credits, Logical_True, &target_credits_info}, //Lugormod
 	{"rail_mover", SP_rail_mover, Logical_False, &rail_mover_info}, //Lugormod
 	{"rail_track", SP_rail_track, Logical_True, &rail_track_info}, //Lugormod
 	{"rail_lane", SP_rail_lane, Logical_True, &rail_lane_info}, //Lugormod

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -450,7 +450,9 @@ extern entityInfo_t target_activate_info;
 void SP_target_deactivate (gentity_t *self);
 extern entityInfo_t target_deactivate_info;
 void SP_target_level_change( gentity_t *self );
+extern entityInfo_t target_level_change_info;
 void SP_target_play_music( gentity_t *self );
+extern entityInfo_t target_play_music_info;
 void SP_target_push (gentity_t *ent);
 
 void SP_light (gentity_t *self);
@@ -939,8 +941,8 @@ spawn_t	spawnInitValues[] = {
 	{"target_interest", SP_target_interest, Logical_True},
 	{"target_activate", SP_target_activate, Logical_True, &target_activate_info},
 	{"target_deactivate", SP_target_deactivate, Logical_True, &target_deactivate_info},
-	{"target_level_change", SP_target_level_change, Logical_True},
-	{"target_play_music", SP_target_play_music, Logical_True},
+	{"target_level_change", SP_target_level_change, Logical_True, &target_level_change_info},
+	{"target_play_music", SP_target_play_music, Logical_True, &target_play_music_info},
 	{"target_push", SP_target_push, Logical_True},
 	{"target_powerup", SP_target_powerup, Logical_True}, //Lugormod
 

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -317,9 +317,13 @@ extern entityInfo_t info_player_siegeteam1_info;
 void SP_info_player_siegeteam2 (gentity_t *ent);
 extern entityInfo_t info_player_siegeteam2_info;
 void SP_info_player_intermission (gentity_t *ent);
+extern entityInfo_t info_player_intermission_info;
 void SP_info_player_intermission_red (gentity_t *ent);
+extern entityInfo_t info_player_intermission_red_info;
 void SP_info_player_intermission_blue (gentity_t *ent);
+extern entityInfo_t info_player_intermission_blue_info;
 void SP_info_jedimaster_start (gentity_t *ent);
+extern entityInfo_t info_jedimaster_start_info;
 void SP_info_player_start_red (gentity_t *ent);
 void SP_info_player_start_blue (gentity_t *ent);
 void SP_info_firstplace(gentity_t *ent);
@@ -829,10 +833,10 @@ spawn_t	spawnInitValues[] = {
   // TODO: Info keys
   	{"info_player_siegeteam1", SP_info_player_siegeteam1, Logical_True, &info_player_siegeteam1_info},
 	{"info_player_siegeteam2", SP_info_player_siegeteam2, Logical_True, &info_player_siegeteam2_info},
-	{"info_player_intermission", SP_info_player_intermission, Logical_True},
-	{"info_player_intermission_red", SP_info_player_intermission_red, Logical_True},
-	{"info_player_intermission_blue", SP_info_player_intermission_blue, Logical_True},
-	{"info_jedimaster_start", SP_info_jedimaster_start, Logical_True},
+	{"info_player_intermission", SP_info_player_intermission, Logical_True, &info_player_intermission_info},
+	{"info_player_intermission_red", SP_info_player_intermission_red, Logical_True, &info_player_intermission_red_info},
+	{"info_player_intermission_blue", SP_info_player_intermission_blue, Logical_True, &info_player_intermission_blue_info},
+	{"info_jedimaster_start", SP_info_jedimaster_start, Logical_True, &info_jedimaster_start_info,
 	{"info_player_start_red", SP_info_player_start_red, Logical_True},
 	{"info_player_start_blue", SP_info_player_start_blue, Logical_True},
 	{"info_null", SP_info_null, Logical_True, &SP_info_null_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -363,6 +363,7 @@ void SP_func_train (gentity_t *ent);
 extern entityInfo_t func_train_info;
 
 void SP_func_timer (gentity_t *self);
+extern entityInfo_t func_timer_info;
 void SP_func_breakable (gentity_t *ent);
 extern entityInfo_t func_breakable_info;
 void SP_func_glass (gentity_t *ent);
@@ -394,8 +395,11 @@ extern entityInfo_t trigger_push_info;
 void SP_trigger_space(gentity_t *self);
 extern entityInfo_t trigger_space_info;
 void SP_trigger_shipboundary(gentity_t *self);
+extern entityInfo_t trigger_shipboundary_info;
 void SP_trigger_hyperspace(gentity_t *self);
+extern entityInfo_t trigger_hyperspace_info;
 void SP_trigger_asteroid_field(gentity_t *self);
+extern entityInfo_t trigger_asteroid_field_info;
 
 void SP_trigger_always (gentity_t *ent);
 void SP_trigger_visible (gentity_t *ent);
@@ -866,7 +870,7 @@ spawn_t	spawnInitValues[] = {
 	{"func_pendulum", SP_func_pendulum, Logical_False, &func_pendulum_info},
 	{"func_train", SP_func_train, Logical_False, &func_train_info},
 	{"func_group", SP_info_null, Logical_False, &SP_info_null_info},
-	{"func_timer", SP_func_timer, Logical_False},			// rename trigger_timer?
+	{"func_timer", SP_func_timer, Logical_False, &func_timer_info},			// rename trigger_timer?
 	{"func_breakable", SP_func_breakable, Logical_False, &func_breakable_info},
 	{"func_glass", SP_func_glass, Logical_False, &func_glass_info},
 	{"func_usable", SP_func_usable, Logical_False, &func_usable_info},
@@ -884,9 +888,9 @@ spawn_t	spawnInitValues[] = {
 	{"trigger_push", SP_trigger_push, Logical_False, &trigger_push_info},
 
 	{"trigger_space", SP_trigger_space, Logical_False, &trigger_space_info},
-	{"trigger_shipboundary", SP_trigger_shipboundary, Logical_False},
-	{"trigger_hyperspace", SP_trigger_hyperspace, Logical_False},
-	{"trigger_asteroid_field", SP_trigger_asteroid_field, Logical_False},
+	{"trigger_shipboundary", SP_trigger_shipboundary, Logical_False, &trigger_shipboundary_info},
+	{"trigger_hyperspace", SP_trigger_hyperspace, Logical_False, &trigger_hyperspace_info},
+	{"trigger_asteroid_field", SP_trigger_asteroid_field, Logical_False, &trigger_asteroid_field_info},
 
 	{"trigger_teleport", SP_trigger_teleport, Logical_False},
 	{"trigger_hurt", SP_trigger_hurt, Logical_False},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -347,6 +347,7 @@ void SP_func_timer (gentity_t *self);
 void SP_func_breakable (gentity_t *ent);
 void SP_func_glass (gentity_t *ent);
 void SP_func_usable( gentity_t *ent);
+extern entityInfo_t func_usable_info;
 void SP_func_wall( gentity_t *ent );
 void SP_rail_mover (gentity_t *ent); //Lugormod
 void SP_rail_track (gentity_t *ent); //Lugormod
@@ -803,7 +804,7 @@ spawn_t	spawnInitValues[] = {
 	{"func_timer", SP_func_timer, Logical_False},			// rename trigger_timer?
 	{"func_breakable", SP_func_breakable, Logical_False},
 	{"func_glass", SP_func_glass, Logical_False},
-	{"func_usable", SP_func_usable, Logical_False},
+	{"func_usable", SP_func_usable, Logical_False, &func_usable_info},
 	{"func_wall", SP_func_wall, Logical_False},
 
 	// Triggers are brush objects that cause an effect when contacted

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -433,6 +433,7 @@ extern entityInfo_t target_teleporter_info;
 void SP_target_relay (gentity_t *ent);
 extern entityInfo_t target_relay_info;
 void SP_target_kill (gentity_t *ent);
+extern entityInfo_t target_kill_info;
 void SP_target_position (gentity_t *ent);
 void SP_target_location (gentity_t *ent);
 void SP_target_counter (gentity_t *self);
@@ -922,7 +923,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_score", SP_target_score, Logical_True, &target_score_info},
 	{"target_teleporter", SP_target_teleporter, Logical_True, &target_teleporter_info},
 	{"target_relay", SP_target_relay, Logical_True, &target_relay_info},
-	{"target_kill", SP_target_kill, Logical_True},
+	{"target_kill", SP_target_kill, Logical_True, &target_kill_info},
 	{"target_position", SP_target_position, Logical_True},
 	{"target_location", SP_target_location, Logical_True},
 	{"target_counter", SP_target_counter, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -435,6 +435,7 @@ extern entityInfo_t target_relay_info;
 void SP_target_kill (gentity_t *ent);
 extern entityInfo_t target_kill_info;
 void SP_target_position (gentity_t *ent);
+extern entityInfo_t target_position_info;
 void SP_target_location (gentity_t *ent);
 void SP_target_counter (gentity_t *self);
 void SP_target_random (gentity_t *self);
@@ -924,7 +925,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_teleporter", SP_target_teleporter, Logical_True, &target_teleporter_info},
 	{"target_relay", SP_target_relay, Logical_True, &target_relay_info},
 	{"target_kill", SP_target_kill, Logical_True, &target_kill_info},
-	{"target_position", SP_target_position, Logical_True},
+	{"target_position", SP_target_position, Logical_True, &target_position_info},
 	{"target_location", SP_target_location, Logical_True},
 	{"target_counter", SP_target_counter, Logical_True},
 	{"target_random", SP_target_random, Logical_True},

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -1047,7 +1047,20 @@ Randomly fires off only one of it's targets each time used
 
 USEONCE	set to never fire again
 */
-
+const entityInfoData_t target_random_spawnflags[] = {
+	{"1", "Fire once then disable itself"},
+	{NULL, NULL}
+};
+const entityInfoData_t target_random_keys[] = {
+	{"target", "should target more than one entity, it will only fire at one of its targets."},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_random_info = {
+	"Randomly fires off only one of it\'s targets each time used",
+	target_random_spawnflags,
+	target_random_keys
+};
 void target_random_use(gentity_t *self, gentity_t *other, gentity_t *activator)
 {
 	int			t_count = 0, pick;
@@ -1242,6 +1255,24 @@ wait - can't be used again in this amount of seconds (Default is 1 second if it'
 delay - how long to wait after use to run script
 
 */
+const entityInfoData_t target_scriptrunner_spawnflags[] = {
+	{"1", "Will run the script on the entity that used this or tripped the trigger that used this"},
+	{"128", "Will start in the off state"},
+	{NULL, NULL}
+};
+const entityInfoData_t target_scriptrunner_keys[] = {
+	{"useScript", "script to run when used. ex: close_door_cinematic"},
+	{"count", "how many times to run, -1 = infinite.  Default is once"},
+	{"wait", "can\'t be used again in this amount of seconds (Default is 1 second if it\'s multiple-use)"},
+	{"delay", "how long to wait after use to run script"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_scriptrunner_info = {
+	"Starts a script once used.",
+	target_scriptrunner_spawnflags,
+	target_scriptrunner_keys
+};
 void SP_target_scriptrunner( gentity_t *self )
 {
 	/*

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -867,6 +867,18 @@ void SP_target_kill( gentity_t *self ) {
 /*QUAKED target_position (0 0.5 0) (-4 -4 -4) (4 4 4)
 Used as a positional target for in-game calculation, like jumppad targets.
 */
+const entityInfoData_t target_position_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_position_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_position_info = {
+	"Used as a positional target for in-game calculation, like jumppad targets.",
+	target_position_spawnflags,
+	target_position_keys
+};
 void SP_target_position( gentity_t *self ){
 	G_SetOrigin( self, self->s.origin );
 	/*

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -1396,6 +1396,19 @@ void target_deactivate_use(gentity_t *self, gentity_t *other, gentity_t *activat
 /*QUAKED target_activate (1 0 0) (-4 -4 -4) (4 4 4)
 Will set the target(s) to be usable/triggerable
 */
+const entityInfoData_t target_activate_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_activate_keys[] = {
+	{"target", "the target to make usable/triggerable"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_activate_info = {
+	"Will set the target(s) to be usable/triggerable.",
+	target_activate_spawnflags,
+	target_activate_keys
+};
 void SP_target_activate( gentity_t *self )
 {
 	G_SetOrigin( self, self->s.origin );

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -99,6 +99,20 @@ void SP_target_remove_powerups( gentity_t *ent ) {
 
 //==========================================================
 
+const entityInfoData_t target_powerup_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_powerup_keys[] = {
+	{"powerup", "powerup to give to the player (number 1-15)"},
+	{"wait", "duration in seconds"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_powerup_info = {
+	"Sets a powerup to the player.",
+	target_powerup_spawnflags,
+	target_powerup_keys
+};
 void Use_target_powerup( gentity_t *ent, gentity_t *other, gentity_t *activator ) {
 	if( !activator->client ) {
 		return;

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -244,6 +244,26 @@ void SP_target_score( gentity_t *ent ) {
 If "private", only the activator gets the message.  If no checks, all clients get the message.
 */
 
+const entityInfoData_t target_print_spawnflags[] = {
+	{"1", "Red team only"},
+	{"2", "Blue team only"},
+	{"4", "Only the person who activated the entity can see the message"},
+	{"8", "Message will appear at top left corner of the screen"},
+	{"16", "Message will appear in area where chat normally appears"},
+	{NULL, NULL}
+};
+const entityInfoData_t target_print_keys[] = {
+	{"message", "text to print"},
+	{"wait", "don\'t fire off again if triggered within this many milliseconds ago"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_print_info = {
+	"This will print a message across the screen. Basically the same as the announce command. If no spawnflag is set, it will make the print global.",
+	target_print_spawnflags,
+	target_print_keys
+};
+
 //RoboPhred
 //Ufo: Added data tags support
 
@@ -419,6 +439,27 @@ Multiple identical looping sounds will just increase volume without any speed co
 "wait" : Seconds between auto triggerings, 0 = don't auto trigger
 "random"	wait variance, default is 0
 */
+
+const entityInfoData_t target_speaker_spawnflags[] = {
+	{"1", "Makes the sound start on, loops the sound when complete"},
+	{"2", "Makes the sound start off"},
+	{"4", "Everybody on the entire map can hear the sound"},
+	{"8", "Only the activator can hear the sound"},
+	{NULL, NULL}
+};
+const entityInfoData_t target_speaker_keys[] = {
+	{"noise", "wav file to play. ex: sound/ambience/narshaddaa/cantina_1.mp3"},
+	{"wait", "seconds between auto triggerings, 0 = don't auto trigger"},
+	{"random", "wait variance, default is 0"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_speaker_info = {
+	"This entity will play a sound that you specify in a certain radius.",
+	target_speaker_keys,
+	target_speaker_spawnflags
+};
+
 void Use_Target_Speaker (gentity_t *ent, gentity_t *other, gentity_t *activator) {
 	G_ActivateBehavior(ent,BSET_USE);
 

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -10,6 +10,20 @@
 /*QUAKED target_give (1 0 0) (-8 -8 -8) (8 8 8)
 Gives the activator all the items pointed to.
 */
+const entityInfoData_t target_give_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t target_give_keys[] = {
+	{"target", "the item to give a player"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_give_info = {
+	"Gives the activator all the items pointed to.",
+	target_give_spawnflags,
+	target_give_keys
+};
 void Use_Target_Give( gentity_t *ent, gentity_t *other, gentity_t *activator ) {
 	gentity_t	*t;
 	trace_t		trace;
@@ -47,6 +61,19 @@ void SP_target_give( gentity_t *ent ) {
 takes away all the activators powerups.
 Used to drop flight powerups into death puts.
 */
+const entityInfoData_t target_remove_powerups_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t target_remove_powerups_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_remove_powerups_info = {
+	"Gives the activator all the items pointed to.",
+	target_remove_powerups_spawnflags,
+	target_remove_powerups_keys
+};
 void Use_target_remove_powerups( gentity_t *ent, gentity_t *other, gentity_t *activator ) {
 	if( !activator->client ) {
 		return;
@@ -112,6 +139,22 @@ activated again while it is counting down to an event.
 "wait" seconds to pause before firing targets.
 "random" delay variance, total delay = delay +/- random seconds
 */
+const entityInfoData_t target_delay_spawnflags[] = {
+	{"1", "Keeps the delay from resetting the time if it is activated again while it is counting down to an event."},
+	{NULL, NULL}
+};
+const entityInfoData_t target_delay_keys[] = {
+	{"wait", "seconds to pause before firing targets"},
+	{"random", "delay variance, total delay = delay +/- random seconds"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_delay_info = {
+	"This is a great entity for making an entity not fire its target right away, instead it waits the amount of time you set with the \'wait\' key to fire its target.",
+	target_delay_spawnflags,
+	target_delay_keys
+};
+
 //Ufo: multithread option
 void Think_Target_Delay( gentity_t *ent ) {
 	if (ent->spawnflags & 2)

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -562,6 +562,19 @@ void SP_target_speaker( gentity_t *ent ) {
 /*QUAKED target_laser (0 .5 .8) (-8 -8 -8) (8 8 8) START_ON
 When triggered, fires a laser.  You can either set a target or a direction.
 */
+const entityInfoData_t target_laser_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_laser_keys[] = {
+	{"target", "make this target a target_position. you don't need to do this you can just set angles"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_laser_info = {
+	"When triggered, fires a laser. You can either set a target or a direction. Starts in the off state so you have to use its targetname for it to turn on",
+	target_laser_keys,
+	target_laser_spawnflags
+};
 void target_laser_think (gentity_t *self) {
 	vec3_t	end;
 	trace_t	tr;

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -230,8 +230,8 @@ const entityInfoData_t target_score_keys[] = {
 };
 const entityInfo_t target_score_info = {
 	"The activator is given this many points.",
-	target_score_keys,
-	target_score_spawnflags
+	target_score_spawnflags,
+	target_score_keys
 };
 void Use_Target_Score (gentity_t *ent, gentity_t *other, gentity_t *activator) {
 	//RoboPhred
@@ -469,8 +469,8 @@ const entityInfoData_t target_speaker_keys[] = {
 };
 const entityInfo_t target_speaker_info = {
 	"This entity will play a sound that you specify in a certain radius.",
-	target_speaker_keys,
-	target_speaker_spawnflags
+	target_speaker_spawnflags,
+	target_speaker_keys
 };
 
 void Use_Target_Speaker (gentity_t *ent, gentity_t *other, gentity_t *activator) {
@@ -585,8 +585,8 @@ const entityInfoData_t target_laser_keys[] = {
 };
 const entityInfo_t target_laser_info = {
 	"When triggered, fires a laser. You can either set a target or a direction. Starts in the off state so you have to use its targetname for it to turn on",
-	target_laser_keys,
-	target_laser_spawnflags
+	target_laser_spawnflags,
+	target_laser_keys
 };
 void target_laser_think (gentity_t *self) {
 	vec3_t	end;
@@ -720,8 +720,8 @@ const entityInfoData_t target_teleporter_keys[] = {
 };
 const entityInfo_t target_teleporter_info = {
 	"The activator will be teleported away... Use angle or angles keys to change the direction that you teleport in.",
-	target_teleporter_keys,
-	target_teleporter_spawnflags
+	target_teleporter_spawnflags,
+	target_teleporter_keys
 };
 void SP_target_teleporter( gentity_t *self ) {
 	//RoboPhred
@@ -765,8 +765,8 @@ const entityInfoData_t target_relay_keys[] = {
 };
 const entityInfo_t target_relay_info = {
 	"Does nothing but fire at its targets, can fire at up to 6 targets it will fire them all at the same time. If random checked, only one will be fired.",
-	target_relay_keys,
-	target_relay_spawnflags
+	target_relay_spawnflags,
+	target_relay_keys
 };
 void target_relay_use (gentity_t *self, gentity_t *other, gentity_t *activator) {
 	qboolean ranscript = qfalse;
@@ -852,8 +852,8 @@ const entityInfoData_t target_kill_keys[] = {
 };
 const entityInfo_t target_kill_info = {
 	"Kills the activator.",
-	target_kill_keys,
-	target_kill_spawnflags
+	target_kill_spawnflags,
+	target_kill_keys
 };
 void target_kill_use( gentity_t *self, gentity_t *other, gentity_t *activator ) {
 	G_ActivateBehavior(self,BSET_USE);

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -220,6 +220,19 @@ void SP_target_delay( gentity_t *ent ) {
 
 The activator is given this many points.
 */
+const entityInfoData_t target_score_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_score_keys[] = {
+	{"count", "number of points to add, default 1"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_score_info = {
+	"The activator is given this many points.",
+	target_score_keys,
+	target_score_spawnflags
+};
 void Use_Target_Score (gentity_t *ent, gentity_t *other, gentity_t *activator) {
 	//RoboPhred
 	if(ent->spawnflags & 1)
@@ -697,6 +710,19 @@ void target_teleporter_use( gentity_t *self, gentity_t *other, gentity_t *activa
 /*QUAKED target_teleporter (1 0 0) (-8 -8 -8) (8 8 8)
 The activator will be teleported away.
 */
+const entityInfoData_t target_teleporter_spawnflags[] = {
+	{"1", "Do not teleport player if they are in a duel."},
+	{NULL, NULL}
+};
+const entityInfoData_t target_teleporter_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_teleporter_info = {
+	"The activator will be teleported away... Use angle or angles keys to change the direction that you teleport in.",
+	target_teleporter_keys,
+	target_teleporter_spawnflags
+};
 void SP_target_teleporter( gentity_t *self ) {
 	//RoboPhred
 	/*Their target is themselvs if neccessary.
@@ -718,6 +744,21 @@ INACTIVE  Can't be used until activated
 
 wait - set to -1 to use it only once
 */
+
+const entityInfoData_t target_relay_spawnflags[] = {
+	{"4", "makes the target get fired off randomly, currently this only works for target1"},
+	{NULL, NULL}
+};
+const entityInfoData_t target_relay_keys[] = {
+	{"wait", "set to -1 to use it only once"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_relay_info = {
+	"Does nothing but fire at its targets, can fire at up to 6 targets it will fire them all at the same time. If random checked, only one will be fired.",
+	target_relay_keys,
+	target_relay_spawnflags
+};
 void target_relay_use (gentity_t *self, gentity_t *other, gentity_t *activator) {
 	qboolean ranscript = qfalse;
 	if ( ( self->spawnflags & 1 ) && activator->client 

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -925,6 +925,20 @@ Set "count" to 0-7 for color.
 Closest target_location in sight used for the location, if none
 in site, closest in distance
 */
+const entityInfoData_t target_location_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_location_keys[] = {
+	{"message", "the name of this location"},
+	{"count", "0-7 for color. 0 - white, 1 - red, 2 - green, etc."},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_location_info = {
+	"Closest target_location in sight used for the location, if none in site, closest in distance",
+	target_location_spawnflags,
+	target_location_keys
+};
 void SP_target_location( gentity_t *self ){
 	self->think = target_location_linkup;
 	self->nextthink = level.time + 200;  // Let them all spawn first

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -746,11 +746,20 @@ wait - set to -1 to use it only once
 */
 
 const entityInfoData_t target_relay_spawnflags[] = {
+	{"1", "only red team can use this"},
+	{"", "only blue team can use this"},
 	{"4", "makes the target get fired off randomly, currently this only works for target1"},
+	{"128", "makes the entity start deactivated"},
 	{NULL, NULL}
 };
 const entityInfoData_t target_relay_keys[] = {
 	{"wait", "set to -1 to use it only once"},
+	{"target", "the first target to fire"},
+	{"target2", "the second target to fire"},
+	{"target3", "the third target to fire"},
+	{"target4", "the fourth target to fire"},
+	{"target5", "the fifth target to fire"},
+	{"target6", "the sixth target to fire"},
 	{"targetname", "make the trigger target this value for the entity to be used"},
 	{NULL, NULL}
 };

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -1401,11 +1401,16 @@ const entityInfoData_t target_activate_spawnflags[] = {
 };
 const entityInfoData_t target_activate_keys[] = {
 	{"target", "the target to make usable/triggerable"},
+	{"target2", "a second target to make usable/triggerable"},
+	{"target3", "a third target to make usable/triggerable"},
+	{"target4", "a fourth target to make usable/triggerable"},
+	{"target5", "a fifth target to make usable/triggerable"},
+	{"target6", "a sixth target to make usable/triggerable"},
 	{"targetname", "make the trigger target this value for the entity to be used"},
 	{NULL, NULL}
 };
 const entityInfo_t target_activate_info = {
-	"Will set the target(s) to be usable/triggerable.",
+	"Will set the target(s) to be usable/triggerable. Accepts up to 6 targets.",
 	target_activate_spawnflags,
 	target_activate_keys
 };

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -1423,6 +1423,24 @@ void SP_target_activate( gentity_t *self )
 /*QUAKED target_deactivate (1 0 0) (-4 -4 -4) (4 4 4)
 Will set the target(s) to be non-usable/triggerable
 */
+const entityInfoData_t target_deactivate_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_deactivate_keys[] = {
+	{"target", "the target to make non-usable/triggerable"},
+	{"target2", "a second target to make non-usable/triggerable"},
+	{"target3", "a third target to make non-usable/triggerable"},
+	{"target4", "a fourth target to make non-usable/triggerable"},
+	{"target5", "a fifth target to make non-usable/triggerable"},
+	{"target6", "a sixth target to make non-usable/triggerable"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_deactivate_info = {
+	"Will set the target(s) to be non-usable/triggerable. Accepts up to 6 targets.",
+	target_deactivate_spawnflags,
+	target_deactivate_keys
+};
 void SP_target_deactivate( gentity_t *self )
 {
 	G_SetOrigin( self, self->s.origin );

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -841,6 +841,20 @@ void SP_target_relay (gentity_t *self) {
 /*QUAKED target_kill (.5 .5 .5) (-8 -8 -8) (8 8 8)
 Kills the activator.
 */
+
+const entityInfoData_t target_kill_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_kill_keys[] = {
+	{"target", "target a player to kill them"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_kill_info = {
+	"Kills the activator.",
+	target_kill_keys,
+	target_kill_spawnflags
+};
 void target_kill_use( gentity_t *self, gentity_t *other, gentity_t *activator ) {
 	G_ActivateBehavior(self,BSET_USE);
 	G_Damage ( activator, NULL, NULL, NULL, NULL, 100000, DAMAGE_NO_PROTECTION, MOD_TELEFRAG);

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -957,6 +957,23 @@ After the counter has been triggered "count" times (default 2), it will fire all
 
 bounceCount - number of times the counter should reset to it's full count when it's done
 */
+const entityInfoData_t target_counter_spawnflags[] = {
+	{"1", "Start Inactive, must be hit by a target_activate to be able to be used."},
+	{NULL, NULL}
+};
+const entityInfoData_t target_counter_keys[] = {
+	{"target", "what to first fire at when the entity as been hit a certain amount of times."},
+	{"target2", "fires this every time you target the entity and it isnt at its count"},
+	{"count", "the amount of times to be hit for firing its target (default 2)"},
+	{"bounceCount", "set this at -1 so the entity will never stop working, otherwise after the first use it will stop working. if you set bouncecount to 5 then after the fifth use it will stop working."},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_counter_info = {
+	"You have to use this entity a specified amount of times for it to fire at its target, the default is 2 times ravensoft made it so it will deactivate after it gets hit a certain amount of times",
+	target_counter_spawnflags,
+	target_counter_keys
+};
 extern void G_DebugPrint( int level, const char *format, ... );
 void target_counter_use( gentity_t *self, gentity_t *other, gentity_t *activator )
 {

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -1252,6 +1252,18 @@ target_credits
 ==============
 */
 
+const entityInfoData_t target_credits_keys[] = {
+	{"count", "the amount of credits to give the activator"},
+	{"random", "the amount of credits you want to randomly receive. This number is added onto the count. If your count is 20 and you set this to 10 you will receive anywhere from 20-30 credits"},
+	{"targetname", "make the trigger target this value for the entity to be used, the person who triggers this will receive the set amount of credits"},
+	{NULL, NULL},
+};
+entityInfo_t target_credits_info = {
+	"Gives the person who fires this an amount of credits",
+	NULL,
+	target_credits_keys
+};
+
 void Use_Target_Credits (gentity_t *ent, gentity_t *other, gentity_t *activator){
 	//RoboPhred: silly lugor
 	int activatorCreds;

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -1460,6 +1460,19 @@ void target_level_change_use(gentity_t *self, gentity_t *other, gentity_t *activ
 /*QUAKED target_level_change (1 0 0) (-4 -4 -4) (4 4 4)
 "mapname" - Name of map to change to
 */
+const entityInfoData_t target_level_change_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_level_change_keys[] = {
+	{"mapname", "Name of map to change to"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_level_change_info = {
+	"changes the map to whatever you specify when this entity gets used. This is dangerous in older lugormod versions or if not used with OpenJK. Escape sequences and the \';\' can be used in the mapname key maliciously. Use with care and/or remove.",
+	target_level_change_spawnflags,
+	target_level_change_keys
+};
 void SP_target_level_change( gentity_t *self )
 {
 	//RoboPhred
@@ -1501,6 +1514,19 @@ If an intro file and loop file are specified, the intro plays first, then the lo
 portion will start and loop indefinetly.  If no introfile is entered, only the loopfile
 will play.
 */
+const entityInfoData_t target_play_music_spawnflags[] = {
+	{NULL, NULL}
+};
+const entityInfoData_t target_play_music_keys[] = {
+	{"music", "music WAV or MP3 file ex: music/introfile.mp3 or music/loopfile.mp3"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_play_music_info = {
+	"Plays the requested music files when this target is used.",
+	target_play_music_spawnflags,
+	target_play_music_keys
+};
 void SP_target_play_music( gentity_t *self )
 {
 	char *s = NULL;

--- a/game/g_trigger.c
+++ b/game/g_trigger.c
@@ -2048,6 +2048,20 @@ causes vehicle to turn toward target and travel in that direction for a set time
 "traveltime"	time to travel in this direction
 
 */
+const entityInfoData_t trigger_shipboundary_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t trigger_shipboundary_keys[] = {
+	{"target", "name of entity to turn toward (can be info_notnull, or whatever)"},
+	{"traveltime", "time to travel in this direction"},
+	{NULL, NULL}
+};
+const entityInfo_t trigger_shipboundary_info = {
+	"causes vehicle to turn toward target and travel in that direction for a set time when hit",
+	trigger_shipboundary_spawnflags,
+	trigger_shipboundary_keys
+};
 void SP_trigger_shipboundary(gentity_t *self)
 {
 	InitTrigger(self);
@@ -2185,6 +2199,20 @@ Ship will turn to face the angles of the first target_position then fly forward,
 "target"		whatever position the ship teleports from in relation to the target_position specified here, that's the relative position the ship will spawn at around the target2 target_position
 "target2"		name of target_position to teleport the ship to (will be relative to it's origin)
 */
+const entityInfoData_t trigger_hyperspace_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t trigger_hyperspace_keys[] = {
+	{"target", "whatever position the ship teleports from in relation to the target_position specified here, that's the relative position the ship will spawn at around the target2 target_position"},
+	{"target2", "name of target_position to teleport the ship to (will be relative to it's origin)"},
+	{NULL, NULL}
+};
+const entityInfo_t trigger_hyperspace_info = {
+	"Ship will turn to face the angles of the first target_position then fly forward, playing the hyperspace effect, then pop out at a relative point around the target",
+	trigger_hyperspace_spawnflags,
+	trigger_hyperspace_keys
+};
 void SP_trigger_hyperspace(gentity_t *self)
 {
 	//register the hyperspace end sound (start sounds are customized)
@@ -2230,6 +2258,22 @@ so, the basic time between firing is a random time between
 (wait - random) and (wait + random)
 
 */
+const entityInfoData_t func_timer_spawnflags[] = {
+	{"1", "start on"},
+	{NULL, NULL}
+};
+const entityInfoData_t func_timer_keys[] = {
+	{"wait", "base time between triggering all targets, default is 1"},
+	{"random", "wait variance (+/- each direction), default is 0"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{"target", "targets to fire"},
+	{NULL, NULL}
+};
+const entityInfo_t func_timer_info = {
+	"This should be renamed trigger_timer... Repeatedly fires its targets. Can be turned on or off by using.",
+	func_timer_spawnflags,
+	func_timer_keys
+};
 void func_timer_think( gentity_t *self ) {
 	G_UseTargets (self, self->activator);
 	// set time before next firing
@@ -2440,6 +2484,21 @@ speed - how fast, on average, the asteroid moves
 count - how many asteroids, max, to have at one time
 target - target this at func_rotating asteroids
 */
+const entityInfoData_t trigger_asteroid_field_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t trigger_asteroid_field_keys[] = {
+	{"speed", "how fast, on average, the asteroid moves"},
+	{"count", "how many asteroids, max, to have at one time"},
+	{"target", "target this at func_rotating asteroids"},
+	{NULL, NULL}
+};
+const entityInfo_t trigger_asteroid_field_info = {
+	"Something like t3_byss asteroid field",
+	trigger_asteroid_field_spawnflags,
+	trigger_asteroid_field_keys
+};
 void SP_trigger_asteroid_field(gentity_t *self)
 {
 	trap_SetBrushModel( self, self->model );

--- a/game/g_trigger.c
+++ b/game/g_trigger.c
@@ -1602,6 +1602,23 @@ Pushes the activator in the direction.of angle, or towards a target apex.
 "speed"		defaults to 1000
 if "bouncepad", play bounce noise instead of none
 */
+
+const entityInfoData_t target_push_spawnflags[] = {
+	{"1", "play bounce noise"},
+	{"2", "will push activator at constant speed, speed does need to be set for this to work"},
+	{NULL, NULL}
+};
+const entityInfoData_t target_push_keys[] = {
+	{"speed", "speed to push activator (default 1000)"},
+	{"target", "a target_position to aim at"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t target_push_info = {
+	"will push activator in direction of \'target\' at constant \'speed\'. Should target a target_position.",
+	target_push_spawnflags,
+	target_push_keys
+};
 void SP_target_push( gentity_t *self ) {
 	if (!self->speed) {
 		self->speed = 1000;

--- a/game/g_trigger.c
+++ b/game/g_trigger.c
@@ -1185,6 +1185,19 @@ trigger_visible_use ( gentity_t *self, gentity_t *other, gentity_t *activator )
 	self->use = NULL;
 }
 
+const entityInfoData_t trigger_visible_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t trigger_visible_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t trigger_visible_info = {
+	"No documentation provided but used in spots where a ent is expected.",
+	trigger_visible_spawnflags,
+	trigger_visible_keys
+};
 void SP_trigger_visible (gentity_t *ent)
 {
 	if (ent->targetname) {

--- a/game/g_trigger.c
+++ b/game/g_trigger.c
@@ -1650,6 +1650,20 @@ If spectator is set, only spectators can use this teleport
 Spectator teleporters are not normally placed in the editor, but are created
 automatically near doors to allow spectators to move through them
 */
+const entityInfoData_t trigger_teleport_spawnflags[] = {
+	{"1", "only spectators can use this teleport"},
+	{NULL, NULL}
+};
+const entityInfoData_t trigger_teleport_keys[] = {
+	{"maxs/mins", "bounding box for trigger size"},
+	{"target", "the location to teleport to"},
+	{NULL, NULL}
+};
+const entityInfo_t trigger_teleport_info = {
+	"Allows client side prediction of teleportation events. Must point at a target_position, which will be the teleport destination",
+	trigger_teleport_spawnflags,
+	trigger_teleport_keys
+};
 void SP_trigger_teleport( gentity_t *self ) {
 	InitTrigger (self);
 
@@ -1691,9 +1705,26 @@ NO_PROTECTION	*nothing* stops the damage
 "team"			team (1 or 2) to allow hurting (if none then hurt anyone) only applicable for siege
 "dmg"			default 5 (whole numbers only)
 If dmg is set to -1 this brush will use the fade-kill method
-
 */
-
+const entityInfoData_t trigger_hurt_spawnflags[] = {
+	{"1", "The entity will start in its off state"},
+	{"2", "if you target it, it will toggle on and off"},
+	{"4", "supresses playing the sound"},
+	{"8", "*nothing* stops the damage"},
+	{"16", "changes the damage rate to once per second"},
+	{NULL, NULL}
+};
+const entityInfoData_t trigger_hurt_keys[] = {
+	{"maxs/mins", "define trigger size"},
+	{"team", "team (1 or 2) to allow hurting (if none then hurt anyone) only applicable for siege"},
+	{"dmg", "default 5 (whole numbers only). -1 is fade-kill method"},
+	{NULL, NULL}
+};
+const entityInfo_t trigger_hurt_info = {
+	"Any entity that touches this will be hurt. It does dmg points of damage each server frame. Targeting the trigger will toggle its on / off state",
+	trigger_hurt_spawnflags,
+	trigger_hurt_keys
+};
 void hurt_touch( gentity_t *self, gentity_t *other, trace_t *trace ) {
 	int		dflags = DAMAGE_NO_DISMEMBER;
 	//RoboPhred: the hell?

--- a/game/g_trigger.c
+++ b/game/g_trigger.c
@@ -1091,6 +1091,20 @@ void trigger_always_think( gentity_t *ent ) {
 /*QUAKED trigger_always (.5 .5 .5) (-8 -8 -8) (8 8 8)
 This trigger will always fire.  It is activated by the world.
 */
+const entityInfoData_t trigger_always_spawnflags[] = {
+	// {"", ""},
+	{NULL, NULL}
+};
+const entityInfoData_t trigger_always_keys[] = {
+	{"target", "target to fire"},
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{NULL, NULL}
+};
+const entityInfo_t trigger_always_info = {
+	"This trigger will always fire.  It is activated by the world.",
+	trigger_always_spawnflags,
+	trigger_always_keys
+};
 void SP_trigger_always (gentity_t *ent) {
 	// we must have some delay to make sure our use targets are present
 	// needs to be very long it seems

--- a/game/g_trigger.c
+++ b/game/g_trigger.c
@@ -792,6 +792,40 @@ multiple classes with the use of |, e.g.:
 */
 
 //        extern vmCvar_t g_dontLoadNPC;
+const entityInfoData_t trigger_once_spawnflags[] = {
+  {"1", "only a player can trigger this by touch. makes it so an NPC cannot fire"},
+  {"2", "won\'t fire unless trigger ent\'s view angles are within 45 degrees of trigger\'s angles"},
+  {"4", "won\'t fire unless player is in it and is pressing the use button"},
+  {"8", "won\'t fire unless player/NPC is in it and pressing the fire button"},
+  {"16", "only non-player NPCs can trigger this by touch"},
+  {"32", "?"},
+  {"64", "?"},
+  {"128", "Starts deactivated"},
+  {"256", "multiple entities can touch this trigger in a single frame and if needed, the trigger can have a wait of > 0"},
+  {NULL, NULL}
+};
+const entityInfoData_t trigger_once_keys[] = {
+  {"target", "what to fire at, if there is a bounding box it will fire when the player/npc is in the box"},
+  {"targetname", "make something target this value for the entity to be used"},
+  {"random", "the wait variance (default 0)"},
+//  {"wait", "unsure if this works, might be wait time between when the trigger fires to check if an entity is inside"},
+  {"delay", "how many seconds to wait to fire its targets after tripped"},
+  {"noise", "sound to play when the trigger fires (plays at activator\'s origin)"},
+  {"NPC_targetname", "only the NPC with this NPC_targetname fires this trigger"},
+  {"team", "if set, only this team can trip the trigger (0 - any, 1 - red, 2 - blue)"},
+  {"soundSet", "ambient sound set to play when this trigger is activated"},
+  {"usetime", "require a client to hold the use key for x amount of milliseconds, along with spawnflags 4"},
+  {"teamuser", "(siege only) if 1, team 2 can\'t use this. if 2, team 1 can\'t use this"},
+  {"siegetrig", "(siege only) if non-0, can only be activated by players carrying a misc_siege_item which is associated with this trigger by the item\'s goaltarget value"},
+  {"idealclass", "(siege only) can only be used by this class/these classes. specify multiple using \'|\' e.g. \'Imperial Medic|Imperial Assassin| ImperialDemolitionist\'"},
+  {NULL, NULL}
+};
+const entityInfo_t trigger_once_info = {
+  "Works exactly like a trigger_multiple but fires only once. Then it doesn\'t fire again.",
+  trigger_once_spawnflags,
+  trigger_once_keys
+};
+
 
 void SP_trigger_once( gentity_t *ent )
 {

--- a/game/g_turret_G2.c
+++ b/game/g_turret_G2.c
@@ -3,6 +3,7 @@
 #include "q_shared.h"
 
 #include "Lmd_Accounts_Property.h"
+#include "Lmd_Entities_Public.h"
 
 void G_SetEnemy( gentity_t *self, gentity_t *enemy );
 void finish_spawning_turretG2( gentity_t *base );
@@ -1139,6 +1140,46 @@ customscale - custom scaling size. 100 is normal size, 1024 is the max scaling. 
 "icon" - icon that represents the objective on the radar
 */
 //-----------------------------------------------------
+
+const entityInfoData_t misc_turretG2_spawnflags[] = {
+	{"1", "Turret will start off and toggle turning on and off when used, requires the entity to have a targetname"},
+	{"2", "Turret will be upside-down (with foot part on floor)"},
+	{"4", "will respawn after being killed (use count)"},
+	{"8", "Big-ass, Boxy Death Star Turbo Laser version (yes this is a direct quote from ravensofts notes)"},
+	{"16", "Turret will aim in front of the enemy, or lead the entity, increases chance to hit"},
+	{"32", "Turret will appear on radar"},
+	{"64", "Target Fighters (I Believe This Means Air Vehicles)"},
+	{"128", "Target Ground Vehicles"},
+	{"256", "Target Players Who Are Armed"},
+	{"512", "If set, turret will only attack players who fit the profession/level/maxlevel keys (By default people on property list are not attacked)"},
+    {NULL, NULL}
+};
+
+const entityInfoData_t misc_turretG2_keys[] = {
+	{"radius", "maximum distance of targeting enemies (default 512)"},
+	{"wait", "time to wait between firing (default 150ms)"},
+	{"dmg", "damage per shot (default 5)"},
+	{"health", "health of the turret (default 100)"},
+	{"count", "time to wait between respawning"},
+	{"paintarget", "in the words of Lugor: target to fire off upon being hurt"},
+	{"painwait", "in the words of Lugor: ms to wait between firing off pain targets"},
+	{"random", "random value (in degrees) of aiming off target when firing at targets (default 2)"},
+	{"shotspeed", "speed of the projectile the Turret fired (defaults 1,100 regular, 20,000 Big-ass Boxy Death Star turret)"},
+	{"splashDamage", "how much the damage the explosion does"},
+	{"splashRadius", "how far the explosion will reach"},
+	{"targetname", "name to be used to activate/deactivate"},
+	{"target", "target to activate upon being destroyed (opening a door when turret is destroyed)"},
+	{"target2", "target to activate upon firing at targets"},
+	{"showhealth", "Will show health when person aims at the turret if set to 1"},
+	{"customscale", "1024 is the maximum (default 100)"},
+	{NULL, NULL}
+};
+
+const entityInfo_t misc_turretG2_info = {
+	"Spawns a turret that will fire at a person. This entity is finicky, some spawnflags don't always work together. Use cvar lmd_spturrets to change turret behavior. MP maps have different turret spawnflag behavior than SP maps.",
+	misc_turretG2_spawnflags,
+	misc_turretG2_keys
+};
 
 //RoboPhred
 extern vmCvar_t lmd_spturrets;

--- a/game/g_weapon.c
+++ b/game/g_weapon.c
@@ -15,6 +15,7 @@
 #include "Lmd_Weapons.h"
 #include "Lmd_Accounts_Core.h"
 #include "Lmd_Accounts_Friends.h"
+#include "Lmd_Entities_Public.h"
 
 qboolean isBuddy(gentity_t *ent, gentity_t *other);
 
@@ -4991,6 +4992,26 @@ teamnodmg - team that turret does not take damage from or do damage to
 */
 
 //----------------------------------------------------------
+const entityInfoData_t emplaced_gun_spawnflags[] = {
+ 	{NULL, NULL}
+};
+
+const entityInfoData_t emplaced_gun_keys[] = {
+	{"count", "if spawnflag 1 is set, decides how long it is before gun respawns (in ms)"},
+    {"constraint", "number of degrees gun is constrained from base angles on each side (default 60.0)"},
+	{"showhealth", "set to 1 to show health bar on this entity when crosshair is over it"},
+	{"teamowner", "crosshair shows green for this team, red for opposite team\n0 - none\n1 - red\n2 - blue"},
+	{"alliedTeam", "team that can use this 0 - any, 1 - red, 2 - blue"},
+	{"teamnodmg", "team that turret does not take damage from or do damage to\n0 - none\n1 - red\n2 - blue"},
+	{NULL, NULL}
+};
+
+const entityInfo_t emplaced_gun_info = {
+    "Spawns a turret gun that can be used if you're a non jedi profession",
+ 	emplaced_gun_spawnflags,
+ 	emplaced_gun_keys
+};
+
 extern qboolean TryHeal(gentity_t *ent, gentity_t *target); //g_utils.c
 
 //RoboPhred
@@ -5261,6 +5282,8 @@ void emplaced_gun_die( gentity_t *self, gentity_t *inflictor, gentity_t *attacke
 }
 
 //RoboPhred
+
+
 void PlayerUsableGetKeys(gentity_t *ent);
 void SP_emplaced_gun( gentity_t *ent )
 {


### PR DESCRIPTION
whole bunch of `entityinfo` entries

Missing these either because they're unused, used by the bsp editor, poorly documented and I didn't attempt to document them, or i'm slightly afraid of them, or for defender i forgot

```
defender - forgot
gametype_item
target_escapetrig
ref_tag_huge
NPC_ with dedicated model
waypoint
waypoint_small
waypoint_*
point_combat
team_CTF_redplayer/blue
team_CTF_redspawn/blue
item_botroam
ghost_exit_red/blue
target_interest
t2_toggle (lmd counterpart has info)
t2_terminal (lmd counterpart has info)
t2_rentterminal (lmd counterpart has info)
t2_pwterminal (lmd counterpart has info)
t2_propertyterminal (lmd counterpart has info)
t2_light (lmd counterpart has info)
t2_gate (lmd counterpart has info)
t2_door (lmd counterpart has info)
lmd_stashzone
lmd_stashspawnpoint
lmd_stashdepo
```