### PR TITLE
Spawnflags 1024 on lmd_restrict to restrict special saber moves.

### DIFF
--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3209,6 +3209,7 @@ const entityInfoData_t lmd_restrict_spawnflags[] = {
     {"128", "Start disabled.  Must be used by a target_activate to have any effect."},
     {"256", "Allow Desann Stance."},
     {"512", "Allow Tavion Stance."},
+    {"1024", "Disallow special saber moves."},
     {NULL, NULL}
 };
 const entityInfoData_t lmd_restrict_keys[] = {

--- a/game/bg_saber.c
+++ b/game/bg_saber.c
@@ -2795,6 +2795,10 @@ qboolean PM_SaberMoveOkayForKata( void )
 
 qboolean PM_CanDoKata( void )
 {
+	gentity_t* ent = &g_entities[pm->ps->clientNum];
+	if (ent && ent->client && ent->client->Lmd.lmd_restrict & 1024)
+		return qfalse;
+	
 	if ( PM_InSecondaryStyle() )
 	{
 		return qfalse;

--- a/game/bg_saber.c
+++ b/game/bg_saber.c
@@ -2653,6 +2653,10 @@ saberMoveName_t PM_SaberAttackForMovement(saberMoveName_t curmove)
 		}
 	}
 
+	gentity_t* ent = &g_entities[pm->ps->clientNum];
+	if (ent && ent->client && ent->client->Lmd.lmd_restrict & 1024 && (BG_SaberInSpecialAttack(newmove) || BG_SaberInSpecial(newmove) || BG_SaberInKata(newmove)))
+		return LS_NONE;
+
 	return newmove;
 }
 
@@ -2894,6 +2898,10 @@ qboolean PM_SaberPowerCheck(void)
 
 qboolean PM_CanDoRollStab( void )
 {
+	gentity_t* ent = &g_entities[pm->ps->clientNum];
+	if (ent && ent->client && ent->client->Lmd.lmd_restrict & 1024)
+		return qfalse;
+
 	if ( pm->ps->weapon == WP_SABER )
 	{
                 //Lugormod: A little hack


### PR DESCRIPTION
By Adding spawnflags 1024 on an lmd_restrict you can restrict special saber moves. Such as roll stab, katas, butterfly, cartwheels.