### PR TITLE
Enhance Bounds & Blowup Console Ouput + Undo ability for Blowup

### DIFF
--- a/game/Lmd_Entities_Commands.c
+++ b/game/Lmd_Entities_Commands.c
@@ -272,67 +272,53 @@ void Cmd_BlowUp_f(gentity_t* ent, int iArg)
 {
     gentity_t* tEnt;
     char* spawnstring = NULL;
-    int sLen = 0;
+    int   sLen = 0;
     Action_t* action;
-    char entInfo[128];
+    char  entInfo[128];
 
     if (trap_Argc() > 1)
-    {
         tEnt = GetEnt(atoi(ConcatArgs(1)));
-    }
-    else
-    {
-        G_PlayEffectID(G_EffectIndex(STANDARD_BEAM), ent->client->renderInfo.eyePoint, ent->client->ps.viewangles);
+    else {
+        G_PlayEffectID(G_EffectIndex(STANDARD_BEAM),
+            ent->client->renderInfo.eyePoint,
+            ent->client->ps.viewangles);
         tEnt = AimAnyTarget(ent, 8192);
     }
 
-    if (!tEnt || !tEnt->inuse)
-    {
-        Disp(ent, "^3Invalid entity.");
-        return;
-    }
+    if (!tEnt || !tEnt->inuse) { Disp(ent, "^3Invalid entity."); return; }
+    if (tEnt->s.number == ENTITYNUM_WORLD) { Disp(ent, "^3You cannot blow up the worldspawn."); return; }
 
-    if (tEnt->s.number == ENTITYNUM_WORLD)
-    {
-        Disp(ent, "^3You cannot blow up the worldspawn.");
-        return;
-    }
+    Com_sprintf(entInfo, sizeof(entInfo), "^2%s ^7(^3%d^7)",
+        FormattedEntString(tEnt), tEnt->s.number);
 
-    Com_sprintf(entInfo, sizeof(entInfo), "^2%s ^7(^3%d^7)", FormattedEntString(tEnt), tEnt->s.number);
-
-    if (tEnt->Lmd.spawnData)
-    {
+    if (tEnt->Lmd.spawnData) {
         sLen = Lmd_Entites_GetSpawnstringLen(tEnt->Lmd.spawnData);
-        if (sLen > 0)
-        {
+        if (sLen > 0) {
             spawnstring = (char*)G_Alloc(sLen);
             Lmd_Entities_getSpawnstring(tEnt->Lmd.spawnData, spawnstring, sLen);
         }
     }
 
+    BlowUpEntity(tEnt);
+
+    Disp(ent, va("^3Detonated entity: %s", entInfo));
     if (spawnstring)
-    {
+        Disp(ent, va("^3Spawnstring:\n^2%s", spawnstring));
+
+    if (spawnstring) {
         if ((action = PlayerActions_Add(ent, "undodelete",
             "View the spawnstring of, or respawn, the last detonated entity",
-            Action_UndoDelete, qtrue)))
-        {
+            Action_UndoDelete, qtrue))) {
             action->strArgs[0] = spawnstring;
             action->iArgs[0] = Lmd_Entities_IsSaveable(tEnt);
         }
-        else
-        {
+        else {
             G_Free(spawnstring);
-            spawnstring = NULL;
         }
     }
-
-    BlowUpEntity(tEnt);
-
-    Disp(ent, va("^3Detonated: %s", entInfo));
-    if (spawnstring)
-        Disp(ent, "^3Use ^2/actions undodelete respawn ^3to restore.");
-    else
+    else {
         Disp(ent, "^3No spawnstring - cannot undo.");
+    }
 }
 
 void Cmd_NextMap_f(gentity_t *ent, int iArg) {
@@ -1139,7 +1125,10 @@ void Cmd_Delent_f(gentity_t* ent, int iArg)
     sLen = Lmd_Entites_GetSpawnstringLen(targ->Lmd.spawnData);
     spawnstring = (char*)G_Alloc(sLen);
     Lmd_Entities_getSpawnstring(targ->Lmd.spawnData, spawnstring, sLen);
-    Disp(ent, va("^3Deleting entity: ^2%i\n^3Spawnstring:\n^2%s", targ->s.number, spawnstring));
+    char delInfo[128];
+    Com_sprintf(delInfo, sizeof(delInfo), "^2%s ^7(^3%d^7)", FormattedEntString(targ), targ->s.number);
+    Disp(ent, va("^3Deleting entity: %s", delInfo));
+    Disp(ent, va("^3Spawnstring:\n^2%s", spawnstring));
     if ((action = PlayerActions_Add(ent, "undodelete", "View the spawnstring of, or respawn, the last deleted entity",
                                     Action_UndoDelete, qtrue)))
     {

--- a/game/Lmd_Entities_Commands.c
+++ b/game/Lmd_Entities_Commands.c
@@ -14,6 +14,9 @@
 #define GRAB_Y 3
 #define GRAB_Z 4
 
+// Forward declaration for action handler
+qboolean Action_UndoDelete(gentity_t* ent, Action_t* action);
+
 gentity_t* AimAnyTarget(gentity_t* ent, int length);
 char* ConcatArgs(int start);
 #define STANDARD_BEAM "env/hevil_bolt"
@@ -37,7 +40,7 @@ void BlowUpEntity(gentity_t* ent)
     VectorSet(upVec, -90, 0, 0);
     G_PlayEffectID(G_EffectIndex("env/ion_cannon_explosion"), pos, upVec);
 
-    G_RadiusDamage(pos, NULL, 300, 512, ent, ent, MOD_TRIGGER_HURT);
+    G_RadiusDamage(pos, NULL, 150, 256, ent, ent, MOD_TRIGGER_HURT);
     if (ent->s.number >= MAX_CLIENTS)
     {
         G_FreeEntity(ent);
@@ -157,14 +160,14 @@ void Cmd_Bounds_f(gentity_t* ent, int iArg)
         if (!targ->Lmd.displayBounds)
         {
             // The entity isn't displaying its bounds (yet)
-            // Display the relevant information
+            // Show entity type + number, then current bounds and contents
+            Disp(ent, va("^3%s ^7(^2%d^7)", FormattedEntString(targ), targ->s.number));
             Disp(ent, va(
-                     CT_B"Mins: "CT_V"%s\n"
-                     CT_B"Maxs: "CT_V"%s",
-                     vtos2(targ->r.mins),
-                     vtos2(targ->r.maxs)));
-            Disp(ent, va("^3Contents: ^2%x ^3Clipmask: ^2%x", ent->r.contents, ent->clipmask));
-
+                CT_B"Mins: "CT_V"%s\n"
+                CT_B"Maxs: "CT_V"%s",
+                vtos2(targ->r.mins),
+                vtos2(targ->r.maxs)));
+            Disp(ent, va("^3Contents: ^2%x ^3Clipmask: ^2%x", targ->r.contents, targ->clipmask));
             // Toggle the bounding box ON
             targ->Lmd.displayBounds = qtrue;
             if (!targ->think)
@@ -173,29 +176,29 @@ void Cmd_Bounds_f(gentity_t* ent, int iArg)
                 targ->nextthink = level.time;
             }
             Disp(ent, "^3Bounding box ^2ON");
-            return;
-        }
-
-        // Otherwise, the entity is currently displaying its bounds => Restore entity "think"
-        // Toggle the bounding box OFF
-        targ->Lmd.displayBounds = qfalse;
-        if (targ->Lmd.oldThink)
-        {
-            targ->think = targ->Lmd.oldThink;
-            targ->nextthink = level.time + targ->Lmd.oldNextthink;
         }
         else
         {
-            targ->think = NULL;
-            targ->nextthink = 0;
+            // The entity is currently displaying its bounds => Restore entity "think"
+            // Toggle the bounding box OFF
+            targ->Lmd.displayBounds = qfalse;
+            if (targ->Lmd.oldThink)
+            {
+                targ->think = targ->Lmd.oldThink;
+                targ->nextthink = level.time + targ->Lmd.oldNextthink;
+            }
+            else
+            {
+                targ->think = NULL;
+                targ->nextthink = 0;
+            }
+            // Reset other fields
+            targ->Lmd.oldThink = 0;
+            targ->Lmd.oldNextthink = 0;
+            // Notify the user
+            Disp(ent, va("^3%s ^7(^2%d^7) - Bounding box ^1OFF", FormattedEntString(targ), targ->s.number));
         }
-
-        // Reset other fields
-        targ->Lmd.oldThink = 0;
-        targ->Lmd.oldNextthink = 0;
-
-        // Notify the user
-        Disp(ent, "^3Bounding box ^2OFF");
+        return;
     }
     else if (arg[0])
     {
@@ -267,7 +270,11 @@ void Cmd_Bounds_f(gentity_t* ent, int iArg)
 
 void Cmd_BlowUp_f(gentity_t* ent, int iArg)
 {
-      gentity_t* tEnt;
+    gentity_t* tEnt;
+    char* spawnstring = NULL;
+    int sLen = 0;
+    Action_t* action;
+    char entInfo[128];
 
     if (trap_Argc() > 1)
     {
@@ -278,13 +285,54 @@ void Cmd_BlowUp_f(gentity_t* ent, int iArg)
         G_PlayEffectID(G_EffectIndex(STANDARD_BEAM), ent->client->renderInfo.eyePoint, ent->client->ps.viewangles);
         tEnt = AimAnyTarget(ent, 8192);
     }
-    if (tEnt && tEnt->inuse)
+
+    if (!tEnt || !tEnt->inuse)
     {
-        BlowUpEntity(tEnt);
-        Disp(ent, "^3Entity detonated.");
-    }
-    else
         Disp(ent, "^3Invalid entity.");
+        return;
+    }
+
+    if (tEnt->s.number == ENTITYNUM_WORLD)
+    {
+        Disp(ent, "^3You cannot blow up the worldspawn.");
+        return;
+    }
+
+    Com_sprintf(entInfo, sizeof(entInfo), "^2%s ^7(^3%d^7)", FormattedEntString(tEnt), tEnt->s.number);
+
+    if (tEnt->Lmd.spawnData)
+    {
+        sLen = Lmd_Entites_GetSpawnstringLen(tEnt->Lmd.spawnData);
+        if (sLen > 0)
+        {
+            spawnstring = (char*)G_Alloc(sLen);
+            Lmd_Entities_getSpawnstring(tEnt->Lmd.spawnData, spawnstring, sLen);
+        }
+    }
+
+    if (spawnstring)
+    {
+        if ((action = PlayerActions_Add(ent, "undodelete",
+            "View the spawnstring of, or respawn, the last detonated entity",
+            Action_UndoDelete, qtrue)))
+        {
+            action->strArgs[0] = spawnstring;
+            action->iArgs[0] = Lmd_Entities_IsSaveable(tEnt);
+        }
+        else
+        {
+            G_Free(spawnstring);
+            spawnstring = NULL;
+        }
+    }
+
+    BlowUpEntity(tEnt);
+
+    Disp(ent, va("^3Detonated: %s", entInfo));
+    if (spawnstring)
+        Disp(ent, "^3Use ^2/actions undodelete respawn ^3to restore.");
+    else
+        Disp(ent, "^3No spawnstring - cannot undo.");
 }
 
 void Cmd_NextMap_f(gentity_t *ent, int iArg) {


### PR DESCRIPTION
## Description
Enhances both the `bounds` and `blowup` commands to give more information in the console output, specifically in regards to entity types and entity numbers. Also adds undo functionality to the `blowup` command via `actions undodelete respawn` to bring it in line with the `delent` command.

Upon reviewing the current `bounds` command code, I noted that the 'Contents' value was actually grabbing the player contents, not the contents of the entity that `bounds` was being used on, so this was a bug that had never been noticed previously. Specifically `ent->r.contents` was used which is the player, versus `targ->r.contents` which is the targeted entity. I have fixed this.

As a little extra to this, as we mainly use `blowup` as part of building, I find the damage and damage radius on it quite annoying. Rather than removing this part of it entirely as it is part of why the command exists, I decided to half the damage and the radius from 300 to 150, and 512 to 256 respectively.

## Testing
I have confirmed that this builds, and have also tested both commands in-game and they are appear to be working as intended.

## Issues
This PR relates to #41 & #79 

## Disclaimer
I am still very much a noob, and have basically zero experience with C or C++ as I'm still in the early days of learning C# and Python. But as I want to help out where I can to lighten the load in the understanding that you guys are putting a lot of work in on a voluntary basis I decided that these two Issues are something I could safely address with the assistance of AI. I hope you wont hold that against me as I continue to learn, and if you'd rather not use code that AI assisted me in writing then please feel free to decline the PR.