### PR TITLE
"/levitate" command fixes/improvements

### DIFF
--- a/docs/cvars.md
+++ b/docs/cvars.md
@@ -238,13 +238,15 @@ If set to 1, Levitate plays an effect when used by Sith.
 ## lmd_levitateJediSound
 ### Default value: 0
 ```
-If set to 1, Levitate plays a sound when used by Jedi.
+If set to 1, Levitate plays a continuous sound when used by Jedi.
 ```
+
 ## lmd_levitateSithSound
 ### Default value: 0
 ```
-If set to 1, Levitate plays a sound when used by Sith.
+If set to 1, Levitate plays a continuous sound when used by Sith.
 ```
+
 ## lmd_levitateFinish
 ### Default value: 0
 ```
@@ -260,6 +262,13 @@ Maximum health a Jedi can reach while levitating.
 ```
 Maximum force points a Sith can reach while levitating.
 ```
+
+## lmd_levitateRegen
+### Default value: 1
+```
+1 to enable health regeneration (for Jedi) and force regeneration (for Sith), 0 to disable it.
+```
+
 ## lmd_lightningBelowLevel3Range
 ### Default value: 600
 ```

--- a/docs/cvars.md
+++ b/docs/cvars.md
@@ -222,6 +222,19 @@ If set to 1, Levitate plays an effect when used by Jedi.
 ```
 If set to 1, Levitate plays an effect when used by Sith.
 ```
+
+## lmd_levitateAscentSound
+### Default value: 1
+```
+1 to enable a sound effect during the ascending phase of /levitate (starting animation), 0 to disable.
+```
+
+## lmd_levitateDescentSound
+### Default value: 1
+```
+1 to enable a sound effect during the descending phase of /levitate (ending animation), 0 to disable.
+```
+
 ## lmd_levitateJediSound
 ### Default value: 0
 ```

--- a/docs/cvars.md
+++ b/docs/cvars.md
@@ -250,8 +250,9 @@ If set to 1, Levitate plays a continuous sound when used by Sith.
 ## lmd_levitateFinish
 ### Default value: 0
 ```
-If set to 1, Levitate will stop once lmd_levitateMaxHealth or lmd_levitateMaxForcePoints is reached.
+If set to 1, Levitate will stop once lmd_levitateMaxHealth (Jedi) or lmd_levitateMaxForcePoints (Sith) is reached.
 ```
+
 ## lmd_levitateMaxHealth
 ### Default value: 100
 ```

--- a/game/Lmd_Medilevitate.c
+++ b/game/Lmd_Medilevitate.c
@@ -81,7 +81,9 @@ void lmd_meditate_levitate_update(gentity_t* self)
             self->client->Lmd.customGravity.time = level.time + FRAMETIME;
             self->client->Lmd.customSpeed.time = level.time + FRAMETIME;
 
