### PR TITLE
NPCs Enhancement.

### DIFF
--- a/docs/entities/npc-entities.md
+++ b/docs/entities/npc-entities.md
@@ -50,6 +50,7 @@ noCombatSounds  - set to 1 to prevent loading and usage of combat sounds
                   (anger, victory, etc.)
 noExtraSounds   - set to 1 to prevent loading and usage of "extra" sounds 
                   (chasing the enemy - detecting them, flanking them... also jedi combat sounds)
+forceResistLevel - <0-4> The higher, the lower the chance of getting his weapon disarmed by force pull. 4 = no chance of disarming. Default is 0.
 ```
 
 

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1803,6 +1803,9 @@ void lmd_menu_exit(gentity_t* player)
 {
     if (!player || !player->client)
         return;
+
+    player->client->Lmd.lmdMenu.lastUsedEntityNum = player->client->Lmd.lmdMenu.entityNum;
+    player->client->Lmd.lmdMenu.lastUsedTime = level.time;
     player->client->Lmd.lmdMenu.entityNum = 0;
     player->client->Lmd.lmdMenu.selection = 0;
     player->client->Lmd.lmdMenu.stoppedPressingUsing = qfalse;

--- a/game/Lmd_Force_Neutral.c
+++ b/game/Lmd_Force_Neutral.c
@@ -451,6 +451,13 @@ void Force_Throw_Client(gentity_t *self, gentity_t *target, int pushPower, qbool
 				if (randfact < 0)
 					randfact = 0;
 			}
+
+			if (target->NPC)
+			{
+				randfact -= target->genericValue9 * 3;
+				if (randfact < 0)
+					randfact = 0;
+			}
 	
 			if (canPullWeapon && Q_irand(1, 10) <= randfact && !OnSameTeam(self, target)) {
 				vec3_t uorg, vecnorm;

--- a/game/Lmd_Weapons_Core.c
+++ b/game/Lmd_Weapons_Core.c
@@ -1627,7 +1627,7 @@ void Weapon_Concussion_AltFire(gentity_t *ent, gentity_t *missile, weaponFire_t 
 						if ( pushDir[2] < 0.2f )
 							pushDir[2] = 0.2f;
 
-						if ( traceEnt->health > 0 && !(traceEnt->NPC && traceEnt->spawnflags & 1024))
+						if ( traceEnt->health > 0 && !(traceEnt->NPC && traceEnt->NPC->scriptFlags & SCF_NO_HURT))
 						{//alive
 							//if ( G_HasKnockdownAnims( traceEnt ) )
 							if (!noKnockBack && !traceEnt->localAnimIndex && traceEnt->client->ps.forceHandExtend != HANDEXTEND_KNOCKDOWN &&

--- a/game/Lmd_Weapons_Core.c
+++ b/game/Lmd_Weapons_Core.c
@@ -1627,7 +1627,7 @@ void Weapon_Concussion_AltFire(gentity_t *ent, gentity_t *missile, weaponFire_t 
 						if ( pushDir[2] < 0.2f )
 							pushDir[2] = 0.2f;
 
-						if ( traceEnt->health > 0 )
+						if ( traceEnt->health > 0 && !(traceEnt->NPC && traceEnt->spawnflags & 1024))
 						{//alive
 							//if ( G_HasKnockdownAnims( traceEnt ) )
 							if (!noKnockBack && !traceEnt->localAnimIndex && traceEnt->client->ps.forceHandExtend != HANDEXTEND_KNOCKDOWN &&

--- a/game/NPC_AI_Jedi.c
+++ b/game/NPC_AI_Jedi.c
@@ -2521,7 +2521,7 @@ NOTE: always blocking projectiles in this func!
 extern qboolean G_FindClosestPointOnLineSegment( const vec3_t start, const vec3_t end, const vec3_t from, vec3_t result );
 evasionType_t Jedi_SaberBlockGo( gentity_t *self, usercmd_t *cmd, vec3_t pHitloc, vec3_t phitDir, gentity_t *incoming, float dist ) //dist = 0.0f
 {
-	if (self && self->NPC && self->spawnflags & 1024)
+	if (self && self->NPC && self->NPC->scriptFlags & SCF_NO_HURT)
 		return EVASION_NONE;
 	
 	vec3_t hitloc, hitdir, diff, fwdangles={0,0,0}, right;

--- a/game/NPC_AI_Jedi.c
+++ b/game/NPC_AI_Jedi.c
@@ -2521,6 +2521,9 @@ NOTE: always blocking projectiles in this func!
 extern qboolean G_FindClosestPointOnLineSegment( const vec3_t start, const vec3_t end, const vec3_t from, vec3_t result );
 evasionType_t Jedi_SaberBlockGo( gentity_t *self, usercmd_t *cmd, vec3_t pHitloc, vec3_t phitDir, gentity_t *incoming, float dist ) //dist = 0.0f
 {
+	if (self && self->NPC && self->spawnflags & 1024)
+		return EVASION_NONE;
+	
 	vec3_t hitloc, hitdir, diff, fwdangles={0,0,0}, right;
 	float rightdot;
 	float zdiff;

--- a/game/NPC_combat.c
+++ b/game/NPC_combat.c
@@ -360,6 +360,9 @@ void G_SetEnemy( gentity_t *self, gentity_t *enemy )
 		return;
 	}
 
+	if (self && self->NPC && self->NPC->scriptFlags & SCF_NO_HURT)
+		return;
+
 	//Don't take the enemy if in notarget
 	if ( enemy->flags & FL_NOTARGET )
 		return;

--- a/game/NPC_reactions.c
+++ b/game/NPC_reactions.c
@@ -1012,6 +1012,13 @@ void NPC_Use( gentity_t *self, gentity_t *other, gentity_t *activator )
 		return;
 	}
 
+	if (self->GenericStrings[7] && self->GenericStrings[7][0])
+	{
+		// usetarg, do this instead
+		G_UseTargets2( self, activator, self->GenericStrings[7] );
+		return;
+	}
+
 	SaveNPCGlobals();
 	SetNPCGlobals( self );
 

--- a/game/NPC_spawn.c
+++ b/game/NPC_spawn.c
@@ -1716,6 +1716,14 @@ gentity_t *NPC_Spawn_Do( gentity_t *ent )
 	newent->GenericStrings[7] = ent->GenericStrings[7];
 	newent->Lmd.crosshairText = ent->Lmd.crosshairText;
 	newent->Lmd.crosshairTextRange = ent->Lmd.crosshairTextRange;
+	newent->genericValue8 = ent->genericValue8;
+
+	if (newent->GenericStrings[7] && newent->GenericStrings[7][0])
+	{
+		// we have a usetarg
+		newent->use = NPC_Use;
+		newent->r.svFlags |= SVF_PLAYER_USABLE;
+	}
 
 	if(ent->paintarget)
 	{	//safe to point at owner's string since memory is never freed during game
@@ -1763,7 +1771,15 @@ gentity_t *NPC_Spawn_Do( gentity_t *ent )
 
 	newent->think = NPC_Begin;
 	newent->nextthink = level.time + FRAMETIME;
-	NPC_DefaultScriptFlags( newent );
+	if (newent->genericValue8)
+	{
+		newent->NPC->scriptFlags = newent->genericValue8;
+	}
+	else
+	{
+		NPC_DefaultScriptFlags( newent );
+	}
+	
 
 	//copy over team variables, too
 	newent->s.shouldtarget = ent->s.shouldtarget;
@@ -2142,6 +2158,16 @@ void NPC_Spawn_Tjo(gentity_t *ent){
 	trap_LinkEntity(newent);
 	newent->spawnflags = ent->spawnflags;
 	newent->GenericStrings[7] = ent->GenericStrings[7];
+	newent->Lmd.crosshairText = ent->Lmd.crosshairText;
+	newent->Lmd.crosshairTextRange = ent->Lmd.crosshairTextRange;
+	newent->genericValue8 = ent->genericValue8;
+
+	if (newent->GenericStrings[7] && newent->GenericStrings[7][0])
+	{
+		// we have a usetarg
+		newent->use = NPC_Use;
+		newent->r.svFlags |= SVF_PLAYER_USABLE;
+	}
 	
 	if(ent->paintarget)
 	{	//safe to point at owner's string since memory is never freed during game
@@ -2193,7 +2219,14 @@ void NPC_Spawn_Tjo(gentity_t *ent){
 
 	newent->think = NPC_Begin;
 	newent->nextthink = level.time + FRAMETIME;
-	NPC_DefaultScriptFlags( newent );
+	if (newent->genericValue8)
+	{
+		newent->NPC->scriptFlags = newent->genericValue8;
+	}
+	else
+	{
+		NPC_DefaultScriptFlags( newent );
+	}
 
 	//copy over team variables, too
 	newent->s.shouldtarget = ent->s.shouldtarget;
@@ -2456,8 +2489,6 @@ const entityInfoData_t NPC_spawner_spawnflags[] = {
 	{"16", "NPC can be in air, but will spawn on the closest floor surface below it"},
 	{"32", "Will spawn with no default AI (BS_CINEMATIC), or the blinking that happens when it spawns"},
 	{"256", "Spawner is shy (wont spawn if a player is looking at it)"},
-	{"512", "Unaffected by force powers"},
-	{"1024", "Unaffected by weapons"},
 	{NULL, NULL}
 };
 const entityInfoData_t NPC_spawner_keys[] = {
@@ -2529,6 +2560,7 @@ void SP_NPC_spawner( gentity_t *self){
 	G_SpawnString("usetarget", "", &self->GenericStrings[7]);
 	G_SpawnString("crosshairText", "", &self->Lmd.crosshairText);
 	G_SpawnInt("crosshairTextRange", "9999", &self->Lmd.crosshairTextRange);
+	G_SpawnInt("scriptflags", "", &self->genericValue8);
 
 	if ( self->targetname )
 		self->use = NPC_Spawn;

--- a/game/NPC_spawn.c
+++ b/game/NPC_spawn.c
@@ -1717,6 +1717,7 @@ gentity_t *NPC_Spawn_Do( gentity_t *ent )
 	newent->Lmd.crosshairText = ent->Lmd.crosshairText;
 	newent->Lmd.crosshairTextRange = ent->Lmd.crosshairTextRange;
 	newent->genericValue8 = ent->genericValue8;
+	newent->genericValue9 = ent->genericValue9;
 
 	if (newent->GenericStrings[7] && newent->GenericStrings[7][0])
 	{
@@ -2161,6 +2162,7 @@ void NPC_Spawn_Tjo(gentity_t *ent){
 	newent->Lmd.crosshairText = ent->Lmd.crosshairText;
 	newent->Lmd.crosshairTextRange = ent->Lmd.crosshairTextRange;
 	newent->genericValue8 = ent->genericValue8;
+	newent->genericValue9 = ent->genericValue9;
 
 	if (newent->GenericStrings[7] && newent->GenericStrings[7][0])
 	{
@@ -2219,6 +2221,8 @@ void NPC_Spawn_Tjo(gentity_t *ent){
 
 	newent->think = NPC_Begin;
 	newent->nextthink = level.time + FRAMETIME;
+
+
 	if (newent->genericValue8)
 	{
 		newent->NPC->scriptFlags = newent->genericValue8;
@@ -2558,6 +2562,7 @@ void SP_NPC_spawner( gentity_t *self){
 	NPC_Precache(self);
 
 	G_SpawnString("usetarget", "", &self->GenericStrings[7]);
+	G_SpawnInt("forceResistLevel", "0", &self->genericValue9);
 	G_SpawnString("crosshairText", "", &self->Lmd.crosshairText);
 	G_SpawnInt("crosshairTextRange", "9999", &self->Lmd.crosshairTextRange);
 	G_SpawnInt("scriptflags", "", &self->genericValue8);
@@ -4671,6 +4676,12 @@ void SP_LMD_spawner (gentity_t *NPCspawner){
 		NPC_GalakMech_Precache();
 	else if ( !Q_stricmp( "wampa", NPCspawner->NPC_type ))
 		NPC_Wampa_Precache();
+
+	G_SpawnString("usetarget", "", &NPCspawner->GenericStrings[7]);
+	G_SpawnInt("forceResistLevel", "0", &NPCspawner->genericValue9);
+	G_SpawnString("crosshairText", "", &NPCspawner->Lmd.crosshairText);
+	G_SpawnInt("crosshairTextRange", "9999", &NPCspawner->Lmd.crosshairTextRange);
+	G_SpawnInt("scriptflags", "", &NPCspawner->genericValue8);
 
 	NPCspawner->damage = 60000;
 

--- a/game/NPC_spawn.c
+++ b/game/NPC_spawn.c
@@ -1713,6 +1713,9 @@ gentity_t *NPC_Spawn_Do( gentity_t *ent )
 
 	trap_LinkEntity(newent);
 	newent->spawnflags = ent->spawnflags;
+	newent->GenericStrings[7] = ent->GenericStrings[7];
+	newent->Lmd.crosshairText = ent->Lmd.crosshairText;
+	newent->Lmd.crosshairTextRange = ent->Lmd.crosshairTextRange;
 
 	if(ent->paintarget)
 	{	//safe to point at owner's string since memory is never freed during game
@@ -2138,7 +2141,8 @@ void NPC_Spawn_Tjo(gentity_t *ent){
 
 	trap_LinkEntity(newent);
 	newent->spawnflags = ent->spawnflags;
-
+	newent->GenericStrings[7] = ent->GenericStrings[7];
+	
 	if(ent->paintarget)
 	{	//safe to point at owner's string since memory is never freed during game
 		newent->paintarget = ent->paintarget;
@@ -2452,6 +2456,8 @@ const entityInfoData_t NPC_spawner_spawnflags[] = {
 	{"16", "NPC can be in air, but will spawn on the closest floor surface below it"},
 	{"32", "Will spawn with no default AI (BS_CINEMATIC), or the blinking that happens when it spawns"},
 	{"256", "Spawner is shy (wont spawn if a player is looking at it)"},
+	{"512", "Unaffected by force powers"},
+	{"1024", "Unaffected by weapons"},
 	{NULL, NULL}
 };
 const entityInfoData_t NPC_spawner_keys[] = {
@@ -2466,6 +2472,7 @@ const entityInfoData_t NPC_spawner_keys[] = {
 	{"NPC_target5", "target to fire when killed for the player that killed the entity (target credits)"},
 	{"NPC_target6", "target to fire when npc kills a player"},
 	{"health", "starting health (default 100)"},
+	{"usetarget", "fires when used by player"},
 	{"showhealth", "set to 1 to show health bar on this entity when crosshair is over it"},
 	{"noBasicSounds", "set to 1 to prevent loading and usage of basic sounds (pain, death, etc)"},
 	{"noCombatSounds", "set to 1 to prevent loading and usage of combat sounds (anger, victory, etc)"},
@@ -2477,6 +2484,8 @@ const entityInfoData_t NPC_spawner_keys[] = {
 	{"painscript", "default script to run when hit"},
 	{"fleescript", "default script to run when hit and below 50 percent health"},
 	{"deathscript", "default script to run when killed"},
+	{"CrosshairText", "Displays this text when a player looks at this entity."},
+	{"CrosshairTextRange", "Displays the CrosshairText if we are at least this close to the entity."},
 	{NULL, NULL}
 };
 const entityInfo_t NPC_spawner_info = {
@@ -2516,6 +2525,10 @@ void SP_NPC_spawner( gentity_t *self){
 
 	//rww - can't cheat and do this on the client like in SP, so I'm doing this.
 	NPC_Precache(self);
+
+	G_SpawnString("usetarget", "", &self->GenericStrings[7]);
+	G_SpawnString("crosshairText", "", &self->Lmd.crosshairText);
+	G_SpawnInt("crosshairTextRange", "9999", &self->Lmd.crosshairTextRange);
 
 	if ( self->targetname )
 		self->use = NPC_Spawn;

--- a/game/b_public.h
+++ b/game/b_public.h
@@ -28,32 +28,33 @@
 #define NPCAI_CUSTOM_GRAVITY	0x00200000	//Don't use g_gravity, I fly!
 
 //Script flags
-#define	SCF_CROUCHED		0x00000001	//Force ucmd.upmove to be -127
-#define	SCF_WALKING			0x00000002	//Force BUTTON_WALKING to be pressed
-#define	SCF_MORELIGHT		0x00000004	//NPC will have a minlight of 96
-#define	SCF_LEAN_RIGHT		0x00000008	//Force rightmove+BUTTON_USE
-#define	SCF_LEAN_LEFT		0x00000010	//Force leftmove+BUTTON_USE
-#define	SCF_RUNNING			0x00000020	//Takes off walking button, overrides SCF_WALKING
-#define	SCF_ALT_FIRE		0x00000040	//Force to use alt-fire when firing
-#define	SCF_NO_RESPONSE		0x00000080	//NPC will not do generic responses to being used
-#define	SCF_FFDEATH			0x00000100	//Just tells player_die to run the friendly fire deathscript
-#define	SCF_NO_COMBAT_TALK	0x00000200	//NPC will not use their generic combat chatter stuff
-#define	SCF_CHASE_ENEMIES	0x00000400	//NPC chase enemies - FIXME: right now this is synonymous with using combat points... should it be?
-#define	SCF_LOOK_FOR_ENEMIES	0x00000800	//NPC be on the lookout for enemies
-#define	SCF_FACE_MOVE_DIR	0x00001000	//NPC face direction it's moving - FIXME: not really implemented right now
-#define	SCF_IGNORE_ALERTS	0x00002000	//NPC ignore alert events
-#define SCF_DONT_FIRE		0x00004000	//NPC won't shoot
-#define	SCF_DONT_FLEE		0x00008000	//NPC never flees
-#define	SCF_FORCED_MARCH	0x00010000	//NPC that the player must aim at to make him walk
-#define	SCF_NO_GROUPS		0x00020000	//NPC cannot alert groups or be part of a group
-#define	SCF_FIRE_WEAPON		0x00040000	//NPC will fire his (her) weapon
-#define	SCF_NO_MIND_TRICK	0x00080000	//Not succeptible to mind tricks
-#define	SCF_USE_CP_NEAREST	0x00100000	//Will use combat point close to it, not next to player or try and flank player
-#define	SCF_NO_FORCE		0x00200000	//Not succeptible to force powers
-#define	SCF_NO_FALLTODEATH	0x00400000	//NPC will not scream and tumble and fall to hit death over large drops
-#define	SCF_NO_ACROBATICS	0x00800000	//Jedi won't jump, roll or cartwheel
-#define	SCF_USE_SUBTITLES	0x01000000	//Regardless of subtitle setting, this NPC will display subtitles when it speaks lines
-#define	SCF_NO_ALERT_TALK	0x02000000	//Will not say alert sounds, but still can be woken up by alerts
+#define	SCF_CROUCHED		    0x00000001	// Force ucmd.upmove to be -127 (1)
+#define	SCF_WALKING			    0x00000002	// Force BUTTON_WALKING to be pressed (2)
+#define	SCF_MORELIGHT		    0x00000004	// NPC will have a minlight of 96 (4)
+#define	SCF_LEAN_RIGHT		    0x00000008	// Force rightmove+BUTTON_USE (8)
+#define	SCF_LEAN_LEFT		    0x00000010	// Force leftmove+BUTTON_USE (16)
+#define	SCF_RUNNING			    0x00000020	// Takes off walking button, overrides SCF_WALKING (32)
+#define	SCF_ALT_FIRE		    0x00000040	// Force to use alt-fire when firing (64)
+#define	SCF_NO_RESPONSE		    0x00000080	// NPC will not do generic responses to being used (128)
+#define	SCF_FFDEATH			    0x00000100	// Just tells player_die to run the friendly fire deathscript (256)
+#define	SCF_NO_COMBAT_TALK	    0x00000200	// NPC will not use their generic combat chatter stuff (512)
+#define	SCF_CHASE_ENEMIES	    0x00000400	// NPC chase enemies (1024)
+#define	SCF_LOOK_FOR_ENEMIES	0x00000800	// NPC be on the lookout for enemies (2048)
+#define	SCF_FACE_MOVE_DIR	    0x00001000	// NPC face direction it's moving (4096)
+#define	SCF_IGNORE_ALERTS	    0x00002000	// NPC ignore alert events (8192)
+#define	SCF_DONT_FIRE		    0x00004000	// NPC won't shoot (16384)
+#define	SCF_DONT_FLEE		    0x00008000	// NPC never flees (32768)
+#define	SCF_FORCED_MARCH	    0x00010000	// NPC that the player must aim at to make him walk (65536)
+#define	SCF_NO_GROUPS		    0x00020000	// NPC cannot alert groups or be part of a group (131072)
+#define	SCF_FIRE_WEAPON		    0x00040000	// NPC will fire his (her) weapon (262144)
+#define	SCF_NO_MIND_TRICK	    0x00080000	// Not susceptible to mind tricks (524288)
+#define	SCF_USE_CP_NEAREST	    0x00100000	// Will use combat point close to it, not next to player or try and flank player (1048576)
+#define	SCF_NO_FORCE		    0x00200000	// Not susceptible to force powers (2097152)
+#define	SCF_NO_FALLTODEATH	    0x00400000	// NPC will not scream and tumble and fall to hit death over large drops (4194304)
+#define	SCF_NO_ACROBATICS	    0x00800000	// Jedi won't jump, roll or cartwheel (8388608)
+#define	SCF_USE_SUBTITLES	    0x01000000	// Regardless of subtitle setting, this NPC will display subtitles when it speaks lines (16777216)
+#define	SCF_NO_ALERT_TALK	    0x02000000	// Will not say alert sounds, but still can be woken up by alerts (33554432)
+#define	SCF_NO_HURT				0x04000000	// Will not be hurt or affected by weapons (67108864)
 
 //#ifdef __DEBUG
 

--- a/game/g_combat.c
+++ b/game/g_combat.c
@@ -3189,7 +3189,7 @@ void G_ApplyKnockback( gentity_t *targ, vec3_t newDir, float knockback )
 		//return;
 	}
 
-	if (targ && targ->NPC && targ->spawnflags & 1024)
+	if (targ && targ->NPC && targ->NPC->scriptFlags & SCF_NO_HURT)
 		mass = 999999;
 	
 	if ( targ->physicsBounce > 0 )	//overide the mass
@@ -4733,7 +4733,7 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_
 		return;
 	}
 
-	if (targ && targ->NPC && targ->spawnflags & 1024)
+	if (targ && targ->NPC && targ->NPC->scriptFlags & SCF_NO_HURT)
 		return;
 
 	//RoboPhred:

--- a/game/g_combat.c
+++ b/game/g_combat.c
@@ -3188,6 +3188,10 @@ void G_ApplyKnockback( gentity_t *targ, vec3_t newDir, float knockback )
 		mass = 999999;
 		//return;
 	}
+
+	if (targ && targ->NPC && targ->spawnflags & 1024)
+		mass = 999999;
+	
 	if ( targ->physicsBounce > 0 )	//overide the mass
 		mass = targ->physicsBounce;
 	else
@@ -4728,6 +4732,9 @@ void G_Damage( gentity_t *targ, gentity_t *inflictor, gentity_t *attacker, vec3_
 	if (!targ->takedamage) {
 		return;
 	}
+
+	if (targ && targ->NPC && targ->spawnflags & 1024)
+		return;
 
 	//RoboPhred:
 	if(targ->s.number < MAX_CLIENTS && targ->client && attacker && attacker->client && attacker != targ && (targ->flags & FL_GODMODE || targ->flags & FL_UNDYING) && !(targ->client->ps.eFlags & EF_NODRAW)) {

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -5730,35 +5730,6 @@ ContinueThink:
 
 				// lumaya: MediLevitate
 				lmd_meditate_levitate_update(ent);
-
-				gentity_t* pcn = &g_entities[ent->client->Lmd.crosshairEntNum];
-				if (ent->client->pers.cmd.buttons & BUTTON_USE
-					&& pcn && pcn->NPC
-					&& pcn->GenericStrings[7] && pcn->GenericStrings[7][0])
-				{
-					
-					float dist = Distance(ent->client->ps.origin, pcn->r.currentOrigin);
-					if (dist > 50)
-						return;
-
-					if (ent->client->ps.torsoAnim != BOTH_BUTTON_HOLD)
-					{
-						G_SetAnim( ent, SETANIM_TORSO, BOTH_BUTTON_HOLD,
-							SETANIM_FLAG_OVERRIDE|SETANIM_FLAG_HOLD, 0 );
-					}
-					else
-					{
-						ent->client->ps.torsoTimer = 500;
-					}
-					
-					ent->client->ps.weaponTime = ent->client->ps.torsoTimer;
-					
-					if (level.time - ent->client->Lmd.lmdMenu.lastUsedTime < 1000)
-						return;
-					
-					G_UseTargets2(pcn, ent, pcn->GenericStrings[7]);
-					
-				}
 				
 				if (ent->client->Lmd.lmdMenu.entityNum != 0)
 				{

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -5731,6 +5731,34 @@ ContinueThink:
 				// lumaya: MediLevitate
 				lmd_meditate_levitate_update(ent);
 
+				gentity_t* pcn = &g_entities[ent->client->Lmd.crosshairEntNum];
+				if (ent->client->pers.cmd.buttons & BUTTON_USE
+					&& pcn && pcn->NPC
+					&& pcn->GenericStrings[7] && pcn->GenericStrings[7][0])
+				{
+					
+					float dist = Distance(ent->client->ps.origin, pcn->r.currentOrigin);
+					if (dist > 50)
+						return;
+
+					if (ent->client->ps.torsoAnim != BOTH_BUTTON_HOLD)
+					{
+						G_SetAnim( ent, SETANIM_TORSO, BOTH_BUTTON_HOLD,
+							SETANIM_FLAG_OVERRIDE|SETANIM_FLAG_HOLD, 0 );
+					}
+					else
+					{
+						ent->client->ps.torsoTimer = 500;
+					}
+					
+					ent->client->ps.weaponTime = ent->client->ps.torsoTimer;
+					
+					if (level.time - ent->client->Lmd.lmdMenu.lastUsedTime < 1000)
+						return;
+					
+					G_UseTargets2(pcn, ent, pcn->GenericStrings[7]);
+					
+				}
 				
 				if (ent->client->Lmd.lmdMenu.entityNum != 0)
 				{

--- a/game/g_trigger.c
+++ b/game/g_trigger.c
@@ -1831,6 +1831,9 @@ void hurt_touch( gentity_t *self, gentity_t *other, trace_t *trace ) {
 	if(other->flags & FL_GODMODE)
 		return;
 
+	if (other && other->NPC && other->spawnflags & 1024)
+		return;
+
 	if ( self->spawnflags & 16 ) {
 		self->timestamp = level.time + 1000;
 	} else {

--- a/game/g_trigger.c
+++ b/game/g_trigger.c
@@ -1831,7 +1831,7 @@ void hurt_touch( gentity_t *self, gentity_t *other, trace_t *trace ) {
 	if(other->flags & FL_GODMODE)
 		return;
 
-	if (other && other->NPC && other->spawnflags & 1024)
+	if (other && other->NPC && other->NPC->scriptFlags & SCF_NO_HURT)
 		return;
 
 	if ( self->spawnflags & 16 ) {

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -595,6 +595,8 @@ struct gclient_s {
 			unsigned int engageTime;
     		int trainerMenuMode;
     		int currentPage;
+    		int lastUsedEntityNum;
+    		unsigned int lastUsedTime;
 		} lmdMenu;
 
 		struct

--- a/game/w_force.c
+++ b/game/w_force.c
@@ -983,6 +983,8 @@ int ForcePowerUsableOn(gentity_t *attacker, gentity_t *other, forcePowers_t forc
 		//Ufo:
 		if(other->flags & FL_GODMODE) 
 			return 0;
+		if(other && other->NPC && other->spawnflags & 512)
+			return 0;
 		if(other->client->pers.Lmd.persistantFlags & SPF_IONLYDUEL)
 			return 0;
 

--- a/game/w_force.c
+++ b/game/w_force.c
@@ -983,7 +983,7 @@ int ForcePowerUsableOn(gentity_t *attacker, gentity_t *other, forcePowers_t forc
 		//Ufo:
 		if(other->flags & FL_GODMODE) 
 			return 0;
-		if(other && other->NPC && other->spawnflags & 512)
+		if(other && other->NPC && other->NPC->scriptFlags & SCF_NO_FORCE)
 			return 0;
 		if(other->client->pers.Lmd.persistantFlags & SPF_IONLYDUEL)
 			return 0;

--- a/game/w_saber.c
+++ b/game/w_saber.c
@@ -123,6 +123,10 @@ qboolean G_CanBeEnemy(gentity_t *self, gentity_t *enemy)
 	if ((enemy->flags & FL_GODMODE) && enemy->s.eType != ET_NPC) {
 		return qfalse;
 	}
+
+	if (enemy && enemy->NPC && enemy->spawnflags & 1024)
+		return qfalse;
+	
 	//end Lugormod
 
 	if (g_gametype.integer < GT_TEAM)
@@ -8110,7 +8114,8 @@ static void G_GrabSomeMofos(gentity_t *self)
 			(!BG_InGrappleMove(grabbed->client->ps.legsAnim) || grabbed->client->ps.legsAnim == BOTH_KYLE_GRAB)
 			//&& (!Auths_Inferior(self,grabbed) 
 			//    || (duelInProgress(&self->client->ps) && (self->client->ps.duelIndex == grabbed->s.number)))
-			&& !(grabbed->flags & FL_GODMODE))
+			&& !(grabbed->flags & FL_GODMODE)
+			&& !(grabbed->NPC && grabbed->spawnflags & 1024))
 		{ //grabbed an active player/npc
 			int tortureAnim = -1;
 			int correspondingAnim = -1;

--- a/game/w_saber.c
+++ b/game/w_saber.c
@@ -124,7 +124,7 @@ qboolean G_CanBeEnemy(gentity_t *self, gentity_t *enemy)
 		return qfalse;
 	}
 
-	if (enemy && enemy->NPC && enemy->spawnflags & 1024)
+	if (enemy && enemy->NPC && enemy->NPC->scriptFlags & SCF_NO_HURT)
 		return qfalse;
 	
 	//end Lugormod
@@ -5579,7 +5579,7 @@ evasionType_t Jedi_SaberBlockGo( gentity_t *self, usercmd_t *cmd, vec3_t pHitloc
 void NPC_SetLookTarget( gentity_t *self, int entNum, int clearTime );
 void WP_SaberStartMissileBlockCheck( gentity_t *self, usercmd_t *ucmd  )
 {
-	if (self && self->NPC && self->spawnflags & 1024)
+	if (self && self->NPC && self->NPC->scriptFlags & SCF_NO_HURT)
 		return;
 		
 	float		dist;
@@ -8118,7 +8118,7 @@ static void G_GrabSomeMofos(gentity_t *self)
 			//&& (!Auths_Inferior(self,grabbed) 
 			//    || (duelInProgress(&self->client->ps) && (self->client->ps.duelIndex == grabbed->s.number)))
 			&& !(grabbed->flags & FL_GODMODE)
-			&& !(grabbed->NPC && grabbed->spawnflags & 1024))
+			&& !(grabbed->NPC && grabbed->NPC->scriptFlags & SCF_NO_HURT))
 		{ //grabbed an active player/npc
 			int tortureAnim = -1;
 			int correspondingAnim = -1;

--- a/game/w_saber.c
+++ b/game/w_saber.c
@@ -5579,6 +5579,9 @@ evasionType_t Jedi_SaberBlockGo( gentity_t *self, usercmd_t *cmd, vec3_t pHitloc
 void NPC_SetLookTarget( gentity_t *self, int entNum, int clearTime );
 void WP_SaberStartMissileBlockCheck( gentity_t *self, usercmd_t *ucmd  )
 {
+	if (self && self->NPC && self->spawnflags & 1024)
+		return;
+		
 	float		dist;
 	gentity_t	*ent, *incoming = NULL;
 	int			entityList[MAX_GENTITIES];


### PR DESCRIPTION
- Made NPC's interactable, they now take a new key named "usetarget", which fires when you use the NPC. For instance you can target a lmd_terminal or lmd_trainer on them.
- NPCs can now be unaffected to weapons. see comment below.
- NPCs can now be unaffected to force powers. see comment below.
- NPCs now accept crosshairText and crosshairTextRange keys.