### PR TITLE
After the latest update we only had the crosshairEntNumber updating if we have a new Ent aimed at.

### DIFF
--- a/game/Lmd_Crosshair.c
+++ b/game/Lmd_Crosshair.c
@@ -79,7 +79,7 @@ void lmd_crosshairEntTrace(const gentity_t* ent)
     fPos[1] = ent->client->renderInfo.eyePoint[1] + fPos[1]*9999;
     fPos[2] = ent->client->renderInfo.eyePoint[2] + fPos[2]*9999;
 
-    trap_Trace(&tr,ent->client->renderInfo.eyePoint, mins, maxs, fPos, ent->s.number, ent->clipmask);
+    trap_Trace(&tr,ent->client->renderInfo.eyePoint, mins, maxs, fPos, ent->s.number, MASK_ALL);
 
     ent->client->Lmd.crosshairEntNum = tr.entityNum;
 }

--- a/game/Lmd_Crosshair.c
+++ b/game/Lmd_Crosshair.c
@@ -63,13 +63,23 @@ void lmd_crosshairEntText(const gentity_t* ent)
 }
 
 
-extern gentity_t* AimAnyTarget (const gentity_t *ent, int length);
 void lmd_crosshairEntTrace(const gentity_t* ent)
 {
     if (!ent->client)
         return;
+    
+    trace_t tr;
+    vec3_t fPos,maxs,mins;
 
-    gentity_t *tracedEntity = AimAnyTarget(ent, 9999);
-    if (tracedEntity)
-        ent->client->Lmd.crosshairEntNum = tracedEntity - g_entities;
+    AngleVectors(ent->client->ps.viewangles, fPos, 0, 0);
+    VectorSet( mins, -8, -8, -8 );
+    VectorSet( maxs, 8, 8, 8 );
+
+    fPos[0] = ent->client->renderInfo.eyePoint[0] + fPos[0]*9999;
+    fPos[1] = ent->client->renderInfo.eyePoint[1] + fPos[1]*9999;
+    fPos[2] = ent->client->renderInfo.eyePoint[2] + fPos[2]*9999;
+
+    trap_Trace(&tr,ent->client->renderInfo.eyePoint, mins, maxs, fPos, ent->s.number, ent->clipmask);
+
+    ent->client->Lmd.crosshairEntNum = tr.entityNum;
 }

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -538,7 +538,7 @@ void SP_target_fp( gentity_t *ent )
 	G_SpawnString("ModifyPowers", "", &ent->target2);
 	G_SpawnFloat("ForceRegenSpeedMultiplier", "0.0", &ent->modelScale[0]);
 
-	if (Q_stricmp(ent->target2, "") && ent->modelScale[0] == 0.0)
+	if (!Q_stricmp(ent->target2, "") && ent->modelScale[0] == 0.0)
 	{
 		EntitySpawnError("Both ModifyPowers and ForceRegenSpeedMultiplier are invalid.");
 		G_FreeEntity(ent);


### PR DESCRIPTION
That would lead to crosshairtexts being displayed even if youre no longer aiming at the entity displaying the crosshairtext.
This also fixes a typo in target_fp.