### PR TITLE
No slide off of other player's heads.

### DIFF
--- a/docs/cvars.md
+++ b/docs/cvars.md
@@ -19,6 +19,11 @@ The minimum amount required to do a /bounty.
 ```
 If lmd_maxsameip is set, then this cvar controls whether to ban ips that go over the given limit.
 ```
+## lmd_noPlayerBounce
+### Default value: 0
+```
+<0-1> If 1, you won't slide off of a Players head. Default 0.
+```
 ## lmd_datapath
 ### Default value: default
 ### Restart required

--- a/game/bg_pmove.c
+++ b/game/bg_pmove.c
@@ -1234,7 +1234,7 @@ static void PM_Friction( void ) {
 		drop += speed*pm_waterfriction*pm->waterlevel*pml.frametime;
 	}
 	// If on a client then there is no friction
-	else if ( lmd_noPlayerBounce->integer == 0 && pm->ps->groundEntityNum < MAX_CLIENTS )
+	else if ( lmd_noPlayerBounce.integer == 0 && pm->ps->groundEntityNum < MAX_CLIENTS )
 	{
 		drop = 0;
 	}

--- a/game/bg_pmove.c
+++ b/game/bg_pmove.c
@@ -1119,6 +1119,7 @@ void PM_ClipVelocity( vec3_t in, vec3_t normal, vec3_t out, float overbounce ) {
 	}
 }
 
+extern vmCvar_t lmd_noPlayerBounce;
 
 /*
 ==================
@@ -1233,7 +1234,7 @@ static void PM_Friction( void ) {
 		drop += speed*pm_waterfriction*pm->waterlevel*pml.frametime;
 	}
 	// If on a client then there is no friction
-	else if ( pm->ps->groundEntityNum < MAX_CLIENTS )
+	else if ( lmd_noPlayerBounce->integer == 0 && pm->ps->groundEntityNum < MAX_CLIENTS )
 	{
 		drop = 0;
 	}

--- a/game/g_main.c
+++ b/game/g_main.c
@@ -424,6 +424,8 @@ vmCvar_t lmd_melee_lightning_multiplier;
 
 vmCvar_t lmd_min_bounty_amount;
 
+vmCvar_t lmd_noPlayerBounce;
+
 //RoboPhred: track this and force it to off
 vmCvar_t sv_allowdownload;
 
@@ -436,6 +438,9 @@ static cvarTable_t		gameCvarTable[] = {
 	{ &lmd_maxsameip, "lmd_maxSameIp", "3", CVAR_ARCHIVE, 0, qfalse, qfalse,
 		"Maximum number of users that can have the same ip.  Once this limit is reached for a certain ip, all new "
 		"connections from the ip will be ignored.  Usefull for stopping fake player attacks."
+	},
+	{ &lmd_noPlayerBounce, "lmd_noPlayerBounce", "0", CVAR_ARCHIVE, 0, qtrue, qfalse,
+	"<0-1> If 1, you won't slide off of a Players head. Default 0."
 	},
 	{ &lmd_autobansameip, "lmd_autoBanSameIp", "0", CVAR_ARCHIVE, 0, qfalse, qfalse,
 		"If lmd_maxsameip is set, then this cvar controls whether to ban ips that go over the given limit."


### PR DESCRIPTION
New cvar: lmd_noPlayerBounce.
0 by default. If 1, have friction when on player's heads.