### PR TITLE
New entity target_doorstate.

### DIFF
--- a/docs/entities/lmd-entities.md
+++ b/docs/entities/lmd-entities.md
@@ -44,6 +44,27 @@ target6   - Corresponding target to fire.
 
 - This randomly genrates a number from 1-7 and fire the target if the number is the same. If it goes over 4, it doesn't fire anything. 4/7 of the time it will do nothing.
 
+## lmd_equalcheck * (L)
+Compares the value of a spawn key across up to six targetnames. When every referenced entity reports the same value (or matches an explicitly provided value) the entity fires `EqualTarget`; otherwise it fires `UnequalTarget`.
+
+### Keys:
+
+```
+target1-6      - targetnames whose entities should be checked.
+key            - spawn key to read from each entity. (required)
+value          - optional expected value. If omitted, the first entity found supplies the reference value.
+EqualTarget    - target to fire when all values match the reference.
+UnequalTarget  - target to fire when a mismatch is detected or a target entity/key is missing.
+```
+
+### Example code:
+
+```
+/place lmd_equalcheck * target1,pillar_a,target2,pillar_b,key,state,EqualTarget,both_active,UnequalTarget,needs_reset,
+```
+
+The example checks that entities named `pillar_a` and `pillar_b` share the same `state` key before triggering `both_active`; otherwise it fires `needs_reset`.
+
 ## lmd_restrict *(L)
 Restricts the person inside of it by whatever spawnflags are set. Use maxs/mins to set the bounding box.
 

--- a/docs/entities/target-entities.md
+++ b/docs/entities/target-entities.md
@@ -169,6 +169,27 @@ target      - what to fire at when the delay time is hit
 
 - This would be for if i pressed a button and i wanna give the player enough time to get to the general area of where the x-wing spawned, so i gave it a three second delay, that way there is a smaller chance of someone stealing that players ship that they paid for.
 
+## target_doorstate **
+Checks a set of func_door or lmd_door entities to make sure they are resting in the position described by their `wantPosition` key. Fires its normal `target` when every door matches; otherwise it fires `target2`. Each monitored door must have `wantPosition` set to either `open` or `close` (synonym `closed`).
+
+### Keys:
+
+```
+target      - fired when all referenced doors match their wantPosition.
+target2     - fired when a door is missing or does not match its wantPosition.
+door1-6     - targetnames of the doors to monitor.
+```
+
+### Example code:
+
+```
+/spawnstring edit vault_door wantPosition close
+/place target_doorstate * target,vault_locked,target2,vault_open,door1,vault_door
+```
+
+The example ensures the door named `vault_door` is closed before firing `vault_locked`; otherwise it fires `vault_open`.
+
+
 ## target_speaker **
 This entity will play a sound that you specify in a certain radius.
 

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -5683,6 +5683,155 @@ void lmd_cskill_compare(gentity_t* self)
     self->use = lmd_cskill_compare_use;
 }
 
