### PR TITLE
Target_fp resetpowers, documentation target_fp and lmd_trainer.

### DIFF
--- a/docs/entities/lmd-entities.md
+++ b/docs/entities/lmd-entities.md
@@ -393,6 +393,35 @@ targetname  - make the trigger target this value for the entity to be used
 ```
 /place lmd_toggle * target,red_light,target2,blue_light,target3,green_light,count,3,targetname,light_sequence,
 ```
+## lmd_trainer *(L)
+Interactive training menu that lets players view account information, learn professions, and upgrade skills via an on-screen interface.
+
+### Keys:
+
+```
+targetname  - Activate the trainer when triggered (for example from a button or lmd_terminal).
+Color1      - Color code used for the currently selected menu option. Defaults to ^3.
+Color2      - Color code used for the main body text. Defaults to ^7.
+Color3      - Color code used for highlighted information. Defaults to ^5.
+message     - Custom text shown on the landing screen. Use `.t` for the trainer name, `.l` for the player's level, and `.n` for the player's name.
+selectsnd   - Sound played when confirming a menu choice. Defaults to `sound/movers/switches/switch1.mp3`.
+navsnd      - Sound played while navigating the menu. Defaults to `sound/interface/menuroam.mp3`.
+cancelsnd   - Sound played when cancelling or closing the menu. Defaults to `sound/interface/esc.mp3`.
+prof        - Restrict usage to specific professions (0 = any, 1 = Jedi, 2 = Merc).
+subprof     - Restrict Force users to a side (0 = any, 1 = light, 2 = dark). Only applies when `prof` is 1.
+anim        - Player animation when the menu opens (0 = console, 1 = talk, 2 = none).
+```
+
+Players must have chosen a profession to access the trainer's skill menus. Trainers can be chained together by targeting them from an `lmd_terminal` or any other entity that fires a `use` event.
+
+### Example code:
+
+```
+/place lmd_trainer 0 targetname,trainer_menu,message,Welcome .n!,Color1,^2,Color2,^7,Color3,^5,prof,1,subprof,1,
+```
+
+- Creates a Jedi-only trainer that greets the player by name and uses custom menu colors.
+
 
 ## lmd_light **(L)
 Spawns a light on the map, recommended you add a number greater than 0 to the z-axis to see the whole light

--- a/docs/entities/target-entities.md
+++ b/docs/entities/target-entities.md
@@ -109,6 +109,16 @@ Applies custom Force power levels and/or a Force regeneration multiplier to whoe
 ### Keys:
 
 ```
+customskill                 - The name of the skill to check. (see lmd_customskill for details)
+customskillcompare          - Comparison type. -1 for direct compare (use this for text), 0 for greater or equal to, 1 for less than. 
+                              (default 0)
+customskillvalue            - The value to compare to.
+property                    - The property to check to fire this entity.
+profession                  - A bitmask of professions. Values: 1 - Jedi, 2 - Merc, 4 - Tech.
+level                       - Minimum player level.
+maxlevel                    - Maximum player level.
+adminlevel                  - Minimum admin level.
+playerflags                 - A bitmask of flags set by the lmd_playerflag entity.
 targetname                  - make the trigger target this value for the entity to be used.
 ModifyPowers                - Dot (`.`) separated list of Force power assignments in the format powernamelevel.
                               For example `push3.lightning1` will set Force Push to level 3 and Lightning to level 1.
@@ -118,9 +128,6 @@ ResetPowers                 - If set to 1 the user's Force powers are reset to t
                               `ModifyPowers`. (Default 0)
 ForceRegenSpeedMultiplier   - Multiplier applied to the player's Force regeneration speed. Must be greater than 0 to have an effect.
 ```
