### PR TITLE
Forcepower entities

### DIFF
--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3213,7 +3213,6 @@ const entityInfoData_t lmd_restrict_spawnflags[] = {
 };
 const entityInfoData_t lmd_restrict_keys[] = {
     {"#HITBOX", NULL},
-    {"ModifyPowers", "E.g. ModifyPowers,heal2 -> would set force heal to level 2"},
     NULL
 };
 
@@ -5270,6 +5269,7 @@ const entityInfoData_t lmd_event_keys[] = {
     //{"Forcetarget", "Target to fire when a player uses an active forcepower (IE any but jump)."},
     {"DeathTarget", "Target to fire when a player dies."}, //target5
     {"KillTarget", "Target to fire when a player kills another player."}, //target6
+    {"ModifyPowers", "E.g. ModifyPowers,heal2.rage2 -> would set force heal and rage to level 2."},
     {NULL, NULL}
 };
 
@@ -5310,7 +5310,7 @@ static const forcePowerMap_t forcePowerMap[] = {
     {NULL, -1}
 };
 
-int ForcePowerIndex(const char *token) {
+int lmd_get_forcePowerMapIndex(const char *token) {
     for (int i = 0; forcePowerMap[i].name; i++) {
         if (!Q_stricmp(forcePowerMap[i].name, token)) {
             return forcePowerMap[i].id;
@@ -5324,6 +5324,39 @@ int ForcePowerIndex(const char *token) {
 	genericValue1: remembered clients 1
 	genericValue2: remembered clients 2
 */
+
+void lmd_set_forcePowerThroughString(gentity_t* ent, gentity_t* targ)
+{
+    const char *mods = ent->Lmd.selectsnd;
+    if (mods)
+    {
+        // Duplicate string so strtok doesn't trash the original
+        char buffer[MAX_STRING_CHARS];
+        Q_strncpyz(buffer, mods, sizeof(buffer));
+
+        char *token = strtok(buffer, ".");
+        while (token)
+        {
+            char powerName[32];
+            int level = -1;
+            
+            if (sscanf(token, "%31[a-zA-Z]%d", powerName, &level) == 2)
+            {
+                int fpIndex = lmd_get_forcePowerMapIndex(powerName);
+                if (fpIndex >= 0 && level >= 0 && level <= FORCE_LEVEL_5)
+                {
+                    targ->client->ps.fd.forcePowerLevel[fpIndex] = level;
+                    if (level > 0)
+                        targ->client->ps.fd.forcePowersKnown |= (1 << fpIndex);
+                    else
+                        targ->client->ps.fd.forcePowersKnown &= ~(1 << fpIndex);
+                }
+            }
+
+            token = strtok(NULL, ".");
+        }
+    }
+}
 
 void lmd_event_think(gentity_t* ent)
 {
@@ -5370,37 +5403,7 @@ void lmd_event_think(gentity_t* ent)
                 {
                     //Entered
                     G_UseTargets(ent, targ);
-
-                    const char *mods = ent->Lmd.selectsnd; // e.g. "heal2rage0jump2"
-                    if (mods)
-                    {
-                        // Duplicate string so strtok doesn't trash the original
-                        char buffer[MAX_QPATH];
-                        Q_strncpyz(buffer, mods, sizeof(buffer));
-
-                        char *token = strtok(buffer, ".");
-                        while (token)
-                        {
-                            char powerName[32];
-                            int level = -1;
-
-                            // Parse name and level (heal2, rage0, jump3, etc.)
-                            if (sscanf(token, "%31[a-zA-Z]%d", powerName, &level) == 2)
-                            {
-                                int fpIndex = ForcePowerIndex(powerName);
-                                if (fpIndex >= 0 && level >= 0 && level <= FORCE_LEVEL_5)
-                                {
-                                    targ->client->ps.fd.forcePowerLevel[fpIndex] = level;
-                                    if (level > 0)
-                                        targ->client->ps.fd.forcePowersKnown |= (1 << fpIndex);
-                                    else
-                                        targ->client->ps.fd.forcePowersKnown &= ~(1 << fpIndex);
-                                }
-                            }
-
-                            token = strtok(NULL, ".");
-                        }
-                    }
+                    lmd_set_forcePowerThroughString(ent, targ);
                 }
             }
 
@@ -5420,37 +5423,7 @@ void lmd_event_think(gentity_t* ent)
                 {
                     //Entered
                     G_UseTargets(ent, targ);
-
-                    const char *mods = ent->Lmd.selectsnd; // e.g. "heal2rage0jump2"
-                    if (mods)
-                    {
-                        // Duplicate string so strtok doesn't trash the original
-                        char buffer[MAX_QPATH];
-                        Q_strncpyz(buffer, mods, sizeof(buffer));
-
-                        char *token = strtok(buffer, ".");
-                        while (token)
-                        {
-                            char powerName[32];
-                            int level = -1;
-
-                            // Parse name and level (heal2, rage0, jump3, etc.)
-                            if (sscanf(token, "%31[a-zA-Z]%d", powerName, &level) == 2)
-                            {
-                                int fpIndex = ForcePowerIndex(powerName);
-                                if (fpIndex >= 0 && level >= 0 && level <= FORCE_LEVEL_5)
-                                {
-                                    targ->client->ps.fd.forcePowerLevel[fpIndex] = level;
-                                    if (level > 0)
-                                        targ->client->ps.fd.forcePowersKnown |= (1 << fpIndex);
-                                    else
-                                        targ->client->ps.fd.forcePowersKnown &= ~(1 << fpIndex);
-                                }
-                            }
-
-                            token = strtok(NULL, ".");
-                        }
-                    }
+                    lmd_set_forcePowerThroughString(ent, targ);
                 }
             }
         }

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3213,6 +3213,7 @@ const entityInfoData_t lmd_restrict_spawnflags[] = {
 };
 const entityInfoData_t lmd_restrict_keys[] = {
     {"#HITBOX", NULL},
+    {"ModifyPowers", "E.g. ModifyPowers,heal2 -> would set force heal to level 2"},
     NULL
 };
 
@@ -5278,6 +5279,47 @@ entityInfo_t lmd_event_info = {
     lmd_event_keys
 };
 
+
+typedef struct {
+    const char *name;
+    int id;
+} forcePowerMap_t;
+
+static const forcePowerMap_t forcePowerMap[] = {
+    {"jump", FP_LEVITATION},
+    {"push", FP_PUSH},
+    {"pull", FP_PULL},
+    {"speed", FP_SPEED},
+    {"seeing", FP_SEE},
+    
+    {"heal", FP_HEAL},
+    {"protect", FP_PROTECT},
+    {"absorb", FP_ABSORB},
+    {"mindtrick", FP_TELEPATHY},
+    {"theal", FP_TELEPATHY},
+    
+    {"grip", FP_GRIP},
+    {"lightning", FP_LIGHTNING},
+    {"rage", FP_RAGE},
+    {"drain", FP_DRAIN},
+    {"tforce", FP_TEAM_FORCE},
+    
+    {"sattack", FP_SABER_OFFENSE},
+    {"sdefend", FP_SABER_DEFENSE},
+    {"sthrow", FP_SABERTHROW},
+    {NULL, -1}
+};
+
+int ForcePowerIndex(const char *token) {
+    for (int i = 0; forcePowerMap[i].name; i++) {
+        if (!Q_stricmp(forcePowerMap[i].name, token)) {
+            return forcePowerMap[i].id;
+        }
+    }
+    return -1;
+}
+
+
 /*
 	genericValue1: remembered clients 1
 	genericValue2: remembered clients 2
@@ -5328,6 +5370,37 @@ void lmd_event_think(gentity_t* ent)
                 {
                     //Entered
                     G_UseTargets(ent, targ);
+
+                    const char *mods = ent->Lmd.selectsnd; // e.g. "heal2rage0jump2"
+                    if (mods)
+                    {
+                        // Duplicate string so strtok doesn't trash the original
+                        char buffer[MAX_QPATH];
+                        Q_strncpyz(buffer, mods, sizeof(buffer));
+
+                        char *token = strtok(buffer, ".");
+                        while (token)
+                        {
+                            char powerName[32];
+                            int level = -1;
+
+                            // Parse name and level (heal2, rage0, jump3, etc.)
+                            if (sscanf(token, "%31[a-zA-Z]%d", powerName, &level) == 2)
+                            {
+                                int fpIndex = ForcePowerIndex(powerName);
+                                if (fpIndex >= 0 && level >= 0 && level <= FORCE_LEVEL_5)
+                                {
+                                    targ->client->ps.fd.forcePowerLevel[fpIndex] = level;
+                                    if (level > 0)
+                                        targ->client->ps.fd.forcePowersKnown |= (1 << fpIndex);
+                                    else
+                                        targ->client->ps.fd.forcePowersKnown &= ~(1 << fpIndex);
+                                }
+                            }
+
+                            token = strtok(NULL, ".");
+                        }
+                    }
                 }
             }
 
@@ -5347,6 +5420,37 @@ void lmd_event_think(gentity_t* ent)
                 {
                     //Entered
                     G_UseTargets(ent, targ);
+
+                    const char *mods = ent->Lmd.selectsnd; // e.g. "heal2rage0jump2"
+                    if (mods)
+                    {
+                        // Duplicate string so strtok doesn't trash the original
+                        char buffer[MAX_QPATH];
+                        Q_strncpyz(buffer, mods, sizeof(buffer));
+
+                        char *token = strtok(buffer, ".");
+                        while (token)
+                        {
+                            char powerName[32];
+                            int level = -1;
+
+                            // Parse name and level (heal2, rage0, jump3, etc.)
+                            if (sscanf(token, "%31[a-zA-Z]%d", powerName, &level) == 2)
+                            {
+                                int fpIndex = ForcePowerIndex(powerName);
+                                if (fpIndex >= 0 && level >= 0 && level <= FORCE_LEVEL_5)
+                                {
+                                    targ->client->ps.fd.forcePowerLevel[fpIndex] = level;
+                                    if (level > 0)
+                                        targ->client->ps.fd.forcePowersKnown |= (1 << fpIndex);
+                                    else
+                                        targ->client->ps.fd.forcePowersKnown &= ~(1 << fpIndex);
+                                }
+                            }
+
+                            token = strtok(NULL, ".");
+                        }
+                    }
                 }
             }
         }
@@ -5410,6 +5514,7 @@ void lmd_event(gentity_t* ent)
     G_SpawnString("exittarget", "", &ent->target2);
     G_SpawnString("deathtarget", "", &ent->target5);
     G_SpawnString("killtarget", "", &ent->target6);
+    G_SpawnString("modifyPowers", "", &ent->Lmd.selectsnd);
 
     G_SpawnVector("mins", "0 0 0", ent->r.mins);
     G_SpawnVector("maxs", "0 0 0", ent->r.maxs);

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -5269,7 +5269,6 @@ const entityInfoData_t lmd_event_keys[] = {
     //{"Forcetarget", "Target to fire when a player uses an active forcepower (IE any but jump)."},
     {"DeathTarget", "Target to fire when a player dies."}, //target5
     {"KillTarget", "Target to fire when a player kills another player."}, //target6
-    {"ModifyPowers", "E.g. ModifyPowers,heal2.rage2 -> would set force heal and rage to level 2."},
     {NULL, NULL}
 };
 
@@ -5279,84 +5278,10 @@ entityInfo_t lmd_event_info = {
     lmd_event_keys
 };
 
-
-typedef struct {
-    const char *name;
-    int id;
-} forcePowerMap_t;
-
-static const forcePowerMap_t forcePowerMap[] = {
-    {"jump", FP_LEVITATION},
-    {"push", FP_PUSH},
-    {"pull", FP_PULL},
-    {"speed", FP_SPEED},
-    {"seeing", FP_SEE},
-    
-    {"heal", FP_HEAL},
-    {"protect", FP_PROTECT},
-    {"absorb", FP_ABSORB},
-    {"mindtrick", FP_TELEPATHY},
-    {"theal", FP_TELEPATHY},
-    
-    {"grip", FP_GRIP},
-    {"lightning", FP_LIGHTNING},
-    {"rage", FP_RAGE},
-    {"drain", FP_DRAIN},
-    {"tforce", FP_TEAM_FORCE},
-    
-    {"sattack", FP_SABER_OFFENSE},
-    {"sdefend", FP_SABER_DEFENSE},
-    {"sthrow", FP_SABERTHROW},
-    {NULL, -1}
-};
-
-int lmd_get_forcePowerMapIndex(const char *token) {
-    for (int i = 0; forcePowerMap[i].name; i++) {
-        if (!Q_stricmp(forcePowerMap[i].name, token)) {
-            return forcePowerMap[i].id;
-        }
-    }
-    return -1;
-}
-
-
 /*
 	genericValue1: remembered clients 1
 	genericValue2: remembered clients 2
 */
-
-void lmd_set_forcePowerThroughString(gentity_t* ent, gentity_t* targ)
-{
-    const char *mods = ent->Lmd.selectsnd;
-    if (mods)
-    {
-        // Duplicate string so strtok doesn't trash the original
-        char buffer[MAX_STRING_CHARS];
-        Q_strncpyz(buffer, mods, sizeof(buffer));
-
-        char *token = strtok(buffer, ".");
-        while (token)
-        {
-            char powerName[32];
-            int level = -1;
-            
-            if (sscanf(token, "%31[a-zA-Z]%d", powerName, &level) == 2)
-            {
-                int fpIndex = lmd_get_forcePowerMapIndex(powerName);
-                if (fpIndex >= 0 && level >= 0 && level <= FORCE_LEVEL_5)
-                {
-                    targ->client->ps.fd.forcePowerLevel[fpIndex] = level;
-                    if (level > 0)
-                        targ->client->ps.fd.forcePowersKnown |= (1 << fpIndex);
-                    else
-                        targ->client->ps.fd.forcePowersKnown &= ~(1 << fpIndex);
-                }
-            }
-
-            token = strtok(NULL, ".");
-        }
-    }
-}
 
 void lmd_event_think(gentity_t* ent)
 {
@@ -5403,7 +5328,6 @@ void lmd_event_think(gentity_t* ent)
                 {
                     //Entered
                     G_UseTargets(ent, targ);
-                    lmd_set_forcePowerThroughString(ent, targ);
                 }
             }
 
@@ -5423,7 +5347,6 @@ void lmd_event_think(gentity_t* ent)
                 {
                     //Entered
                     G_UseTargets(ent, targ);
-                    lmd_set_forcePowerThroughString(ent, targ);
                 }
             }
         }
@@ -5487,7 +5410,6 @@ void lmd_event(gentity_t* ent)
     G_SpawnString("exittarget", "", &ent->target2);
     G_SpawnString("deathtarget", "", &ent->target5);
     G_SpawnString("killtarget", "", &ent->target6);
-    G_SpawnString("modifyPowers", "", &ent->Lmd.selectsnd);
 
     G_SpawnVector("mins", "0 0 0", ent->r.mins);
     G_SpawnVector("maxs", "0 0 0", ent->r.maxs);

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -424,6 +424,8 @@ extern entityInfo_t target_speaker_info;
 
 void SP_target_print (gentity_t *ent);
 extern entityInfo_t target_print_info;
+void SP_target_fp(gentity_t *ent);
+extern entityInfo_t target_fp_info;
 void SP_target_laser (gentity_t *self);
 extern entityInfo_t target_laser_info;
 void SP_target_character (gentity_t *ent); // no doc
@@ -931,6 +933,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_delay", SP_target_delay, Logical_True, &target_delay_info},
 	{"target_speaker", SP_target_speaker, {qtrue, target_speaker_allowlogical}, &target_speaker_info},
 	{"target_print", SP_target_print, Logical_True, &target_print_info},
+	{"target_fp", SP_target_fp, Logical_True, &target_fp_info},
 	{"target_laser", SP_target_laser, Logical_True, &target_laser_info},
 	{"target_score", SP_target_score, Logical_True, &target_score_info},
 	{"target_teleporter", SP_target_teleporter, Logical_True, &target_teleporter_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -853,6 +853,7 @@ spawn_t	spawnInitValues[] = {
 	{"lmd_customskill", lmd_customskill, Logical_True, &lmd_customskill_info},
 
 	{"lmd_event", lmd_event, Logical_True, &lmd_event_info},
+	{"lmd_forcepower", lmd_event, Logical_True, &lmd_event_info},
 
 	{"lmd_interact", lmd_interact, Logical_True, &lmd_interact_info},
 	

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -450,6 +450,102 @@ void SP_target_print( gentity_t *ent ) {
 		G_SpawnString("arg", "", &ent->target2);
 }
 
+const entityInfoData_t target_fp_keys[] = {
+	{"targetname", "make the trigger target this value for the entity to be used"},
+	{"ModifyPowers", "E.g. ModifyPowers,heal2.rage2 -> would set force heal and rage to level 2. Available keys are: jump, push, pull, speed, seeing, heal, protect, absorb"
+				  "mindtrick, theal, grip, lightning, rage, drain, tforce, sattack, sdefend, sthrow."},
+	{NULL, NULL}
+};
+
+const entityInfo_t target_fp_info = {
+	"The activator is given the forcepower + levels given in the ModifyPowers key. ForcePowers not given in ModifyPowers key will remain unchanged. Only death can reset this.",
+	NULL,
+	target_fp_keys
+};
+
+typedef struct {
+	const char *name;
+	int id;
+} forcePowerMap_t;
+
+static const forcePowerMap_t forcePowerMap[] = {
+	{"jump", FP_LEVITATION},
+	{"push", FP_PUSH},
+	{"pull", FP_PULL},
+	{"speed", FP_SPEED},
+	{"seeing", FP_SEE},
+    
+	{"heal", FP_HEAL},
+	{"protect", FP_PROTECT},
+	{"absorb", FP_ABSORB},
+	{"mindtrick", FP_TELEPATHY},
+	{"theal", FP_TELEPATHY},
+    
+	{"grip", FP_GRIP},
+	{"lightning", FP_LIGHTNING},
+	{"rage", FP_RAGE},
+	{"drain", FP_DRAIN},
+	{"tforce", FP_TEAM_FORCE},
+    
+	{"sattack", FP_SABER_OFFENSE},
+	{"sdefend", FP_SABER_DEFENSE},
+	{"sthrow", FP_SABERTHROW},
+	{NULL, -1}
+};
+
+int lmd_get_forcePowerMapIndex(const char *token) {
+	for (int i = 0; forcePowerMap[i].name; i++) {
+		if (!Q_stricmp(forcePowerMap[i].name, token)) {
+			return forcePowerMap[i].id;
+		}
+	}
+	return -1;
+}
+
+void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
+{
+	if (!activator || !activator->client)
+		return;
+	
+	char *token = strtok(ent->target2, ".");
+	while (token)
+	{
+		char powerName[32];
+		int level = -1;
+            
+		if (sscanf(token, "%31[a-zA-Z]%d", powerName, &level) == 2)
+		{
+			int fpIndex = lmd_get_forcePowerMapIndex(powerName);
+			if (fpIndex >= 0 && level >= 0 && level <= FORCE_LEVEL_5)
+			{
+				activator->client->ps.fd.forcePowerLevel[fpIndex] = level;
+				if (level > 0)
+					activator->client->ps.fd.forcePowersKnown |= (1 << fpIndex);
+				else
+					activator->client->ps.fd.forcePowersKnown &= ~(1 << fpIndex);
+			}
+		}
+
+		token = strtok(NULL, ".");
+	}
+}
+
+void SP_target_fp( gentity_t *ent )
+{
+	G_SpawnString("ModifyPowers", "", &ent->target2);
+	
+	if (!Q_stricmp(ent->target2, ""))
+	{
+		EntitySpawnError("ModifyPowers key is empty.");
+		G_FreeEntity(ent);
+		return;
+	}
+	
+	ent->use = Use_Target_Fp;
+}
+
+
+
 
 //==========================================================
 

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -480,7 +480,7 @@ static const forcePowerMap_t forcePowerMap[] = {
 	{"protect", FP_PROTECT},
 	{"absorb", FP_ABSORB},
 	{"mindtrick", FP_TELEPATHY},
-	{"theal", FP_TELEPATHY},
+	{"theal", FP_TEAM_HEAL},
     
 	{"grip", FP_GRIP},
 	{"lightning", FP_LIGHTNING},

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -454,6 +454,7 @@ const entityInfoData_t target_fp_keys[] = {
 	{"targetname", "make the trigger target this value for the entity to be used"},
 	{"ModifyPowers", "E.g. ModifyPowers,heal2.rage2 -> would set force heal and rage to level 2. Available keys are: jump, push, pull, speed, seeing, heal, protect, absorb"
 				  "mindtrick, theal, grip, lightning, rage, drain, tforce, sattack, sdefend, sthrow."},
+	{"ForceRegenTimeMultiplier", "Multiply the existing force regen time by the given amount. E.g: 1.25"},
 	{NULL, NULL}
 };
 
@@ -506,6 +507,8 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 {
 	if (!activator || !activator->client)
 		return;
+
+	activator->client->Lmd.customForceRegenTimeMultiplier = ent->modelScale[0];
 	
 	char *token = strtok(ent->target2, ".");
 	while (token)
@@ -533,6 +536,7 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 void SP_target_fp( gentity_t *ent )
 {
 	G_SpawnString("ModifyPowers", "", &ent->target2);
+	G_SpawnFloat("ForceRegenTimeMultiplier", "1.0", &ent->modelScale[0]);
 	
 	if (!Q_stricmp(ent->target2, ""))
 	{

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -538,13 +538,6 @@ void SP_target_fp( gentity_t *ent )
 	G_SpawnString("ModifyPowers", "", &ent->target2);
 	G_SpawnFloat("ForceRegenTimeMultiplier", "1.0", &ent->modelScale[0]);
 	
-	if (!Q_stricmp(ent->target2, ""))
-	{
-		EntitySpawnError("ModifyPowers key is empty.");
-		G_FreeEntity(ent);
-		return;
-	}
-	
 	ent->use = Use_Target_Fp;
 }
 

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -454,7 +454,7 @@ const entityInfoData_t target_fp_keys[] = {
 	{"targetname", "make the trigger target this value for the entity to be used"},
 	{"ModifyPowers", "E.g. ModifyPowers,heal2.rage2 -> would set force heal and rage to level 2. Available keys are: jump, push, pull, speed, seeing, heal, protect, absorb"
 				  "mindtrick, theal, grip, lightning, rage, drain, tforce, sattack, sdefend, sthrow."},
-	{"ForceRegenTimeMultiplier", "Multiply the existing force regen time by the given amount. E.g: 1.25"},
+	{"ForceRegenSpeedMultiplier", "Multiply the existing force regen speed by the given amount. E.g: 1.25. Must be greater than 0."},
 	{NULL, NULL}
 };
 
@@ -508,7 +508,7 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 	if (!activator || !activator->client)
 		return;
 
-	activator->client->Lmd.customForceRegenTimeMultiplier = ent->modelScale[0];
+	activator->client->Lmd.customForceRegenSpeedMultiplier = ent->modelScale[0];
 	
 	char *token = strtok(ent->target2, ".");
 	while (token)
@@ -536,7 +536,14 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 void SP_target_fp( gentity_t *ent )
 {
 	G_SpawnString("ModifyPowers", "", &ent->target2);
-	G_SpawnFloat("ForceRegenTimeMultiplier", "1.0", &ent->modelScale[0]);
+	G_SpawnFloat("ForceRegenSpeedMultiplier", "0.0", &ent->modelScale[0]);
+
+	if (Q_stricmp(ent->target2, "") && ent->modelScale[0] == 0.0)
+	{
+		EntitySpawnError("Both ModifyPowers and ForceRegenSpeedMultiplier are invalid.");
+		G_FreeEntity(ent);
+		return;
+	}
 	
 	ent->use = Use_Target_Fp;
 }

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -606,7 +606,7 @@ struct gclient_s {
 
 		int crosshairEntNum;
 		unsigned int grabbing;
-		float customForceRegenTimeMultiplier;
+		float customForceRegenSpeedMultiplier;
 	}Lmd;
 	unsigned int lastTargetUse;
 	unsigned int infoChanged;

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -606,8 +606,9 @@ struct gclient_s {
 
 		int crosshairEntNum;
 		unsigned int grabbing;
-
+		float customForceRegenTimeMultiplier;
 	}Lmd;
 	unsigned int lastTargetUse;
 	unsigned int infoChanged;
+	
 };

--- a/game/q_shared.c
+++ b/game/q_shared.c
@@ -1483,32 +1483,20 @@ FIXME: make this buffer size safe someday
 //[OverflowProtection]
 //Ensiform provided this new version which apprenently can't overflow and gives the char array pool circular indexing to
 //provide better protection against multiple va strings stepping on each other's data.
-char	* QDECL va( char *format, ... ) {
+#define MAX_VA_STRING 32000
+#define MAX_VA_BUFFERS 2
+char	* QDECL va( const char *format, ... ) {
 	va_list		argptr;
-#define	MAX_VA_STRING	32000
-	static char		temp_buffer[MAX_VA_STRING];
-	static char		string[MAX_VA_STRING];	// in case va is called by nested functions
+	static char		string[MAX_VA_BUFFERS][MAX_VA_STRING];	// in case va is called by nested functions
 	static int		index = 0;
 	char	*buf;
-	int len;
 
+	buf = string[index & 1];
+	index++;
 
 	va_start (argptr, format);
-	vsprintf (temp_buffer, format,argptr);
+	Q_vsnprintf (buf, MAX_VA_STRING, format,argptr);
 	va_end (argptr);
-
-	if ((len = strlen(temp_buffer)) >= MAX_VA_STRING) {
-		Com_Error( ERR_DROP, "Attempted to overrun string in call to va()\n" );
-	}
-
-	if (len + index >= MAX_VA_STRING-1) {
-		index = 0;
-	}
-
-	buf = &string[index];
-	memcpy( buf, temp_buffer, len+1 );
-
-	index += len + 1;
 
 	return buf;
 }

--- a/game/q_shared.c
+++ b/game/q_shared.c
@@ -1473,16 +1473,10 @@ void QDECL Com_sprintf( char *dest, int size, const char *fmt, ...) {
 /*
 ============
 va
-
 does a varargs printf into a temp buffer, so I don't need to have
 varargs versions of all text functions.
-FIXME: make this buffer size safe someday
 ============
 */
-//RoboPhred
-//[OverflowProtection]
-//Ensiform provided this new version which apprenently can't overflow and gives the char array pool circular indexing to
-//provide better protection against multiple va strings stepping on each other's data.
 #define MAX_VA_STRING 32000
 #define MAX_VA_BUFFERS 2
 char	* QDECL va( const char *format, ... ) {

--- a/game/q_shared.h
+++ b/game/q_shared.h
@@ -1599,7 +1599,7 @@ float	LittleFloat (const float *l);
 
 void	Swap_Init (void);
 */
-char	* QDECL va(char *format, ...);
+char	* QDECL va(const char *format, ...);
 
 //=============================================
 

--- a/game/w_force.c
+++ b/game/w_force.c
@@ -6575,6 +6575,9 @@ void WP_ForcePowersUpdate( gentity_t *self, usercmd_t *ucmd ){
 			else 
 				regenTime = g_forceRegenTime.integer;
 
+			if (self->client->Lmd.customForceRegenTimeMultiplier)
+				regenTime *= self->client->Lmd.customForceRegenTimeMultiplier;
+		
 			if(regenTime <= 0)
 				regenTime = 1;
 

--- a/game/w_force.c
+++ b/game/w_force.c
@@ -6575,8 +6575,8 @@ void WP_ForcePowersUpdate( gentity_t *self, usercmd_t *ucmd ){
 			else 
 				regenTime = g_forceRegenTime.integer;
 
-			if (self->client->Lmd.customForceRegenTimeMultiplier)
-				regenTime *= self->client->Lmd.customForceRegenTimeMultiplier;
+			if (self->client->Lmd.customForceRegenSpeedMultiplier > 0.0)
+				regenTime /= self->client->Lmd.customForceRegenSpeedMultiplier;
 		
 			if(regenTime <= 0)
 				regenTime = 1;


### PR DESCRIPTION
Refactoring to target_fp.
I've rethought that idea and now made a new entity named target_fp.

Example: /place target_fp * targetname,asd,modifypowers,absorb5.grip0.theal3

This example would give the activator absorb level 5, grip level 0, and team heal 3. It would overwrite his existing forcepowers.
Death and only death will reset this.

A table for usable values in "ModifyPowers":

    {"jump", FP_LEVITATION},
    {"push", FP_PUSH},
    {"pull", FP_PULL},
    {"speed", FP_SPEED},
    {"seeing", FP_SEE},

    {"heal", FP_HEAL},
    {"protect", FP_PROTECT},
    {"absorb", FP_ABSORB},
    {"mindtrick", FP_TELEPATHY},
    {"theal", FP_TELEPATHY},

    {"grip", FP_GRIP},
    {"lightning", FP_LIGHTNING},
    {"rage", FP_RAGE},
    {"drain", FP_DRAIN},
    {"tforce", FP_TEAM_FORCE},

    {"sattack", FP_SABER_OFFENSE},
    {"sdefend", FP_SABER_DEFENSE},
    {"sthrow", FP_SABERTHROW},


This PR includes a Fix for va() Dropping the server.