-            if (lmd_levitateSithFx.integer > 0 && Jedi_GetAccSide(self->client->pers.Lmd.account) == FORCE_DARKSIDE)
+            const int isSith = (Jedi_GetAccSide(self->client->pers.Lmd.account) == FORCE_DARKSIDE);
+
+            if (lmd_levitateSithFx.integer > 0 && isSith)
             {
                 if (level.time > self->client->Lmd.mediLevitate.sithFxTimer)
                 {
@@ -112,7 +114,7 @@ void lmd_meditate_levitate_update(gentity_t* self)
             {
                 self->client->Lmd.mediLevitate.humSoundTimer = level.time + 3500;
 
-                if (lmd_levitateSithSound.integer > 0 && Jedi_GetAccSide(self->client->pers.Lmd.account) == FORCE_DARKSIDE)
+                if (lmd_levitateSithSound.integer > 0 && isSith)
                 {
                     G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/rageloop.wav"));
                 }
@@ -124,8 +126,6 @@ void lmd_meditate_levitate_update(gentity_t* self)
             
             if (self->client->Lmd.mediLevitate.autoHealTimer < level.time)
             {
-                const int isSith = (Jedi_GetAccSide(self->client->pers.Lmd.account) == FORCE_DARKSIDE);
-
                 if (lmd_levitateMaxHealth.integer >= 100 && !isSith)
                 {
                     if (self->health < lmd_levitateMaxHealth.integer)
@@ -161,22 +161,18 @@ void lmd_meditate_levitate_update(gentity_t* self)
             
             if (!self->client->Lmd.mediLevitate.effectFullFxPlayed)
             {
-                int isSith = (Jedi_GetAccSide(self->client->pers.Lmd.account) == FORCE_DARKSIDE);
-
-                if ((!isSith && self->health >= 135) || (isSith && self->client->ps.fd.forcePower >= 200))
+                if (!isSith && self->health >= lmd_levitateMaxHealth.integer)
                 {
                     self->client->Lmd.mediLevitate.effectFullFxPlayed = qtrue;
+                    G_PlayEffectID(G_EffectIndex("force/heal2"), self->client->ps.origin, vec3_origin);
+                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/absorploop.wav"));
+                }
 
-                    if (isSith)
-                    {
-                        G_PlayEffectID(G_EffectIndex("force/rage2"), self->client->ps.origin, vec3_origin);
-                        G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/drainloop.wav"));
-                    }
-                    else
-                    {
-                        G_PlayEffectID(G_EffectIndex("force/heal2"), self->client->ps.origin, vec3_origin);
-                        G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/absorploop.wav"));
-                    }
+                if (isSith && self->client->ps.fd.forcePower >= lmd_levitateMaxForcePoints.integer)
+                {
+                    self->client->Lmd.mediLevitate.effectFullFxPlayed = qtrue;
+                    G_PlayEffectID(G_EffectIndex("force/rage2"), self->client->ps.origin, vec3_origin);
+                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/drainloop.wav"));
                 }
             }
 

--- a/game/Lmd_Medilevitate.c
+++ b/game/Lmd_Medilevitate.c
@@ -14,12 +14,16 @@ extern vmCvar_t lmd_levitateHealInterval;
 extern vmCvar_t lmd_levitateBreathSway;
 extern vmCvar_t lmd_levitateJediFx;
 extern vmCvar_t lmd_levitateSithFx;
+extern vmCvar_t lmd_levitateAscentSound;
+extern vmCvar_t lmd_levitateDescentSound;
 extern vmCvar_t lmd_levitateJediSound;
 extern vmCvar_t lmd_levitateSithSound;
 extern vmCvar_t lmd_levitateFinish;
 extern vmCvar_t lmd_levitateMaxHealth;
 extern vmCvar_t lmd_levitateMaxForcePoints;
 
+extern int rageLoopSound;
+extern int protectLoopSound;
 void lmd_meditate_levitate_update(gentity_t* self)
 {
     if (!self || !self->client || !self->inuse || !self->client->Lmd.mediLevitate.enabled ||
@@ -58,6 +62,31 @@ void lmd_meditate_levitate_update(gentity_t* self)
             self->client->Lmd.customSpeed.time = level.time + FRAMETIME;
             G_SetAnim(self, SETANIM_BOTH, BOTH_FORCE_RAGE,
                       SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD | SETANIM_FLAG_HOLDLESS, 500);
+
+            if (!self->client->Lmd.mediLevitate.soundStarted)
+            {
+                self->client->Lmd.mediLevitate.soundStarted = qtrue;
+
+                // Play the initial "rising" sound
+                if (lmd_levitateAscentSound.integer)
+                {
+                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/jumpbuild.mp3"));
+                }
+
+                // Start the "hum" sound loop (if not yet started)
+                const int isSith = (Jedi_GetAccSide(self->client->pers.Lmd.account) == FORCE_DARKSIDE);
+                if (lmd_levitateSithSound.integer > 0 && isSith)
+                {
+                    G_Sound( self, TRACK_CHANNEL_3, rageLoopSound );
+                    // Will be stopped by G_MuteSound() in lmd_meditate_levitate_end()
+                }
+                else if (lmd_levitateJediSound.integer > 0 && !isSith)
+                {
+                    G_Sound( self, TRACK_CHANNEL_3, protectLoopSound );
+                    // Will be stopped by G_MuteSound() in lmd_meditate_levitate_end()
+                }
+            }
+
             if (level.time > self->client->Lmd.mediLevitate.runTime + 1500)
             {
                 self->client->Lmd.mediLevitate.state = 2;
@@ -91,7 +120,7 @@ void lmd_meditate_levitate_update(gentity_t* self)
                     G_PlayEffectID(G_EffectIndex("force/kothos_recharge"), self->client->ps.origin, self->client->ps.viewangles);
                 }
             }
-            else if (lmd_levitateJediFx.integer > 0)
+            else if (lmd_levitateJediFx.integer > 0 && !isSith)
             {
                 self->client->pushEffectTime = level.time + FRAMETIME;
             }
@@ -109,21 +138,6 @@ void lmd_meditate_levitate_update(gentity_t* self)
             float swayOffset = cosf(self->client->Lmd.mediLevitate.phase) * swayAmplitude;
             self->client->ps.origin[0] += (swayOffset - (self->client->ps.origin[0] - self->client->Lmd.mediLevitate.startOrigin[0])) * 0.1f;
 
-
-            if (level.time > self->client->Lmd.mediLevitate.humSoundTimer)
-            {
-                self->client->Lmd.mediLevitate.humSoundTimer = level.time + 3500;
-
-                if (lmd_levitateSithSound.integer > 0 && isSith)
-                {
-                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/rageloop.wav"));
-                }
-                else if (lmd_levitateJediSound.integer > 0)
-                {
-                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/protectloop.wav"));
-                }
-            }
-            
             if (self->client->Lmd.mediLevitate.autoHealTimer < level.time)
             {
                 if (lmd_levitateMaxHealth.integer >= 100 && !isSith)
@@ -165,14 +179,14 @@ void lmd_meditate_levitate_update(gentity_t* self)
                 {
                     self->client->Lmd.mediLevitate.effectFullFxPlayed = qtrue;
                     G_PlayEffectID(G_EffectIndex("force/heal2"), self->client->ps.origin, vec3_origin);
-                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/absorploop.wav"));
+                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/absorb.mp3"));
                 }
 
                 if (isSith && self->client->ps.fd.forcePower >= lmd_levitateMaxForcePoints.integer)
                 {
                     self->client->Lmd.mediLevitate.effectFullFxPlayed = qtrue;
                     G_PlayEffectID(G_EffectIndex("force/rage2"), self->client->ps.origin, vec3_origin);
-                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/drainloop.wav"));
+                    G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/drain.mp3"));
                 }
             }
 
@@ -239,7 +253,13 @@ void lmd_meditate_levitate_end(gentity_t* self)
     self->client->ps.forceHandExtendTime = level.time + self->client->ps.legsTimer;
     self->client->ps.weaponTime = self->client->ps.legsTimer;
     self->client->Lmd.customSpeed.time = level.time + self->client->ps.legsTimer;
+    self->client->Lmd.mediLevitate.soundStarted = qfalse;
     self->client->Lmd.mediLevitate.effectFullFxPlayed = qfalse;
     self->client->Lmd.mediLevitate.enabled = qfalse;
     self->client->Lmd.mediLevitate.state = 0;
+    G_MuteSound(self->client->ps.fd.killSoundEntIndex[TRACK_CHANNEL_3-50], CHAN_VOICE);
+    if (lmd_levitateDescentSound.integer)
+    {
+        G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/effects/woosh1.mp3"));
+    }
 }

--- a/game/Lmd_Medilevitate.c
+++ b/game/Lmd_Medilevitate.c
@@ -179,6 +179,12 @@ void lmd_meditate_levitate_update(gentity_t* self)
                     self->client->Lmd.mediLevitate.effectFullFxPlayed = qtrue;
                     G_PlayEffectID(G_EffectIndex("force/heal2"), self->client->ps.origin, vec3_origin);
                     G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/absorb.mp3"));
+
+                    if (lmd_levitateFinish.integer)
+                    {
+                        lmd_meditate_levitate_end(self);
+                        break;
+                    }
                 }
 
                 if (isSith && self->client->ps.fd.forcePower >= lmd_levitateMaxForcePoints.integer)
@@ -186,6 +192,12 @@ void lmd_meditate_levitate_update(gentity_t* self)
                     self->client->Lmd.mediLevitate.effectFullFxPlayed = qtrue;
                     G_PlayEffectID(G_EffectIndex("force/rage2"), self->client->ps.origin, vec3_origin);
                     G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/drain.mp3"));
+
+                    if (lmd_levitateFinish.integer)
+                    {
+                        lmd_meditate_levitate_end(self);
+                        break;
+                    }
                 }
             }
 
@@ -247,6 +259,18 @@ int lmd_meditate_levitate_abort(gentity_t* self)
 void lmd_meditate_levitate_end(gentity_t* self)
 {
     G_SetAnim(self, SETANIM_BOTH, BOTH_MEDITATE_END, SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD, 100);
+
+    G_MuteSound(self->client->ps.fd.killSoundEntIndex[TRACK_CHANNEL_3-50], CHAN_VOICE);
+    if (
+        lmd_levitateDescentSound.integer
+        && !(lmd_levitateFinish.integer && self->client->Lmd.mediLevitate.effectFullFxPlayed)
+    ) {
+        // Play the sound for the descending phase,
+        // if enabled AND not currently playing the "full" sound effect because of lmd_levitateFinish,
+        // (to avoid playing both sounds at the same time).
+        G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/effects/woosh1.mp3"));
+    }
+
     self->client->ps.stats[STAT_MAX_HEALTH] = 100;
     self->client->ps.forceHandExtendTime = level.time + self->client->ps.legsTimer;
     self->client->ps.weaponTime = self->client->ps.legsTimer;
@@ -255,9 +279,4 @@ void lmd_meditate_levitate_end(gentity_t* self)
     self->client->Lmd.mediLevitate.effectFullFxPlayed = qfalse;
     self->client->Lmd.mediLevitate.enabled = qfalse;
     self->client->Lmd.mediLevitate.state = 0;
-    G_MuteSound(self->client->ps.fd.killSoundEntIndex[TRACK_CHANNEL_3-50], CHAN_VOICE);
-    if (lmd_levitateDescentSound.integer)
-    {
-        G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/effects/woosh1.mp3"));
-    }
 }

--- a/game/Lmd_Medilevitate.c
+++ b/game/Lmd_Medilevitate.c
@@ -126,7 +126,7 @@ void lmd_meditate_levitate_update(gentity_t* self)
             {
                 const int isSith = (Jedi_GetAccSide(self->client->pers.Lmd.account) == FORCE_DARKSIDE);
 
-                if (lmd_levitateMaxHealth.integer > 100 && !isSith)
+                if (lmd_levitateMaxHealth.integer >= 100 && !isSith)
                 {
                     if (self->health < lmd_levitateMaxHealth.integer)
                     {
@@ -137,7 +137,7 @@ void lmd_meditate_levitate_update(gentity_t* self)
                         self->client->ps.stats[STAT_MAX_HEALTH] = self->health;
                     }
                 }
-                else if (lmd_levitateMaxForcePoints.integer > 100 && isSith)
+                else if (lmd_levitateMaxForcePoints.integer >= 100 && isSith)
                 {
                     if (self->client->ps.fd.forcePower < lmd_levitateMaxForcePoints.integer)
                     {

--- a/game/Lmd_Medilevitate.c
+++ b/game/Lmd_Medilevitate.c
@@ -21,6 +21,7 @@ extern vmCvar_t lmd_levitateSithSound;
 extern vmCvar_t lmd_levitateFinish;
 extern vmCvar_t lmd_levitateMaxHealth;
 extern vmCvar_t lmd_levitateMaxForcePoints;
+extern vmCvar_t lmd_levitateRegen;
 
 extern int rageLoopSound;
 extern int protectLoopSound;
@@ -138,26 +139,24 @@ void lmd_meditate_levitate_update(gentity_t* self)
             float swayOffset = cosf(self->client->Lmd.mediLevitate.phase) * swayAmplitude;
             self->client->ps.origin[0] += (swayOffset - (self->client->ps.origin[0] - self->client->Lmd.mediLevitate.startOrigin[0])) * 0.1f;
 
-            if (self->client->Lmd.mediLevitate.autoHealTimer < level.time)
+            if (lmd_levitateRegen.integer && self->client->Lmd.mediLevitate.autoHealTimer < level.time)
             {
-                if (lmd_levitateMaxHealth.integer >= 100 && !isSith)
+                if (!isSith && self->health < lmd_levitateMaxHealth.integer)
                 {
-                    if (self->health < lmd_levitateMaxHealth.integer)
+                    self->health += lmd_levitateHealAmount.integer;
+                    if (self->health > lmd_levitateMaxHealth.integer)
                     {
-                        self->health += lmd_levitateHealAmount.integer;
-                        if (self->health > lmd_levitateMaxHealth.integer)
-                            self->health = lmd_levitateMaxHealth.integer;
-
-                        self->client->ps.stats[STAT_MAX_HEALTH] = self->health;
+                        self->health = lmd_levitateMaxHealth.integer;
                     }
+
+                    self->client->ps.stats[STAT_MAX_HEALTH] = self->health;
                 }
-                else if (lmd_levitateMaxForcePoints.integer >= 100 && isSith)
+                else if (isSith && self->client->ps.fd.forcePower < lmd_levitateMaxForcePoints.integer)
                 {
-                    if (self->client->ps.fd.forcePower < lmd_levitateMaxForcePoints.integer)
+                    self->client->ps.fd.forcePower += lmd_levitateHealAmount.integer;
+                    if (self->client->ps.fd.forcePower > lmd_levitateMaxForcePoints.integer)
                     {
-                        self->client->ps.fd.forcePower += lmd_levitateHealAmount.integer;
-                        if (self->client->ps.fd.forcePower > lmd_levitateMaxForcePoints.integer)
-                            self->client->ps.fd.forcePower = lmd_levitateMaxForcePoints.integer;
+                        self->client->ps.fd.forcePower = lmd_levitateMaxForcePoints.integer;
                     }
                 }
                 
@@ -173,7 +172,7 @@ void lmd_meditate_levitate_update(gentity_t* self)
                 self->client->Lmd.mediLevitate.autoHealTimer = level.time + heal_interval;
             }
             
-            if (!self->client->Lmd.mediLevitate.effectFullFxPlayed)
+            if (lmd_levitateRegen.integer && !self->client->Lmd.mediLevitate.effectFullFxPlayed)
             {
                 if (!isSith && self->health >= lmd_levitateMaxHealth.integer)
                 {
@@ -189,7 +188,6 @@ void lmd_meditate_levitate_update(gentity_t* self)
                     G_Sound(self, CHAN_AUTO, G_SoundIndex("sound/weapons/force/drain.mp3"));
                 }
             }
-
 
             G_SetAnim(self, SETANIM_BOTH, BOTH_STAND5TOSIT2,
                       SETANIM_FLAG_OVERRIDE | SETANIM_FLAG_HOLD | SETANIM_FLAG_HOLDLESS, 100);

--- a/game/Lmd_Medilevitate.c
+++ b/game/Lmd_Medilevitate.c
@@ -160,12 +160,12 @@ void lmd_meditate_levitate_update(gentity_t* self)
                     }
                 }
                 
-                float jedi_level = Accounts_Prof_GetLevel(self->client->pers.Lmd.account);
+                float jedi_level = (float)Accounts_Prof_GetLevel(self->client->pers.Lmd.account);
                 jedi_level *= 0.5f;
                 if (jedi_level < 1.0f)
                     jedi_level = 1.0f;
 
-                int heal_interval = (int)(lmd_levitateHealInterval.integer / jedi_level);
+                int heal_interval = (int)((float)lmd_levitateHealInterval.integer / jedi_level);
                 if (heal_interval < 300)
                     heal_interval = 300;
 
@@ -236,7 +236,7 @@ void lmd_meditate_levitate_update(gentity_t* self)
     }
 }
 
-int lmd_meditate_levitate_abort(gentity_t* self)
+qboolean lmd_meditate_levitate_abort(gentity_t* self)
 {
     if (!self || !self->client || !self->inuse)
         return qfalse;

--- a/game/Lmd_Prof_Core.c
+++ b/game/Lmd_Prof_Core.c
@@ -1083,6 +1083,12 @@ void Cmd_MediLevitate_f(gentity_t* ent, int iArg)
 		return;
 	}
 
+	if (duelInProgress(&ent->client->ps))
+	{
+		Disp(ent, "^3You cannot do this while in a duel.");
+		return;
+	}
+
 	if (ent->client->Lmd.mediLevitate.enabled)
 	{
 		Disp(ent, "^3You are already doing this.");

--- a/game/g_cmds.c
+++ b/game/g_cmds.c
@@ -8,6 +8,7 @@
 #include "Lmd_Accounts_Friends.h"
 
 #include "Lmd_Commands_Auths.h"
+#include "Lmd_Medilevitate.h"
 
 #include "../ui/menudef.h"			// for the voice chats
 
@@ -3584,6 +3585,16 @@ void Cmd_EngageDuel_f(gentity_t *ent){
 			ent->client->ps.duelInProgress = qtrue;
 			challenged->client->ps.duelInProgress = qtrue;
 			//}
+
+			if (ent->client->Lmd.mediLevitate.enabled)
+			{
+				lmd_meditate_levitate_end(ent);
+			}
+
+			if (challenged->client->Lmd.mediLevitate.enabled)
+			{
+				lmd_meditate_levitate_end(challenged);
+			}
 
 			ent->client->ps.duelTime = level.time + 2000;
 			challenged->client->ps.duelTime = level.time + 2000;

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -412,6 +412,7 @@ vmCvar_t lmd_levitateSithSound;
 vmCvar_t lmd_levitateFinish;
 vmCvar_t lmd_levitateMaxHealth;
 vmCvar_t lmd_levitateMaxForcePoints;
+vmCvar_t lmd_levitateRegen;
 
 // lumaya: SetSaber enable use time
 vmCvar_t lmd_set_saber_delay;
@@ -686,6 +687,9 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &lmd_levitateMaxForcePoints, "lmd_levitateMaxForcePoints", "100", CVAR_ARCHIVE, 0, qtrue, qfalse,
 	"The amount a Sith's FP can go up to when levitating.",
   },
+	{ &lmd_levitateRegen, "lmd_levitateRegen", "1", CVAR_ARCHIVE, 0, qtrue, qfalse,
+"1 to enable health regeneration (for Jedi) and force regeneration (for Sith), 0 to disable it.",
+	},
 	{ &lmd_set_saber_delay, "lmd_set_saber_delay", "750", CVAR_ARCHIVE, 0, qtrue, qfalse,
 		"Set the delay for instant saber switch for when to be able to use saber again after swapping.",
 	},

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -679,7 +679,7 @@ static cvarTable_t		gameCvarTable[] = {
 	"If 1 levitate plays a continuous sound when on sith.",
 	},
 	{ &lmd_levitateFinish, "lmd_levitateFinish", "0", CVAR_ARCHIVE, 0, qtrue, qfalse,
-	"Set to 1 to automatically end /levitate when lmd_levitateMaxHealth (Jedi) or lmd_levitateMaxForcePoints (Sith) are reached (and lmd_levitateRegen is enabled).",
+	"If set to 1, Levitate will stop once lmd_levitateMaxHealth (Jedi) or lmd_levitateMaxForcePoints (Sith) is reached.",
 	},
 	{ &lmd_levitateMaxHealth, "lmd_levitateMaxHealth", "100", CVAR_ARCHIVE, 0, qtrue, qfalse,
 	"The amount a jedi's HP can go up to when levitating.",

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -405,6 +405,8 @@ vmCvar_t lmd_levitateHealInterval;
 vmCvar_t lmd_levitateBreathSway;
 vmCvar_t lmd_levitateJediFx;
 vmCvar_t lmd_levitateSithFx;
+vmCvar_t lmd_levitateAscentSound;
+vmCvar_t lmd_levitateDescentSound;
 vmCvar_t lmd_levitateJediSound;
 vmCvar_t lmd_levitateSithSound;
 vmCvar_t lmd_levitateFinish;
@@ -663,11 +665,17 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &lmd_levitateSithFx, "lmd_levitateSithFx", "0", CVAR_ARCHIVE, 0, qtrue, qfalse,
 	"If 1 then levitate plays an effect when on sith.",
 	},
+	{ &lmd_levitateAscentSound, "lmd_levitateAscentSound", "1", CVAR_ARCHIVE, 0, qtrue, qfalse,
+"1 to enable a sound effect during the ascending phase of /levitate (starting animation), 0 to disable.",
+	},
+	{ &lmd_levitateDescentSound, "lmd_levitateDescentSound", "1", CVAR_ARCHIVE, 0, qtrue, qfalse,
+"1 to enable a sound effect during the descending phase of /levitate (ending animation), 0 to disable.",
+	},
 	{ &lmd_levitateJediSound, "lmd_levitateJediSound", "0", CVAR_ARCHIVE, 0, qtrue, qfalse,
-	"If 1 levitate plays a sound when on jedi.",
+	"If 1 levitate plays a continuous sound when on jedi.",
 	},
 	{ &lmd_levitateSithSound, "lmd_levitateSithSound", "0", CVAR_ARCHIVE, 0, qtrue, qfalse,
-	"If 1 levitate plays a sound when on sith.",
+	"If 1 levitate plays a continuous sound when on sith.",
 	},
 	{ &lmd_levitateFinish, "lmd_levitateFinish", "0", CVAR_ARCHIVE, 0, qtrue, qfalse,
 	"If 1 levitate finishes if lmd_levitateMaxHealth or lmd_levitateMaxForcePoints is greater than 100 and their values are reached.",

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -679,7 +679,7 @@ static cvarTable_t		gameCvarTable[] = {
 	"If 1 levitate plays a continuous sound when on sith.",
 	},
 	{ &lmd_levitateFinish, "lmd_levitateFinish", "0", CVAR_ARCHIVE, 0, qtrue, qfalse,
-	"If 1 levitate finishes if lmd_levitateMaxHealth or lmd_levitateMaxForcePoints is greater than 100 and their values are reached.",
+	"Set to 1 to automatically end /levitate when lmd_levitateMaxHealth (Jedi) or lmd_levitateMaxForcePoints (Sith) are reached (and lmd_levitateRegen is enabled).",
 	},
 	{ &lmd_levitateMaxHealth, "lmd_levitateMaxHealth", "100", CVAR_ARCHIVE, 0, qtrue, qfalse,
 	"The amount a jedi's HP can go up to when levitating.",

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -559,7 +559,7 @@ struct gclient_s {
 			unsigned int sithFxTimer;
 			float phase;
 			qboolean enabled;
-			unsigned int humSoundTimer;
+			qboolean soundStarted;
 			unsigned int autoHealTimer;
 			vec3_t startOrigin;
 			qboolean effectFullFxPlayed;


### PR DESCRIPTION
## Fix `/levitate` not regenerating when max value == 100
- Previously, `/levitate` would not regenerate any health (for Jedi) when `lmd_levitateMaxHealth` was set to 100 (or lower).  
  It will now regenerate up to the specified amount.
- Similarly, `/levitate` now regenerates force points (for Sith) up to the specified amount (even if <= 100).

## Fix hard-coded values (+ minor refactoring)
- The "full" effect was always triggered at 135 HP instead of `lmd_levitateMaxHealth`, and 200 force points instead of `lmd_levitateMaxForcePoints`.
- Also refactored `isSith` detection slightly.

## Sound fixes/improvements
Including:
- Fixed the "full" effect (had no sound, due to typos)
- Fixed the looping "Jedi sound" / "Sith sound" (now continuous, no more gaps)
- Added a sound effect during the ascending phase (starting animation)
  - Can be enabled/disabled with `g_levitateAscentSound`
- Added a sound effect during the descending phase (ending animation)
  - Can be enabled/disabled with `g_levitateDescentSound`

## Added the `lmd_levitateRegen` cvar
*"1 to enable health regeneration (for Jedi) and force regeneration (for Sith), 0 to disable it."*

## Implemented the `lmd_levitateFinish` cvar
*"If set to 1, Levitate will stop once lmd_levitateMaxHealth (Jedi) or lmd_levitateMaxForcePoints (Sith) is reached."*
It was previously declared and documented, but unused.

## Prevented `/levitate` during duels
- When a player is engaged in a duel, they won't be able to use `/levitate`
- When a player is using `/levitate`, they can accept duels, and challenge others to a duel, but `/levitate` will end as soon as the duel starts.