### PR TITLE
Entityinfo improvements/fixes

### DIFF
--- a/docs/entities/lmd-entities.md
+++ b/docs/entities/lmd-entities.md
@@ -56,6 +56,7 @@ Restricts the person inside of it by whatever spawnflags are set. Use maxs/mins 
 4     - No jetpack
 8     - No duels, existing duels break if a player enters this.
 16    - No firing weapons
+32    - Players in this area will not be able to use force jump.
 128   - Start inactive, must be hit by a target_activate entity to become active.
 256   - Alow Desann Stance
 512   - Allow Tavion Stance

--- a/docs/entities/lmd-entities.md
+++ b/docs/entities/lmd-entities.md
@@ -50,16 +50,16 @@ Restricts the person inside of it by whatever spawnflags are set. Use maxs/mins 
 ### Spawnflags:
 
 ```
-1     - Damage restrict, the people inside cannot be inflicted with damage
-2     - Restrict forcepowers
-        (includes non-offensive force heal/protect etc...)
-4     - No jetpack
-8     - No duels, existing duels break if a player enters this.
-16    - No firing weapons
-32    - Players in this area will not be able to use force jump.
-128   - Start inactive, must be hit by a target_activate entity to become active.
-256   - Alow Desann Stance
-512   - Allow Tavion Stance
+1    - Players in this area will not take damage.
+2    - Players in this area will not be able to use forcepowers.
+4    - Players in this area will not be able to use their jetpack.
+8    - Players in this area will not be able to duel.  Existing duels will be broken if a player enters it.
+16   - Players in this area will not be able to fire weapons.  Players may still see the weapon fire animation.
+32   - Players in this area will not be able to use force jump.
+128  - Start disabled.  Must be used by a target_activate to have any effect.
+256  - Allow Desann Stance.
+512  - Allow Tavion Stance.
+1024 - Disallow special saber moves.
 ```
 
 ### Keys:

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -3218,6 +3218,7 @@ const entityInfoData_t lmd_restrict_spawnflags[] = {
     {"4", "Players in this area will not be able to use their jetpack."},
     {"8", "Players in this area will not be able to duel.  Existing duels will be broken if a player enters it."},
     {"16", "Players in this area will not be able to fire weapons.  Players may still see the weapon fire animation."},
+    {"32", "Players in this area will not be able to use force jump."},
     {"128", "Start disabled.  Must be used by a target_activate to have any effect."},
     {"256", "Allow Desann Stance."},
     {"512", "Allow Tavion Stance."},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -1427,8 +1427,6 @@ void Cmd_Entityinfo_t(gentity_t *ent, int iArg) {
 				color = qfalse;
 				header = qfalse;
 				for(data = spawn->info->spawnflags; data->key != NULL; data++) {
-					if(!data->key == 0)
-						break;
 					if(!header) {
 						Disp(ent, "^2Spawnflags ===============================================");
 						header = qtrue;

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -1445,18 +1445,24 @@ void Cmd_Entityinfo_t(gentity_t *ent, int iArg) {
 					}
 					if(Q_stricmp(data->key, "#UKEYS") == 0) {
 						const entityInfoData_t *d2;
-						for(d2 = usable_key_description; d2->key != NULL; d2++)
+						for(d2 = usable_key_description; d2->key != NULL; d2++) {
 							Disp(ent, va("%s%s: %s", (color)?"^3":"", d2->key, d2->value));
+							color = !color;
+						}
 					}
 					else if(Q_stricmp(data->key, "#MODEL") == 0) {
 						Disp(ent, va("%s%s: %s", (color)?"^3":"", model_key_description.key, model_key_description.value));
+						color = !color;
 					}
 					else if(Q_stricmp(data->key, "#HITBOX") == 0) {
 						Disp(ent, va("%s%s: %s", (color)?"^3":"", hitbox_key_description.key, hitbox_key_description.value));
+						color = !color;
 					}
 					else
+					{
 						Disp(ent, va("%s%s: %s", (color)?"^3":"", data->key, data->value));
-					color = !color;
+						color = !color;
+					}
 				}
 			}
 			if(spawn->info->description != NULL) {


### PR DESCRIPTION
- Documented `lmd_restrict` spawnflag `32` (no force jump),
- `lmd_restrict` spawnflags are now identical in documentation and code,
- Removed faulty condition preventing spawnflags from showing on `/entityinfo`,
- Fixed #UKEYS colors not alternating in `/entityinfo`.