-
-At least one of `ModifyPowers` or `ForceRegenSpeedMultiplier` must be set.
-
 ### Example code:
 
 ```

--- a/docs/entities/target-entities.md
+++ b/docs/entities/target-entities.md
@@ -103,6 +103,33 @@ wait        - duration
 
 - this is an example of what you could use to make a button that would give the player a ysalarimi blast everytime he pressed the button.
 
+## target_fp ** (L)
+Applies custom Force power levels and/or a Force regeneration multiplier to whoever activates it.
+
+### Keys:
+
+```
+targetname                  - make the trigger target this value for the entity to be used.
+ModifyPowers                - Dot (`.`) separated list of Force power assignments in the format powernamelevel.
+                              For example `push3.lightning1` will set Force Push to level 3 and Lightning to level 1.
+                              Supported power names: jump, push, pull, speed, seeing, heal, protect, absorb, mindtrick,
+                              theal, grip, lightning, rage, drain, tforce, sattack, sdefend, sthrow.
+ResetPowers                 - If set to 1 the user's Force powers are reset to their normal values instead of applying
+                              `ModifyPowers`. (Default 0)
+ForceRegenSpeedMultiplier   - Multiplier applied to the player's Force regeneration speed. Must be greater than 0 to have an effect.
+```
+
+At least one of `ModifyPowers` or `ForceRegenSpeedMultiplier` must be set.
+
+### Example code:
+
+```
+/place target_fp * targetname,force_buff,ModifyPowers,push3.lightning2.ForceRegenSpeedMultiplier,1.5,
+```
+
+- When triggered this target gives players Force Push level 3, Force Lightning level 2 and increases their Force regeneration speed by 50%.
+
+
 ## target_remove_powerups **
 Remove all powerups from the person who uses this. In U# It will not longer remove the stash glow effect when a player uses this.
 

--- a/game/Lmd_Prof_Core.c
+++ b/game/Lmd_Prof_Core.c
@@ -766,6 +766,12 @@ void Cmd_SkillSelect(gentity_t *ent, int prof, profSkill_t *skill, int depth) {
 		return;
 	}
 
+	if (ent->client->Lmd.targetFpUsed)
+	{
+		Disp(ent, "^1Your force powers have been set. Can't change right now. Wait for them to be reset or /kill.");
+		return;
+	}
+
 	trap_Argv(depth + 1, arg, sizeof(arg));
 	if(arg[0]) {
 		if(Q_stricmp(arg, "up") == 0) {

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -452,6 +452,7 @@ void SP_target_print( gentity_t *ent ) {
 
 const entityInfoData_t target_fp_keys[] = {
 	{"targetname", "make the trigger target this value for the entity to be used"},
+	{"ResetPowers", "Resets the users original force powers. 0-1 (Default 0)"},
 	{"ModifyPowers", "E.g. ModifyPowers,heal2.rage2 -> would set force heal and rage to level 2. Available keys are: jump, push, pull, speed, seeing, heal, protect, absorb"
 				  "mindtrick, theal, grip, lightning, rage, drain, tforce, sattack, sdefend, sthrow."},
 	{"ForceRegenSpeedMultiplier", "Multiply the existing force regen speed by the given amount. E.g: 1.25. Must be greater than 0."},
@@ -509,6 +510,12 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 		return;
 
 	activator->client->Lmd.customForceRegenSpeedMultiplier = ent->modelScale[0];
+
+	if (ent->Lmd.customIndex == 1)
+	{
+		WP_InitForcePowers(activator);
+		return;
+	}
 	
 	char *token = strtok(ent->target2, ".");
 	while (token)
@@ -537,6 +544,7 @@ void SP_target_fp( gentity_t *ent )
 {
 	G_SpawnString("ModifyPowers", "", &ent->target2);
 	G_SpawnFloat("ForceRegenSpeedMultiplier", "0.0", &ent->modelScale[0]);
+	G_SpawnInt("ResetPowers", "0", &ent->Lmd.customIndex);
 
 	if (!Q_stricmp(ent->target2, "") && ent->modelScale[0] == 0.0)
 	{

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -503,10 +503,13 @@ int lmd_get_forcePowerMapIndex(const char *token) {
 	}
 	return -1;
 }
-
+qboolean PlayerUseableCheck(gentity_t *self, gentity_t *activator);
 void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 {
 	if (!activator || !activator->client)
+		return;
+		
+	if (PlayerUseableCheck(ent, other) == qfalse)
 		return;
 
 	activator->client->Lmd.customForceRegenSpeedMultiplier = ent->modelScale[0];

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -516,9 +516,12 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 
 	if (ent->Lmd.customIndex == 1)
 	{
+		activator->client->Lmd.targetFpUsed = qfalse;
 		WP_InitForcePowers(activator);
 		return;
 	}
+
+	activator->client->Lmd.targetFpUsed = qtrue;
 	
 	char *token = strtok(ent->target2, ".");
 	while (token)

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -509,7 +509,7 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 	if (!activator || !activator->client)
 		return;
 		
-	if (PlayerUseableCheck(ent, other) == qfalse)
+	if (PlayerUseableCheck(ent, activator) == qfalse)
 		return;
 
 	activator->client->Lmd.customForceRegenSpeedMultiplier = ent->modelScale[0];
@@ -548,13 +548,6 @@ void SP_target_fp( gentity_t *ent )
 	G_SpawnString("ModifyPowers", "", &ent->target2);
 	G_SpawnFloat("ForceRegenSpeedMultiplier", "0.0", &ent->modelScale[0]);
 	G_SpawnInt("ResetPowers", "0", &ent->Lmd.customIndex);
-
-	if (!Q_stricmp(ent->target2, "") && ent->modelScale[0] == 0.0)
-	{
-		EntitySpawnError("Both ModifyPowers and ForceRegenSpeedMultiplier are invalid.");
-		G_FreeEntity(ent);
-		return;
-	}
 	
 	ent->use = Use_Target_Fp;
 }

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -609,6 +609,7 @@ struct gclient_s {
 		int crosshairEntNum;
 		unsigned int grabbing;
 		float customForceRegenSpeedMultiplier;
+		qboolean targetFpUsed;
 	}Lmd;
 	unsigned int lastTargetUse;
 	unsigned int infoChanged;


### PR DESCRIPTION
Added lmd_trainer and target_fp to docs.
Added player usable checks to target_fp.
Added new key to target_fp: resetpowers (default 0)
if 1, resets the activators force powers to whatever they were.
Denied to be able to upgrade or downgrade skills once u got locked into target_fp. To reset this wait for target_fp reset or die.