+void lmd_equalcheck_use(gentity_t* self, gentity_t* other, gentity_t* activator)
+{
+    const char* keyName = self->GenericStrings[6];
+    if (!keyName || !keyName[0])
+    {
+        return;
+    }
+
+    char compareValue[MAX_STRING_CHARS];
+    qboolean haveCompareValue = qfalse;
+    qboolean mismatch = qfalse;
+    qboolean foundAny = qfalse;
+
+    if (self->GenericStrings[7] && self->GenericStrings[7][0])
+    {
+        Q_strncpyz(compareValue, self->GenericStrings[7], sizeof(compareValue));
+        haveCompareValue = qtrue;
+    }
+
+    for (int i = 0; i < 6 && !mismatch; i++)
+    {
+        const char* targetName = self->GenericStrings[i];
+        if (!targetName || !targetName[0])
+        {
+            continue;
+        }
+
+        gentity_t* ent = NULL;
+        qboolean foundForTarget = qfalse;
+
+        while ((ent = G_Find(ent, FOFS(targetname), targetName)) != NULL)
+        {
+            foundForTarget = qtrue;
+            foundAny = qtrue;
+
+            if (!ent->Lmd.spawnData)
+            {
+                mismatch = qtrue;
+                break;
+            }
+
+            char value[MAX_STRING_CHARS];
+            if (!Lmd_Entities_getSpawnstringKey(ent->Lmd.spawnData, (char*)keyName, value, sizeof(value)))
+            {
+                mismatch = qtrue;
+                break;
+            }
+
+            if (!haveCompareValue)
+            {
+                Q_strncpyz(compareValue, value, sizeof(compareValue));
+                haveCompareValue = qtrue;
+                continue;
+            }
+
+            if (Q_stricmp(compareValue, value) != 0)
+            {
+                mismatch = qtrue;
+                break;
+            }
+        }
+
+        if (mismatch)
+        {
+            break;
+        }
+
+        if (!foundForTarget)
+        {
+            mismatch = qtrue;
+        }
+    }
+
+    if (!haveCompareValue || !foundAny)
+    {
+        mismatch = qtrue;
+    }
+
+    if (!mismatch)
+    {
+        G_UseTargets2(self, activator, self->GenericStrings[8]);
+    }
+    else
+    {
+        G_UseTargets2(self, activator, self->GenericStrings[9]);
+    }
+}
+
+const entityInfoData_t lmd_equalcheck_keys[] = {
+    {"Target1", "First targetname to evaluate."},
+    {"Target2", "Second targetname to evaluate."},
+    {"Target3", "Third targetname to evaluate."},
+    {"Target4", "Fourth targetname to evaluate."},
+    {"Target5", "Fifth targetname to evaluate."},
+    {"Target6", "Sixth targetname to evaluate."},
+    {"Key", "Spawn key to compare across all referenced entities."},
+    {"Value", "Optional expected value; if omitted the first entity's value is used."},
+    {"EqualTarget", "Target to fire when all values match."},
+    {"UnequalTarget", "Target to fire when a mismatch is detected."},
+    {NULL, NULL},
+};
+
+entityInfo_t lmd_equalcheck_info = {
+    "Compares a spawn key across up to six targetnames, firing EqualTarget when all values match and UnequalTarget otherwise.",
+    NULL,
+    lmd_equalcheck_keys
+};
+
+void lmd_equalcheck(gentity_t* self)
+{
+    for (int i = 0; i < 6; i++)
+    {
+        char keyName[16];
+        Com_sprintf(keyName, sizeof(keyName), "target%d", i + 1);
+        G_SpawnString(keyName, "", &self->GenericStrings[i]);
+        if (!self->GenericStrings[i] || !self->GenericStrings[i][0])
+        {
+            self->GenericStrings[i] = NULL;
+        }
+    }
+
+    G_SpawnString("key", "", &self->GenericStrings[6]);
+    if (!self->GenericStrings[6] || !self->GenericStrings[6][0])
+    {
+        G_FreeEntity(self);
+        return;
+    }
+
+    G_SpawnString("value", "", &self->GenericStrings[7]);
+    if (!self->GenericStrings[7] || !self->GenericStrings[7][0])
+    {
+        self->GenericStrings[7] = NULL;
+    }
+
+    G_SpawnString("equaltarget", "", &self->GenericStrings[8]);
+    if (!self->GenericStrings[8] || !self->GenericStrings[8][0])
+    {
+        self->GenericStrings[8] = NULL;
+    }
+
+    G_SpawnString("unequaltarget", "", &self->GenericStrings[9]);
+    if (!self->GenericStrings[9] || !self->GenericStrings[9][0])
+    {
+        self->GenericStrings[9] = NULL;
+    }
+
+    self->use = lmd_equalcheck_use;
+}
+
 void lmd_countcheck_use(gentity_t* self, gentity_t* other, gentity_t* activator)
 {
     int count;

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1416,6 +1416,7 @@ const entityInfoData_t lmd_door_keys[] = {
     {"OpenTarget", "Fired after reaching the \'open\' position."},
     {"Target2", "Fired when it starts moving from the open position to the closed position."},
     {"CloseTarget", "Fire after reaching the \'closed\' position."},
+    {"WantPosition", "Desired resting position for target_doorstate checks. Accepts 'open' or 'close'."},
     {
         "TargetName",
         "Trigger when an entity uses this.  If not specified, the door will open when someone gets close to it."
@@ -1459,6 +1460,11 @@ void lmd_door(gentity_t* ent)
     {
         ent->classname = "lmd_door";
         Lmd_Entities_setSpawnstringKey(ent->Lmd.spawnData, "classname", "lmd_door");
+    }
+    G_SpawnString("wantPosition", "", &ent->GenericStrings[15]);
+    if (ent->GenericStrings[15] && !ent->GenericStrings[15][0])
+    {
+        ent->GenericStrings[15] = NULL;
     }
     G_SpawnInt("vehopen", "0", &ent->genericValue14);
 

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -1668,6 +1668,7 @@ const entityInfoData_t func_door_keys[] = {
   {"opentarget", "Door fires this after reaching it\'s \'open\' position"},
   {"target2", "Door fires this when it starts moving from it\'s open position to it\'s closed position"},
   {"closetarget", "Door fires this after reaching it\'s \'closed\' position"},
+  {"wantPosition", "Desired resting position for target_doorstate checks. Accepts 'open' or 'close'."},
   {"model2", ".md3 model to also draw"},
   {"angle", "determines the opening direction"},
   {"targetname", "if set, no touch field will be spawned and a remote button or trigger field activates the door."},
@@ -1695,9 +1696,15 @@ const entityInfo_t func_door_info = {
   func_door_keys
 };
 
-void SP_func_door (gentity_t *ent) 
+void SP_func_door (gentity_t *ent)
 {
 	//Lugormod
+
+	G_SpawnString("wantPosition", "", &ent->GenericStrings[15]);
+	if (ent->GenericStrings[15] && !ent->GenericStrings[15][0])
+	{
+		ent->GenericStrings[15] = NULL;
+	}
 
 	//RoboPhred: bugger this, screws up many mp maps
 	//if it should be kept, then add if !ent->targetname to it.

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -446,6 +446,8 @@ void SP_target_location (gentity_t *ent);
 extern entityInfo_t target_location_info;
 void SP_target_counter (gentity_t *self);
 extern entityInfo_t target_counter_info;
+void SP_target_doorstate (gentity_t *self);
+extern entityInfo_t target_doorstate_info;
 void SP_target_random (gentity_t *self);
 extern entityInfo_t target_random_info;
 void SP_target_scriptrunner( gentity_t *self );
@@ -946,6 +948,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_position", SP_target_position, Logical_True, &target_position_info},
 	{"target_location", SP_target_location, Logical_True, &target_location_info},
 	{"target_counter", SP_target_counter, Logical_True, &target_counter_info},
+	{"target_doorstate", SP_target_doorstate, Logical_True, &target_doorstate_info},
 	{"target_random", SP_target_random, Logical_True, &target_random_info},
 	{"target_scriptrunner", SP_target_scriptrunner, qfalse, &target_scriptrunner_info},
 	{"target_interest", SP_target_interest, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -753,6 +753,9 @@ extern entityInfo_t target_modify_info;
 void lmd_cskill_compare(gentity_t* self);
 extern entityInfo_t lmd_cskill_compare_info;
 
+void lmd_equalcheck(gentity_t* self);
+extern entityInfo_t lmd_equalcheck_info;
+
 void lmd_countcheck(gentity_t* self);
 extern entityInfo_t lmd_countcheck_info;
 
@@ -1146,6 +1149,9 @@ spawn_t	spawnInitValues[] = {
 	{"target_heal", sp_target_heal, Logical_True, &target_heal_info},
 	{"lmd_actor_modify", lmd_actor_modify, Logical_True, &lmd_actor_modify_info},
 	{"target_animate", sp_target_animate, Logical_True, &target_animate_info},
+
+	// lumaya:
+		{"lmd_equalcheck", lmd_equalcheck, Logical_True, &lmd_equalcheck_info},
 
 	{NULL, 0, Logical_False}
 };

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -1507,6 +1507,139 @@ void SP_target_counter(gentity_t* self)
     self->use = target_counter_use;
 }
 
+#define TARGET_DOORSTATE_MAX_DOORS 6
+
+static qboolean target_doorstate_is_door(gentity_t* ent)
+{
+    return ent && ent->classname && (!Q_stricmp(ent->classname, "func_door") || !Q_stricmp(ent->classname, "lmd_door"));
+}
+
+static qboolean target_doorstate_matches(gentity_t* door)
+{
+    const char* want = door->GenericStrings[15];
+
+    if (!want || !want[0])
+    {
+        return qfalse;
+    }
+
+    if (!Q_stricmp(want, "open"))
+    {
+        return (door->moverState == MOVER_POS2);
+    }
+
+    if (!Q_stricmp(want, "close") || !Q_stricmp(want, "closed"))
+    {
+        return (door->moverState == MOVER_POS1);
+    }
+
+    return qfalse;
+}
+
+const entityInfoData_t target_doorstate_keys[] = {
+    {"target", "Fired when every referenced door matches its wantPosition."},
+    {"target2", "Fired when any referenced door is missing or does not match its wantPosition."},
+    {"door1", "Targetname of the first door to check."},
+    {"door2", "Targetname of the second door to check."},
+    {"door3", "Targetname of the third door to check."},
+    {"door4", "Targetname of the fourth door to check."},
+    {"door5", "Targetname of the fifth door to check."},
+    {"door6", "Targetname of the sixth door to check."},
+    {NULL, NULL},
+};
+
+const entityInfo_t target_doorstate_info = {
+    "Checks a list of doors to ensure each is in its configured wantPosition. Fires target when all match, otherwise fires target2.",
+    NULL,
+    target_doorstate_keys
+};
+
+static void target_doorstate_use(gentity_t* self, gentity_t* other, gentity_t* activator)
+{
+    qboolean allMatch = qtrue;
+    qboolean hasDoor = qfalse;
+    int i;
+
+    if (!activator)
+    {
+        activator = self;
+    }
+
+    for (i = 0; i < TARGET_DOORSTATE_MAX_DOORS && allMatch; ++i)
+    {
+        const char* doorTarget = self->GenericStrings[i];
+        gentity_t* door = NULL;
+        qboolean foundDoor = qfalse;
+
+        if (!doorTarget || !doorTarget[0])
+        {
+            continue;
+        }
+
+        hasDoor = qtrue;
+
+        while ((door = G_Find(door, FOFS(targetname), doorTarget)) != NULL)
+        {
+            if (!target_doorstate_is_door(door))
+            {
+                continue;
+            }
+
+            foundDoor = qtrue;
+
+            if (!target_doorstate_matches(door))
+            {
+                allMatch = qfalse;
+                break;
+            }
+        }
+
+        if (!allMatch)
+        {
+            break;
+        }
+
+        if (!foundDoor)
+        {
+            allMatch = qfalse;
+            break;
+        }
+    }
+
+    if (!hasDoor)
+    {
+        allMatch = qfalse;
+    }
+
+    if (allMatch)
+    {
+        G_UseTargets(self, activator);
+    }
+    else if (self->target2 && self->target2[0])
+    {
+        G_UseTargets2(self, activator, self->target2);
+    }
+}
+
+void SP_target_doorstate(gentity_t* self)
+{
+    int i;
+
+    for (i = 0; i < TARGET_DOORSTATE_MAX_DOORS; ++i)
+    {
+        char keyName[8];
+
+        Com_sprintf(keyName, sizeof(keyName), "door%d", i + 1);
+        G_SpawnString(keyName, "", &self->GenericStrings[i]);
+        if (self->GenericStrings[i] && !self->GenericStrings[i][0])
+        {
+            self->GenericStrings[i] = NULL;
+        }
+    }
+
+    self->use = target_doorstate_use;
+}
+
 /*QUAKED target_random (.5 .5 .5) (-4 -4 -4) (4 4 4) USEONCE
 Randomly fires off only one of it's targets each time used
 

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -374,6 +374,8 @@ static void TargetWeapons_ParseAndGive(gentity_t* activator, const char* input, 
     char buffer[1024];
     Q_strncpyz(buffer, input, sizeof(buffer));
 
+    int forcedWeapon = -1;
+
     char* token = strtok(buffer, ".");
     while (token)
     {
@@ -510,9 +512,22 @@ static void TargetWeapons_ParseAndGive(gentity_t* activator, const char* input, 
                         activator->client->ps.fd.saberAnimLevel;
                 }
             }
+
+            if (forceGive && !justAllow && ammoAmount != 0)
+            {
+                forcedWeapon = weaponID;
+            }
         }
 
         token = strtok(NULL, ".");
+    }
+
+    if (forcedWeapon != -1)
+    {
+        activator->client->ps.weapon = forcedWeapon;
+        activator->client->ps.weaponstate = WEAPON_READY;
+        activator->client->ps.weaponTime = 0;
+        activator->s.weapon = forcedWeapon;
     }
 }
 


### PR DESCRIPTION
I got slightly annoyed by lmd_gate, so here we are.

- Added a WantPosition spawn key for func_door and lmd_door.
- target_doorstate validates referenced doors are in their desired positions before firing (keys door1-door6, values targetnames of doors)

keys:

-     {"target", "Fired when every referenced door matches its wantPosition."},
-     {"target2", "Fired when any referenced door is missing or does not match its wantPosition."},
-     {"door1", "Targetname of the first door to check."},
-     {"door2", "Targetname of the second door to check."},
-     {"door3", "Targetname of the third door to check."},
-     {"door4", "Targetname of the fourth door to check."},
-     {"door5", "Targetname of the fifth door to check."},
-     {"door6", "Targetname of the sixth door to check."},


Example:

/place target_doorstate * targetname,when_we_fire_this,target,to_fire_when_all_wantPositions_ok,target2,to_fire_when_wantPositions_arent_ok,door1,targetname_of_door1,door2,targetname_of_door2