### PR TITLE
Door state entity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ set(GAME_SRC
 	game/Lmd_Creditshunt.c
 	game/Lmd_Crosshair.c  
 	game/Lmd_Data.c 
+	game/Lmd_HiRuns.c 
 	game/Lmd_Entities_Commands.c 
 	game/Lmd_Entities_Core.c 
 	game/Lmd_Entities_Ents.c 

--- a/docs/entities/lmd-entities.md
+++ b/docs/entities/lmd-entities.md
@@ -44,6 +44,27 @@ target6   - Corresponding target to fire.
 
 - This randomly genrates a number from 1-7 and fire the target if the number is the same. If it goes over 4, it doesn't fire anything. 4/7 of the time it will do nothing.
 
+## lmd_equalcheck * (L)
+Compares the value of a spawn key across up to six targetnames. When every referenced entity reports the same value (or matches an explicitly provided value) the entity fires `EqualTarget`; otherwise it fires `UnequalTarget`.
+
+### Keys:
+
+```
+target1-6      - targetnames whose entities should be checked.
+key            - spawn key to read from each entity. (required)
+value          - optional expected value. If omitted, the first entity found supplies the reference value.
+EqualTarget    - target to fire when all values match the reference.
+UnequalTarget  - target to fire when a mismatch is detected or a target entity/key is missing.
+```
+
+### Example code:
+
+```
+/place lmd_equalcheck * target1,pillar_a,target2,pillar_b,key,state,EqualTarget,both_active,UnequalTarget,needs_reset,
+```
+
+The example checks that entities named `pillar_a` and `pillar_b` share the same `state` key before triggering `both_active`; otherwise it fires `needs_reset`.
+
 ## lmd_restrict *(L)
 Restricts the person inside of it by whatever spawnflags are set. Use maxs/mins to set the bounding box.
 

--- a/docs/entities/target-entities.md
+++ b/docs/entities/target-entities.md
@@ -169,6 +169,27 @@ target      - what to fire at when the delay time is hit
 
 - This would be for if i pressed a button and i wanna give the player enough time to get to the general area of where the x-wing spawned, so i gave it a three second delay, that way there is a smaller chance of someone stealing that players ship that they paid for.
 
+## target_doorstate **
+Checks a set of func_door or lmd_door entities to make sure they are resting in the position described by their `wantPosition` key. Fires its normal `target` when every door matches; otherwise it fires `target2`. Each monitored door must have `wantPosition` set to either `open` or `close` (synonym `closed`).
+
+### Keys:
+
+```
+target      - fired when all referenced doors match their wantPosition.
+target2     - fired when a door is missing or does not match its wantPosition.
+door1-6     - targetnames of the doors to monitor.
+```
+
+### Example code:
+
+```
+/spawnstring edit vault_door wantPosition close
+/place target_doorstate * target,vault_locked,target2,vault_open,door1,vault_door
+```
+
+The example ensures the door named `vault_door` is closed before firing `vault_locked`; otherwise it fires `vault_open`.
+
+
 ## target_speaker **
 This entity will play a sound that you specify in a certain radius.
 

--- a/game/Lmd_Accounts.c
+++ b/game/Lmd_Accounts.c
@@ -615,6 +615,7 @@ void Lmd_Accounts_Player_CreateSecurityCode(gentity_t *ent, Account_t *acc) {
 
 qboolean Lmd_Accounts_Player_TryLogin(gentity_t *ent, char *username, char *pass, char *secCode){
 	unsigned long int chk = Checksum(pass);
+	
 	int i;
 	Account_t *acc;
 	char *accSec;

--- a/game/Lmd_Accounts_Core.c
+++ b/game/Lmd_Accounts_Core.c
@@ -519,7 +519,7 @@ void Accounts_SetName(Account_t *acc, char *name) {
 	Lmd_Accounts_Modify(acc);
 }
 
-int Accounts_GetPassword(Account_t *acc) {
+unsigned int Accounts_GetPassword(Account_t *acc) {
 	if(!acc)
 		return 0;
 	return acc->pwChksum;

--- a/game/Lmd_Accounts_Core.c
+++ b/game/Lmd_Accounts_Core.c
@@ -706,17 +706,16 @@ int Accounts_LoadTitles(void) {
 			line = strtok(NULL, "\n");
 			continue;
 		}
-
-		char *rest = NULL;
-		char *type = strtok_s(line, ",", &rest);
+		
+		char *type = strtok(line, ",");
 		if (!type) {
 			line = strtok(NULL, "\n");
 			continue;
 		}
 
 		char *titles[6] = {0};
-		for (int i = 0; i < 6 && rest; i++) {
-			titles[i] = strtok_s(NULL, ",", &rest);
+		for (int i = 0; i < 6; i++) {
+			titles[i] = strtok(NULL, ",");
 		}
 
 		if (!titles[0] || !titles[4]) {

--- a/game/Lmd_Accounts_Core.h
+++ b/game/Lmd_Accounts_Core.h
@@ -33,7 +33,7 @@ char* Accounts_GetName(Account_t *acc);
 void Accounts_SetName(Account_t *acc, char *name);
 #define PlayerAcc_SetName(ent, value) Accounts_SetName(ent->client->pers.Lmd.account, value)
 
-int Accounts_GetPassword(Account_t *acc);
+unsigned int Accounts_GetPassword(Account_t *acc);
 
 void Accounts_SetPassword(Account_t *acc, char *password);
 #define PlayerAcc_SetPassword(ent, password) Accounts_SetPassword(ent->client->pers.Lmd.account, password)

--- a/game/Lmd_Checksum.c
+++ b/game/Lmd_Checksum.c
@@ -72,7 +72,7 @@ unsigned int Checksum (char *str){
 		while (str[i] && i < MAX_STRING_CHARS){
 			//RoboPhred: serious checksum failure fix
 			//c += (str[i++] + i + k) % 23;
-			c += (str[i++] + i + l) % 23; 
+			c += ((signed char)str[i++] + i + l) % 23;
 			c %= 24;
 			sum ^= (1 << c);
 		}

--- a/game/Lmd_Checksum.c
+++ b/game/Lmd_Checksum.c
@@ -1,86 +1,102 @@
-
 #include "g_local.h"
 
-int HexToInt( const char *string ){
-	int		sign;
-	int		value;
-	int		c;
+int HexToInt(const char* string)
+{
+    int sign;
+    int value;
+    int c;
 
-	// skip whitespace
-	while ( *string <= ' ' ) {
-		if ( !*string ) {
-			return 0;
-		}
-		string++;
-	}
+    // skip whitespace
+    while (*string <= ' ')
+    {
+        if (!*string)
+        {
+            return 0;
+        }
+        string++;
+    }
 
-	// check sign
-	switch ( *string ) {
-	case '+':
-		string++;
-		sign = 1;
-		break;
-	case '-':
-		string++;
-		sign = -1;
-		break;
-	default:
-		sign = 1;
-		break;
-	}
+    // check sign
+    switch (*string)
+    {
+    case '+':
+        string++;
+        sign = 1;
+        break;
+    case '-':
+        string++;
+        sign = -1;
+        break;
+    default:
+        sign = 1;
+        break;
+    }
 
-	// read digits
-	value = 0;
-	do{
-		c = *string++;
-		// Skip any whitespace (handles trailing \r, \n, space, tab from cross-platform file copying)
-		if ( c <= ' ' && c != 0 ) {
-			continue;
-		}
-		if ( c >= '0' && c <='9' ) {
-			c -= '0';
-		} else if (c >= 'a' && c <= 'f') {
-			c -= 'a' - 10;
-		} else if (c >= 'A' && c <= 'F') {
-			c -= 'A' - 10;
-		} else {
-			break;
-		}
+    // read digits
+    value = 0;
+    do
+    {
+        c = *string++;
+        // Skip any whitespace (handles trailing \r, \n, space, tab from cross-platform file copying)
+        if (c <= ' ' && c != 0)
+        {
+            continue;
+        }
+        if (c >= '0' && c <= '9')
+        {
+            c -= '0';
+        }
+        else if (c >= 'a' && c <= 'f')
+        {
+            c -= 'a' - 10;
+        }
+        else if (c >= 'A' && c <= 'F')
+        {
+            c -= 'A' - 10;
+        }
+        else
+        {
+            break;
+        }
 
-		value = value * 16 + c;
-	}while(1);
+        value = value * 16 + c;
+    }
+    while (1);
 
-	// not handling 10e10 notation...
+    // not handling 10e10 notation...
 
-	return value * sign;
+    return value * sign;
 }
 
-unsigned int Checksum (char *str){
-	int k;
-	int l;
-	int c = 0;
-	int i;
-	unsigned int sum = 0xaaaaaa;
+unsigned int Checksum(char* str)
+{
+    int k;
+    int l;
+    int c = 0;
+    int i;
+    unsigned int sum = 0xaaaaaa;
 
-	if (!str || str[0] == 0){
-		return 0;
-	}
-	k = strlen(str);
-	l = 11 - k;
+    if (!str || str[0] == 0)
+    {
+        return 0;
+    }
+    k = strlen(str);
+    l = 11 - k;
 
-	if (l < 1) {
-		l = 1;
-	}
-	while(l--){
-		i = 0;
-		while (str[i] && i < MAX_STRING_CHARS){
-			//RoboPhred: serious checksum failure fix
-			//c += (str[i++] + i + k) % 23;
-			c += (str[i++] + i + l) % 23;
-			c %= 24;
-			sum ^= (1 << c);
-		}
-	}
-	return sum;
+    if (l < 1)
+    {
+        l = 1;
+    }
+    while (l--)
+    {
+        i = 0;
+        while (str[i] && i < MAX_STRING_CHARS)
+        {
+            int intermediate = i + l;
+            c += (str[i++] + intermediate) % 23;
+            c %= 24;
+            sum ^= (1 << c);
+        }
+    }
+    return sum;
 }
-

--- a/game/Lmd_Checksum.c
+++ b/game/Lmd_Checksum.c
@@ -33,6 +33,10 @@ int HexToInt( const char *string ){
 	value = 0;
 	do{
 		c = *string++;
+		// Skip any whitespace (handles trailing \r, \n, space, tab from cross-platform file copying)
+		if ( c <= ' ' && c != 0 ) {
+			continue;
+		}
 		if ( c >= '0' && c <='9' ) {
 			c -= '0';
 		} else if (c >= 'a' && c <= 'f') {
@@ -56,7 +60,7 @@ unsigned int Checksum (char *str){
 	int l;
 	int c = 0;
 	int i;
-	unsigned long int sum = 0xaaaaaa;
+	unsigned int sum = 0xaaaaaa;
 
 	if (!str || str[0] == 0){
 		return 0;
@@ -72,7 +76,7 @@ unsigned int Checksum (char *str){
 		while (str[i] && i < MAX_STRING_CHARS){
 			//RoboPhred: serious checksum failure fix
 			//c += (str[i++] + i + k) % 23;
-			c += ((signed char)str[i++] + i + l) % 23;
+			c += (str[i++] + i + l) % 23;
 			c %= 24;
 			sum ^= (1 << c);
 		}

--- a/game/Lmd_Commands.c
+++ b/game/Lmd_Commands.c
@@ -12,6 +12,7 @@
 #include "Lmd_PlayerActions.h"
 #include "Lmd_Arrays.h"
 #include "Lmd_Console.h"
+#include "Lmd_HiRuns.h"
 #include "Lmd_Time.h"
 
 gentity_t *G_GetJediMaster (void);
@@ -1055,6 +1056,24 @@ void Cmd_DropStash_f(gentity_t *ent, int iArg){
 	}
 }
 
+void Cmd_HiRuns_f(gentity_t *ent, int iArg){
+	char arg[MAX_STRING_CHARS];
+	int argc = trap_Argc();
+
+	if(argc < 2){
+		HiRuns_ListRuns(ent);
+		return;
+	}
+
+	trap_Argv(1, arg, sizeof(arg));
+	if(Q_stricmp(arg, "list") == 0){
+		HiRuns_ListRuns(ent);
+		return;
+	}
+
+	HiRuns_Show(ent, arg);
+}
+
 void Cmd_Examine_f (gentity_t *ent, int iArg)
 {
 	gentity_t *targ = AimAnyTarget(ent, 64);
@@ -1163,6 +1182,7 @@ cmdEntry_t playerCommandEntries[] = {
 	{"topduels","Display the top ten players with the highest duel win/loss ratio.", HiRatio, RATIO_DUEL_WIN_LOSS, qfalse, 0, 1, 0, 0},
 	{"hihits","Display the top ten players with the highest accuracy (hit/miss ratio).", HiRatio, RATIO_HIT_MISS, qfalse, 0, 1, 0, 0},
 	{"tophits","Display the top ten players with the highest accuracy (hit/miss ratio).", HiRatio, RATIO_HIT_MISS, qfalse, 0, 1, 0, 0},
+	{"hiruns","Display top runs for a named timer. Use \"/hiruns list\" to see available names.", Cmd_HiRuns_f, 0, qfalse, 0, 1, 0, 0},
 	{"ignore", "Ignore messages from the player.  Set player to -1 to ignore/unignore all.", Cmd_IgnoreClient_f, 0, qfalse, 0, 0, 0, 0},
 	{"interact", "Use this to interact with certain terminals.", Cmd_Interact_f, 0, qfalse, 0, 0, 0, 0},
 	{"ionlyduel","You will be (almost) invulnerable until you engage a duel, but you can't use offensive force powers or hurt anyone.", Cmd_Ionlyduel_f, 0, qfalse, 0, 64, ~(1 << GT_FFA), 0},

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -5683,6 +5683,155 @@ void lmd_cskill_compare(gentity_t* self)
     self->use = lmd_cskill_compare_use;
 }
 
+void lmd_equalcheck_use(gentity_t* self, gentity_t* other, gentity_t* activator)
+{
+    const char* keyName = self->GenericStrings[6];
+    if (!keyName || !keyName[0])
+    {
+        return;
+    }
+
+    char compareValue[MAX_STRING_CHARS];
+    qboolean haveCompareValue = qfalse;
+    qboolean mismatch = qfalse;
+    qboolean foundAny = qfalse;
+
+    if (self->GenericStrings[7] && self->GenericStrings[7][0])
+    {
+        Q_strncpyz(compareValue, self->GenericStrings[7], sizeof(compareValue));
+        haveCompareValue = qtrue;
+    }
+
+    for (int i = 0; i < 6 && !mismatch; i++)
+    {
+        const char* targetName = self->GenericStrings[i];
+        if (!targetName || !targetName[0])
+        {
+            continue;
+        }
+
+        gentity_t* ent = NULL;
+        qboolean foundForTarget = qfalse;
+
+        while ((ent = G_Find(ent, FOFS(targetname), targetName)) != NULL)
+        {
+            foundForTarget = qtrue;
+            foundAny = qtrue;
+
+            if (!ent->Lmd.spawnData)
+            {
+                mismatch = qtrue;
+                break;
+            }
+
+            char value[MAX_STRING_CHARS];
+            if (!Lmd_Entities_getSpawnstringKey(ent->Lmd.spawnData, (char*)keyName, value, sizeof(value)))
+            {
+                mismatch = qtrue;
+                break;
+            }
+
+            if (!haveCompareValue)
+            {
+                Q_strncpyz(compareValue, value, sizeof(compareValue));
+                haveCompareValue = qtrue;
+                continue;
+            }
+
+            if (Q_stricmp(compareValue, value) != 0)
+            {
+                mismatch = qtrue;
+                break;
+            }
+        }
+
+        if (mismatch)
+        {
+            break;
+        }
+
+        if (!foundForTarget)
+        {
+            mismatch = qtrue;
+        }
+    }
+
+    if (!haveCompareValue || !foundAny)
+    {
+        mismatch = qtrue;
+    }
+
+    if (!mismatch)
+    {
+        G_UseTargets2(self, activator, self->GenericStrings[8]);
+    }
+    else
+    {
+        G_UseTargets2(self, activator, self->GenericStrings[9]);
+    }
+}
+
+const entityInfoData_t lmd_equalcheck_keys[] = {
+    {"Target1", "First targetname to evaluate."},
+    {"Target2", "Second targetname to evaluate."},
+    {"Target3", "Third targetname to evaluate."},
+    {"Target4", "Fourth targetname to evaluate."},
+    {"Target5", "Fifth targetname to evaluate."},
+    {"Target6", "Sixth targetname to evaluate."},
+    {"Key", "Spawn key to compare across all referenced entities."},
+    {"Value", "Optional expected value; if omitted the first entity's value is used."},
+    {"EqualTarget", "Target to fire when all values match."},
+    {"UnequalTarget", "Target to fire when a mismatch is detected."},
+    {NULL, NULL},
+};
+
+entityInfo_t lmd_equalcheck_info = {
+    "Compares a spawn key across up to six targetnames, firing EqualTarget when all values match and UnequalTarget otherwise.",
+    NULL,
+    lmd_equalcheck_keys
+};
+
+void lmd_equalcheck(gentity_t* self)
+{
+    for (int i = 0; i < 6; i++)
+    {
+        char keyName[16];
+        Com_sprintf(keyName, sizeof(keyName), "target%d", i + 1);
+        G_SpawnString(keyName, "", &self->GenericStrings[i]);
+        if (!self->GenericStrings[i] || !self->GenericStrings[i][0])
+        {
+            self->GenericStrings[i] = NULL;
+        }
+    }
+
+    G_SpawnString("key", "", &self->GenericStrings[6]);
+    if (!self->GenericStrings[6] || !self->GenericStrings[6][0])
+    {
+        G_FreeEntity(self);
+        return;
+    }
+
+    G_SpawnString("value", "", &self->GenericStrings[7]);
+    if (!self->GenericStrings[7] || !self->GenericStrings[7][0])
+    {
+        self->GenericStrings[7] = NULL;
+    }
+
+    G_SpawnString("equaltarget", "", &self->GenericStrings[8]);
+    if (!self->GenericStrings[8] || !self->GenericStrings[8][0])
+    {
+        self->GenericStrings[8] = NULL;
+    }
+
+    G_SpawnString("unequaltarget", "", &self->GenericStrings[9]);
+    if (!self->GenericStrings[9] || !self->GenericStrings[9][0])
+    {
+        self->GenericStrings[9] = NULL;
+    }
+
+    self->use = lmd_equalcheck_use;
+}
+
 void lmd_countcheck_use(gentity_t* self, gentity_t* other, gentity_t* activator)
 {
     int count;

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -11,6 +11,7 @@
 #include "Lmd_Professions.h"
 #include "Lmd_EntityCore.h"
 #include "Lmd_Inventory.h"
+#include "Lmd_HiRuns.h"
 #include "Lmd_Time.h"
 #include "Lmd_Interact.h"
 #include "Lmd_Professions_Public.h"
@@ -636,6 +637,73 @@ void lmd_toggle(gentity_t* ent)
     {
         EntitySpawnError("lmd_toggle must have a count value greater than or equal to 2.");
         G_FreeEntity(ent);
+    }
+}
+
+void lmd_timer_use(gentity_t* self, gentity_t* other, gentity_t* activator)
+{
+    if (!activator || !activator->client)
+        return;
+
+    if (!self->target || !self->target[0])
+    {
+        Disp(activator, "^3lmd_timer has no target run name.");
+        return;
+    }
+
+    if (self->spawnflags & 2)
+    {
+        HiRuns_ShowTerminal(activator, self->target);
+        return;
+    }
+
+    if (self->spawnflags & 1)
+    {
+        HiRuns_TimerStop(activator, self->target);
+        return;
+    }
+
+    HiRuns_TimerStart(activator, self->target, self->count > 0 ? self->count : 1);
+}
+
+const entityInfoData_t lmd_timer_spawnflags[] = {
+    {"1", "Stop the timer and record the run when all participants finish."},
+    {"2", "Show the run list in a terminal menu for the activator."},
+    {NULL, NULL}
+};
+
+const entityInfoData_t lmd_timer_keys[] = {
+    {"Count", "Number of players required to start the run (default 1)."},
+    {"Target", "Name of the run to record."},
+    {NULL, NULL}
+};
+
+entityInfo_t lmd_timer_info = {
+    "Start/stop a named run timer and record top run times.",
+    lmd_timer_spawnflags,
+    lmd_timer_keys
+};
+
+void lmd_timer(gentity_t* ent)
+{
+    ent->use = lmd_timer_use;
+
+    if (ent->Lmd.spawnData && Q_stricmp(ent->classname, "lmd_timer") != 0)
+    {
+        ent->classname = "lmd_timer";
+        Lmd_Entities_setSpawnstringKey(ent->Lmd.spawnData, "classname", "lmd_timer");
+    }
+
+    if (!ent->target || !ent->target[0])
+    {
+        EntitySpawnError("lmd_timer must have a target value for the run name.");
+        G_FreeEntity(ent);
+        return;
+    }
+
+    if (ent->count < 1)
+    {
+        ent->count = 1;
     }
 }
 

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1416,6 +1416,7 @@ const entityInfoData_t lmd_door_keys[] = {
     {"OpenTarget", "Fired after reaching the \'open\' position."},
     {"Target2", "Fired when it starts moving from the open position to the closed position."},
     {"CloseTarget", "Fire after reaching the \'closed\' position."},
+    {"WantPosition", "Desired resting position for target_doorstate checks. Accepts 'open' or 'close'."},
     {
         "TargetName",
         "Trigger when an entity uses this.  If not specified, the door will open when someone gets close to it."
@@ -1459,6 +1460,11 @@ void lmd_door(gentity_t* ent)
     {
         ent->classname = "lmd_door";
         Lmd_Entities_setSpawnstringKey(ent->Lmd.spawnData, "classname", "lmd_door");
+    }
+    G_SpawnString("wantPosition", "", &ent->GenericStrings[15]);
+    if (ent->GenericStrings[15] && !ent->GenericStrings[15][0])
+    {
+        ent->GenericStrings[15] = NULL;
     }
     G_SpawnInt("vehopen", "0", &ent->genericValue14);
 

--- a/game/Lmd_Entities_Ents.c
+++ b/game/Lmd_Entities_Ents.c
@@ -1798,7 +1798,7 @@ void lmd_menu_show(gentity_t* player, gentity_t* menu)
         Q_strcat(msg, sizeof(msg), va("  %sCancel\n", menu->Lmd.color2));
     }
     
-    strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(player, msg, NULL));
+    strcpy(msg, lmd_processMessagePlaceholders(player, msg, NULL));
 
 
     trap_SendServerCommand(player->s.number, va("cp \"%s\"", msg));
@@ -2078,7 +2078,7 @@ void lmd_terminal_use(gentity_t* self, gentity_t* other, gentity_t* activator)
     int i;
     if (self->message)
     {
-        strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(activator, self->message, NULL));
+        strcpy(msg, lmd_processMessagePlaceholders(activator, self->message, NULL));
         Q_strcat(msg, sizeof(msg), va("\n^5==============================\n", msg));
     }
 
@@ -2399,7 +2399,7 @@ void lmd_rentterminal_examine(gentity_t* self, gentity_t* activator)
     if (self->message)
     {
         char msgt[MAX_STRING_CHARS] = "";
-        strcpy_s(msgt, sizeof(msgt), lmd_processMessagePlaceholders(activator, self->message, NULL));
+        strcpy(msgt, lmd_processMessagePlaceholders(activator, self->message, NULL));
         Disp(activator, msgt); //send this as a seperate disp, in case the msg makes us hit MAX_STRING_CHARS
     }
 
@@ -2496,7 +2496,7 @@ void lmd_rentterminal_use(gentity_t* self, gentity_t* other, gentity_t* activato
     int sec = 0, min = 0;
     if (self->message)
     {
-        strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(activator, self->message, NULL));
+        strcpy(msg, lmd_processMessagePlaceholders(activator, self->message, NULL));
         Q_strcat(msg, sizeof(msg), va("\n", msg));
     }
 
@@ -2542,7 +2542,7 @@ void lmd_rentterminal_think(gentity_t* ent)
             char msg[MAX_STRING_CHARS] = "";
             if (ent->message)
             {
-                strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(ent->activator, ent->message, NULL));
+                strcpy(msg, lmd_processMessagePlaceholders(ent->activator, ent->message, NULL));
                 Q_strncpyz(msg, va("%s\n", msg), sizeof(msg));
             }
             Q_strcat(msg, sizeof(msg), va("^3You have ^2%i^3 seconds left.", timeLeft));
@@ -2556,7 +2556,7 @@ void lmd_rentterminal_think(gentity_t* ent)
                 char msg[MAX_STRING_CHARS] = "";
                 if (ent->message)
                 {
-                    strcpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(ent->activator, ent->message, NULL));
+                    strcpy(msg, lmd_processMessagePlaceholders(ent->activator, ent->message, NULL));
                     Q_strncpyz(msg, va("%s\n", msg), sizeof(msg));
                 }
                 Q_strcat(msg, sizeof(msg), "^1Your rent has expired.");

--- a/game/Lmd_HiRuns.c
+++ b/game/Lmd_HiRuns.c
@@ -1,0 +1,595 @@
+#include "g_local.h"
+
+#include "Lmd_Arrays.h"
+#include "Lmd_Console.h"
+#include "Lmd_Data.h"
+#include "Lmd_HiRuns.h"
+
+void lmd_menu_enter(gentity_t *player, gentity_t *menu);
+
+typedef struct {
+	unsigned int count;
+	LmdHiRun_t *runs;
+} HiRunsState_t;
+
+static HiRunsState_t HiRunsState;
+
+static int HiRuns_GetClientRunIndex(const gclient_t *client) {
+	if (!client || client->Lmd.hiRuns.runIndex <= 0) {
+		return -1;
+	}
+	return client->Lmd.hiRuns.runIndex - 1;
+}
+
+static void HiRuns_ClearClientState(gclient_t *client) {
+	if (!client) {
+		return;
+	}
+	client->Lmd.hiRuns.runIndex = 0;
+	client->Lmd.hiRuns.pendingStart = qfalse;
+	client->Lmd.hiRuns.running = qfalse;
+	client->Lmd.hiRuns.pendingStop = qfalse;
+}
+
+static void HiRuns_SetClientRunIndex(gclient_t *client, int runIndex) {
+	if (!client) {
+		return;
+	}
+	client->Lmd.hiRuns.runIndex = runIndex + 1;
+}
+
+static LmdHiRun_t *HiRuns_GetRun(int index) {
+	if (index < 0 || index >= (int)HiRunsState.count) {
+		return NULL;
+	}
+	return &HiRunsState.runs[index];
+}
+
+static int HiRuns_FindIndex(const char *name) {
+	if (!name || !name[0]) {
+		return -1;
+	}
+	for (unsigned int i = 0; i < HiRunsState.count; i++) {
+		if (Q_stricmp(HiRunsState.runs[i].name, name) == 0) {
+			return (int)i;
+		}
+	}
+	return -1;
+}
+
+static LmdHiRun_t *HiRuns_GetOrCreate(const char *name, int *outIndex) {
+	int index = HiRuns_FindIndex(name);
+	if (index >= 0) {
+		if (outIndex) {
+			*outIndex = index;
+		}
+		return &HiRunsState.runs[index];
+	}
+
+	index = (int)Lmd_Arrays_AddArrayElement((void **)&HiRunsState.runs, sizeof(LmdHiRun_t), &HiRunsState.count);
+	LmdHiRun_t *run = &HiRunsState.runs[index];
+	Q_strncpyz(run->name, name, sizeof(run->name));
+	if (outIndex) {
+		*outIndex = index;
+	}
+	return run;
+}
+
+static void HiRuns_FormatDuration(int durationMs, char *out, int outSize) {
+	int totalSeconds = durationMs / 1000;
+	int millis = durationMs % 1000;
+	int minutes = totalSeconds / 60;
+	int seconds = totalSeconds % 60;
+	int hours = minutes / 60;
+	minutes = minutes % 60;
+
+	if (hours > 0) {
+		Com_sprintf(out, outSize, "%d:%02d:%02d.%03d", hours, minutes, seconds, millis);
+	} else {
+		Com_sprintf(out, outSize, "%d:%02d.%03d", minutes, seconds, millis);
+	}
+}
+
+static void HiRuns_SanitizeName(const char *src, char *dst, int dstSize) {
+	char clean[MAX_STRING_CHARS];
+	Q_strncpyz(clean, src ? src : "", sizeof(clean));
+	Q_CleanStr(clean);
+	Q_strncpyz(dst, clean, dstSize);
+	for (int i = 0; dst[i]; i++) {
+		if (dst[i] == '"') {
+			dst[i] = '\'';
+		}
+	}
+}
+
+static void HiRuns_InsertEntry(LmdHiRun_t *run, int durationMs, const char *players) {
+	if (!run || durationMs <= 0) {
+		return;
+	}
+
+	int insertIndex = run->entryCount;
+	for (int i = 0; i < run->entryCount; i++) {
+		if (durationMs < run->entries[i].durationMs) {
+			insertIndex = i;
+			break;
+		}
+	}
+
+	if (insertIndex >= LMD_HIRUNS_MAX_ENTRIES) {
+		return;
+	}
+
+	if (run->entryCount < LMD_HIRUNS_MAX_ENTRIES) {
+		if (insertIndex < run->entryCount) {
+			memmove(&run->entries[insertIndex + 1], &run->entries[insertIndex],
+				sizeof(run->entries[0]) * (run->entryCount - insertIndex));
+		}
+		run->entryCount++;
+	} else if (insertIndex < LMD_HIRUNS_MAX_ENTRIES - 1) {
+		memmove(&run->entries[insertIndex + 1], &run->entries[insertIndex],
+			sizeof(run->entries[0]) * (LMD_HIRUNS_MAX_ENTRIES - 1 - insertIndex));
+	}
+
+	run->entries[insertIndex].durationMs = durationMs;
+	Q_strncpyz(run->entries[insertIndex].players, players ? players : "", sizeof(run->entries[insertIndex].players));
+}
+
+static void HiRuns_ResetRunState(LmdHiRun_t *run) {
+	if (!run) {
+		return;
+	}
+	run->active = qfalse;
+	run->requiredCount = 0;
+	run->startTime = 0;
+	run->participantCount = 0;
+	memset(run->participants, 0, sizeof(run->participants));
+	memset(run->stopRequested, 0, sizeof(run->stopRequested));
+}
+
+static qboolean HiRuns_IsParticipant(const LmdHiRun_t *run, int clientNum) {
+	if (!run) {
+		return qfalse;
+	}
+	for (int i = 0; i < run->participantCount; i++) {
+		if (run->participants[i] == clientNum) {
+			return qtrue;
+		}
+	}
+	return qfalse;
+}
+
+static void HiRuns_RemoveParticipant(LmdHiRun_t *run, int clientNum) {
+	if (!run) {
+		return;
+	}
+	for (int i = 0; i < run->participantCount; i++) {
+		if (run->participants[i] == clientNum) {
+			if (i + 1 < run->participantCount) {
+				memmove(&run->participants[i], &run->participants[i + 1],
+					sizeof(run->participants[0]) * (run->participantCount - i - 1));
+			}
+			run->participantCount--;
+			run->stopRequested[clientNum] = qfalse;
+			return;
+		}
+	}
+}
+
+static qboolean HiRuns_AllStopped(const LmdHiRun_t *run) {
+	if (!run) {
+		return qfalse;
+	}
+	for (int i = 0; i < run->participantCount; i++) {
+		int clientNum = run->participants[i];
+		if (!run->stopRequested[clientNum]) {
+			return qfalse;
+		}
+	}
+	return qtrue;
+}
+
+static void HiRuns_BuildPlayersLabel(const LmdHiRun_t *run, char *out, int outSize) {
+	out[0] = '\0';
+	if (!run) {
+		return;
+	}
+	for (int i = 0; i < run->participantCount; i++) {
+		int clientNum = run->participants[i];
+		if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
+			continue;
+		}
+		gentity_t *ent = &g_entities[clientNum];
+		if (!ent->client) {
+			continue;
+		}
+		char cleanName[LMD_HIRUNS_PLAYERS_LEN];
+		HiRuns_SanitizeName(ent->client->pers.netname, cleanName, sizeof(cleanName));
+		if (out[0]) {
+			Q_strcat(out, outSize, " + ");
+		}
+		Q_strcat(out, outSize, cleanName);
+	}
+}
+
+static void HiRuns_BuildDisplay(const LmdHiRun_t *run, char *out, int outSize) {
+	char line[MAX_STRING_CHARS];
+	out[0] = '\0';
+
+	if (!run) {
+		Q_strncpyz(out, "^3No run data found.", outSize);
+		return;
+	}
+
+	Q_strncpyz(out, va("^5Top runs for ^3%s^5\n\n", run->name), outSize);
+
+	if (run->entryCount == 0) {
+		Q_strcat(out, outSize, "^7No runs recorded yet.");
+		return;
+	}
+
+	int maxEntries = run->entryCount;
+	if (maxEntries > LMD_HIRUNS_MAX_ENTRIES) {
+		maxEntries = LMD_HIRUNS_MAX_ENTRIES;
+	}
+
+	for (int i = 0; i < maxEntries; i++) {
+		char timeBuf[32];
+		HiRuns_FormatDuration(run->entries[i].durationMs, timeBuf, sizeof(timeBuf));
+		Com_sprintf(line, sizeof(line), "^2%2i^7) ^3%s^7 - ^5%s\n",
+			i + 1, timeBuf, run->entries[i].players);
+		if ((int)strlen(out) + (int)strlen(line) >= outSize) {
+			break;
+		}
+		Q_strcat(out, outSize, line);
+	}
+}
+
+static void HiRuns_AbortRun(LmdHiRun_t *run, const char *reason) {
+	if (!run || run->participantCount <= 0) {
+		return;
+	}
+
+	for (int i = 0; i < run->participantCount; i++) {
+		int clientNum = run->participants[i];
+		if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
+			continue;
+		}
+		gentity_t *ent = &g_entities[clientNum];
+		if (!ent->client) {
+			continue;
+		}
+		if (reason && reason[0]) {
+			Disp(ent, reason);
+		}
+		HiRuns_ClearClientState(ent->client);
+	}
+
+	HiRuns_ResetRunState(run);
+}
+
+static qboolean HiRuns_Load_Callback(char *key, char *value, void *state) {
+	char runName[MAX_STRING_CHARS] = "";
+	char players[MAX_STRING_CHARS] = "";
+	int durationMs = 0;
+
+	if (Q_stricmp(key, "run") != 0) {
+		return qfalse;
+	}
+
+	int matched = sscanf(value, "\"%1024[^\"]\" %d \"%1024[^\"]\"", runName, &durationMs, players);
+	if (matched < 2) {
+		return qfalse;
+	}
+	if (matched < 3) {
+		players[0] = 0;
+	}
+
+	int index = 0;
+	LmdHiRun_t *run = HiRuns_GetOrCreate(runName, &index);
+	HiRuns_InsertEntry(run, durationMs, players);
+	return qtrue;
+}
+
+static DBSaveFileCallbackReturn_t *HiRuns_Save_Callback(byte *structure, DBSaveFileCallbackReturn_t *arg,
+	char *key, int keySze, char *value, int valueSze) {
+	while (arg->func < HiRunsState.count) {
+		LmdHiRun_t *run = &HiRunsState.runs[arg->func];
+		if (arg->offset >= run->entryCount) {
+			arg->func++;
+			arg->offset = 0;
+			continue;
+		}
+
+		Q_strncpyz(key, "run", keySze);
+		Q_strncpyz(value, va("\"%s\" %d \"%s\"", run->name, run->entries[arg->offset].durationMs,
+			run->entries[arg->offset].players), valueSze);
+		arg->offset++;
+		return arg;
+	}
+
+	return NULL;
+}
+
+void HiRuns_Load(void) {
+	char *buf = Lmd_Data_AllocFileContents(LMD_HIRUNS_FILE);
+	if (!buf) {
+		return;
+	}
+	char *str = buf;
+	Lmd_Data_ParseKeys_Old(&str, qtrue, HiRuns_Load_Callback, NULL);
+	G_Free(buf);
+}
+
+void HiRuns_Save(void) {
+	Lmd_Data_SaveDatafile(NULL, LMD_HIRUNS_FILE, NULL, NULL, NULL, HiRuns_Save_Callback);
+}
+
+void HiRuns_ListRuns(gentity_t *ent) {
+	if (HiRunsState.count == 0) {
+		Disp(ent, "^3No runs recorded.");
+		return;
+	}
+
+	Disp(ent, "^5Available runs:");
+	for (unsigned int i = 0; i < HiRunsState.count; i++) {
+		Disp(ent, "^2%i^3: ^7%s", i + 1, HiRunsState.runs[i].name);
+	}
+}
+
+void HiRuns_Show(gentity_t *ent, const char *nameOrIndex) {
+	char msg[MAX_STRING_CHARS];
+	int runIndex = -1;
+
+	if (!nameOrIndex || !nameOrIndex[0]) {
+		HiRuns_ListRuns(ent);
+		return;
+	}
+
+	qboolean numeric = qtrue;
+	for (int i = 0; nameOrIndex[i]; i++) {
+		if (nameOrIndex[i] < '0' || nameOrIndex[i] > '9') {
+			numeric = qfalse;
+			break;
+		}
+	}
+
+	if (numeric) {
+		int index = atoi(nameOrIndex);
+		if (index > 0 && index <= (int)HiRunsState.count) {
+			runIndex = index - 1;
+		}
+	} else {
+		int matches = 0;
+		int len = strlen(nameOrIndex);
+		for (unsigned int i = 0; i < HiRunsState.count; i++) {
+			if (Q_stricmpn(nameOrIndex, HiRunsState.runs[i].name, len) == 0) {
+				runIndex = (int)i;
+				matches++;
+			}
+		}
+		if (matches > 1) {
+			Disp(ent, "^3Multiple runs match that name:");
+			for (unsigned int i = 0; i < HiRunsState.count; i++) {
+				if (Q_stricmpn(nameOrIndex, HiRunsState.runs[i].name, len) == 0) {
+					Disp(ent, va("^2%i^3: ^7%s", i + 1, HiRunsState.runs[i].name));
+				}
+			}
+			return;
+		}
+	}
+
+	if (runIndex < 0) {
+		Disp(ent, "^3No run by that name.");
+		return;
+	}
+
+	LmdHiRun_t *run = HiRuns_GetRun(runIndex);
+	HiRuns_BuildDisplay(run, msg, sizeof(msg));
+	Disp(ent, msg);
+}
+
+void HiRuns_TimerStart(gentity_t *player, const char *runName, int requiredCount) {
+	if (!player || !player->client || !runName || !runName[0]) {
+		return;
+	}
+
+	if (requiredCount < 1) {
+		requiredCount = 1;
+	}
+	if (requiredCount > MAX_CLIENTS) {
+		requiredCount = MAX_CLIENTS;
+	}
+
+	int runIndex = 0;
+	LmdHiRun_t *run = HiRuns_GetOrCreate(runName, &runIndex);
+
+	int currentRunIndex = HiRuns_GetClientRunIndex(player->client);
+	if (currentRunIndex >= 0 && currentRunIndex != runIndex) {
+		Disp(player, "^3You are already queued for another run.");
+		return;
+	}
+
+	if (run->active) {
+		Disp(player, "^3That run is already active.");
+		return;
+	}
+
+	if (HiRuns_IsParticipant(run, player->s.number)) {
+		Disp(player, "^3You are already queued for that run.");
+		return;
+	}
+
+	if (run->participantCount >= MAX_CLIENTS) {
+		Disp(player, "^3That run is full.");
+		return;
+	}
+
+	if (run->participantCount > 0) {
+		requiredCount = run->requiredCount;
+	} else {
+		run->requiredCount = requiredCount;
+	}
+	run->participants[run->participantCount++] = player->s.number;
+	HiRuns_SetClientRunIndex(player->client, runIndex);
+	player->client->Lmd.hiRuns.pendingStart = qtrue;
+
+	if (run->participantCount >= run->requiredCount) {
+		run->active = qtrue;
+		run->startTime = level.time;
+		for (int i = 0; i < run->participantCount; i++) {
+			int clientNum = run->participants[i];
+			if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
+				continue;
+			}
+			gentity_t *ent = &g_entities[clientNum];
+			if (!ent->client) {
+				continue;
+			}
+			ent->client->Lmd.hiRuns.pendingStart = qfalse;
+			ent->client->Lmd.hiRuns.running = qtrue;
+			ent->client->Lmd.hiRuns.pendingStop = qfalse;
+			run->stopRequested[clientNum] = qfalse;
+			Disp(ent, "^5Run started: ^3%s", run->name);
+		}
+	} else {
+		Disp(player, "^3Waiting for ^2%i^3 more player%s to start.",
+			run->requiredCount - run->participantCount,
+			(run->requiredCount - run->participantCount) == 1 ? "" : "s");
+	}
+}
+
+void HiRuns_TimerStop(gentity_t *player, const char *runName) {
+	if (!player || !player->client || !runName || !runName[0]) {
+		return;
+	}
+
+	int runIndex = HiRuns_FindIndex(runName);
+	LmdHiRun_t *run = HiRuns_GetRun(runIndex);
+	if (!run) {
+		Disp(player, "^3No run by that name.");
+		return;
+	}
+
+	if (!run->active) {
+		if (HiRuns_IsParticipant(run, player->s.number)) {
+			HiRuns_RemoveParticipant(run, player->s.number);
+			HiRuns_ClearClientState(player->client);
+			Disp(player, "^3Removed from pending run.");
+		} else {
+			Disp(player, "^3That run is not active.");
+		}
+		return;
+	}
+
+	if (!HiRuns_IsParticipant(run, player->s.number)) {
+		Disp(player, "^3You are not part of that run.");
+		return;
+	}
+
+	if (run->stopRequested[player->s.number]) {
+		Disp(player, "^3You have already marked your finish.");
+		return;
+	}
+
+	run->stopRequested[player->s.number] = qtrue;
+	player->client->Lmd.hiRuns.pendingStop = qtrue;
+
+	if (!HiRuns_AllStopped(run)) {
+		Disp(player, "^3Waiting for others to finish.");
+		return;
+	}
+
+	int durationMs = level.time - run->startTime;
+	char playersLabel[LMD_HIRUNS_PLAYERS_LEN];
+	HiRuns_BuildPlayersLabel(run, playersLabel, sizeof(playersLabel));
+	HiRuns_InsertEntry(run, durationMs, playersLabel);
+	HiRuns_Save();
+
+	char timeBuf[32];
+	HiRuns_FormatDuration(durationMs, timeBuf, sizeof(timeBuf));
+
+	for (int i = 0; i < run->participantCount; i++) {
+		int clientNum = run->participants[i];
+		if (clientNum < 0 || clientNum >= MAX_CLIENTS) {
+			continue;
+		}
+		gentity_t *ent = &g_entities[clientNum];
+		if (!ent->client) {
+			continue;
+		}
+		Disp(ent, va("^5Run finished: ^3%s ^7- ^2%s", run->name, timeBuf));
+		HiRuns_ClearClientState(ent->client);
+	}
+
+	HiRuns_ResetRunState(run);
+}
+
+static void HiRuns_TerminalCleanup(gentity_t *ent) {
+	for (int i = 0; i < MAX_CLIENTS; i++) {
+		gclient_t *client = level.clients + i;
+		if (!client) {
+			continue;
+		}
+		
+		if (client->pers.connected == CON_CONNECTED &&
+			client->Lmd.lmdMenu.entityNum == ent->s.number) {
+			ent->nextthink = level.time + 2000;
+			return;
+		}
+	}
+	
+	G_FreeEntity(ent);
+}
+
+void lmd_menu_exit(gentity_t* player);
+void HiRuns_ShowTerminal(gentity_t *player, const char *runName) {
+	if (!player || !player->client || !runName || !runName[0]) {
+		return;
+	}
+
+	
+
+	int runIndex = HiRuns_FindIndex(runName);
+	LmdHiRun_t *run = HiRuns_GetRun(runIndex);
+	char msg[MAX_STRING_CHARS];
+	if (!run) {
+		Q_strncpyz(msg, "^3No run by that name.", sizeof(msg));
+	} else {
+		HiRuns_BuildDisplay(run, msg, sizeof(msg));
+	}
+
+	gentity_t *menu = G_Spawn();
+	menu->classname = G_NewString("lmd_terminal");
+	menu->spawnflags = 4;
+	menu->r.svFlags |= SVF_NOCLIENT;
+	menu->message = G_NewString2(msg);
+	menu->count = 0;
+	menu->Lmd.color = G_NewString2("^7");
+	menu->Lmd.color2 = G_NewString2("^7");
+	menu->Lmd.customIndex = 0;
+	menu->think = HiRuns_TerminalCleanup;
+	menu->nextthink = level.time + 500;
+
+	if (player->client->Lmd.lmdMenu.entityNum != 0)
+		lmd_menu_exit(player);
+	lmd_menu_enter(player, menu);
+}
+
+void HiRuns_ClientDisconnect(gentity_t *player) {
+	if (!player || !player->client) {
+		return;
+	}
+
+	int runIndex = HiRuns_GetClientRunIndex(player->client);
+	LmdHiRun_t *run = HiRuns_GetRun(runIndex);
+	if (!run) {
+		return;
+	}
+
+	HiRuns_RemoveParticipant(run, player->s.number);
+	HiRuns_ClearClientState(player->client);
+
+	if (run->active && run->participantCount < run->requiredCount) {
+		HiRuns_AbortRun(run, "^3Run canceled due to disconnect.");
+	}
+}

--- a/game/Lmd_HiRuns.h
+++ b/game/Lmd_HiRuns.h
@@ -1,0 +1,39 @@
+#ifndef LMD_HIRUNS_H
+#define LMD_HIRUNS_H
+
+#include "g_local.h"
+
+#define LMD_HIRUNS_FILE "hiruns"
+#define LMD_HIRUNS_MAX_ENTRIES 25
+#define LMD_HIRUNS_NAME_LEN 64
+#define LMD_HIRUNS_PLAYERS_LEN 128
+
+typedef struct {
+	int durationMs;
+	char players[LMD_HIRUNS_PLAYERS_LEN];
+} LmdHiRunEntry_t;
+
+typedef struct {
+	char name[LMD_HIRUNS_NAME_LEN];
+	int entryCount;
+	LmdHiRunEntry_t entries[LMD_HIRUNS_MAX_ENTRIES];
+
+	// Active run state (not saved)
+	qboolean active;
+	int requiredCount;
+	int startTime;
+	int participantCount;
+	int participants[MAX_CLIENTS];
+	qboolean stopRequested[MAX_CLIENTS];
+} LmdHiRun_t;
+
+void HiRuns_Load(void);
+void HiRuns_Save(void);
+void HiRuns_ListRuns(gentity_t *ent);
+void HiRuns_Show(gentity_t *ent, const char *nameOrIndex);
+void HiRuns_TimerStart(gentity_t *player, const char *runName, int requiredCount);
+void HiRuns_TimerStop(gentity_t *player, const char *runName);
+void HiRuns_ShowTerminal(gentity_t *player, const char *runName);
+void HiRuns_ClientDisconnect(gentity_t *player);
+
+#endif

--- a/game/Lmd_Main.c
+++ b/game/Lmd_Main.c
@@ -2,6 +2,7 @@
 #include "g_local.h"
 #include "Lmd_Crosshair.h"
 #include "Lmd_EntityCore.h"
+#include "Lmd_HiRuns.h"
 #include "Lmd_SetSaber.h"
 
 //#define LMD_MEMORY_DEBUG
@@ -78,6 +79,8 @@ void Lmd_Startup(void) {
 	LoadLocationData();
 	G_Printf("^5Loading bans...\n");
 	Bans_Load();
+	G_Printf("^5Loading hiruns...\n");
+	HiRuns_Load();
 }
 
 void jailPlayer(gentity_t *targ, int time);
@@ -238,6 +241,7 @@ void Lmd_Shutdown(void){
 	Accounts_SaveAll(qtrue);
 	Factions_Save(qtrue);
 
+	HiRuns_Save();
 	Auths_Shutdown();
 }
 

--- a/game/g_client.c
+++ b/game/g_client.c
@@ -10,6 +10,7 @@
 #include "Lmd_EntityCore.h"
 #include "Lmd_IPs.h"
 #include "Lmd_Bans.h"
+#include "Lmd_HiRuns.h"
 #include "Lmd_Time.h"
 
 #include "Lmd_Entities_Public.h"
@@ -4725,6 +4726,7 @@ void ClientDisconnect( int clientNum ) {
 	updatePlayer(ent);
 	Confirm_Clear(ent);
 	Interact_Clear(ent);
+	HiRuns_ClientDisconnect(ent);
 
 	//Lugormod remove buddies and ignores
 	j = (int)floor((float)clientNum / 16);

--- a/game/g_misc.c
+++ b/game/g_misc.c
@@ -731,7 +731,7 @@ void misc_model_breakable_use (gentity_t *self, gentity_t *other, gentity_t *act
 	if(self->message && !(self->spawnflags & 8192))
 	{
 		char msg[MAX_STRING_CHARS];
-		strncpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(activator, self->message, NULL), MAX_STRING_CHARS);
+		strncpy(msg, lmd_processMessagePlaceholders(activator, self->message, NULL), MAX_STRING_CHARS);
 		trap_SendServerCommand(activator->s.number, va("cp \"%s\"", msg));
 	}
 }
@@ -756,7 +756,7 @@ void misc_model_breakable_pay (gentity_t *self, gentity_t *other, gentity_t *act
 	if (other->client->pers.cmd.buttons & BUTTON_USE ) {
 		if (self->message) {
 			char msg[MAX_STRING_CHARS];
-			strncpy_s(msg, sizeof(msg), lmd_processMessagePlaceholders(activator, self->message, NULL), MAX_STRING_CHARS);
+			strncpy(msg, lmd_processMessagePlaceholders(activator, self->message, NULL), MAX_STRING_CHARS);
 			trap_SendServerCommand(other-g_entities,
 				va("cp \"%s\nUse the command \\pay on this.\nThe cost is CR %i.\"", msg,self->count));
 		} else {

--- a/game/g_mover.c
+++ b/game/g_mover.c
@@ -1668,6 +1668,7 @@ const entityInfoData_t func_door_keys[] = {
   {"opentarget", "Door fires this after reaching it\'s \'open\' position"},
   {"target2", "Door fires this when it starts moving from it\'s open position to it\'s closed position"},
   {"closetarget", "Door fires this after reaching it\'s \'closed\' position"},
+  {"wantPosition", "Desired resting position for target_doorstate checks. Accepts 'open' or 'close'."},
   {"model2", ".md3 model to also draw"},
   {"angle", "determines the opening direction"},
   {"targetname", "if set, no touch field will be spawned and a remote button or trigger field activates the door."},
@@ -1695,9 +1696,15 @@ const entityInfo_t func_door_info = {
   func_door_keys
 };
 
-void SP_func_door (gentity_t *ent) 
+void SP_func_door (gentity_t *ent)
 {
 	//Lugormod
+
+	G_SpawnString("wantPosition", "", &ent->GenericStrings[15]);
+	if (ent->GenericStrings[15] && !ent->GenericStrings[15][0])
+	{
+		ent->GenericStrings[15] = NULL;
+	}
 
 	//RoboPhred: bugger this, screws up many mp maps
 	//if it should be kept, then add if !ent->targetname to it.

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -446,6 +446,8 @@ void SP_target_location (gentity_t *ent);
 extern entityInfo_t target_location_info;
 void SP_target_counter (gentity_t *self);
 extern entityInfo_t target_counter_info;
+void SP_target_doorstate (gentity_t *self);
+extern entityInfo_t target_doorstate_info;
 void SP_target_random (gentity_t *self);
 extern entityInfo_t target_random_info;
 void SP_target_scriptrunner( gentity_t *self );
@@ -946,6 +948,7 @@ spawn_t	spawnInitValues[] = {
 	{"target_position", SP_target_position, Logical_True, &target_position_info},
 	{"target_location", SP_target_location, Logical_True, &target_location_info},
 	{"target_counter", SP_target_counter, Logical_True, &target_counter_info},
+	{"target_doorstate", SP_target_doorstate, Logical_True, &target_doorstate_info},
 	{"target_random", SP_target_random, Logical_True, &target_random_info},
 	{"target_scriptrunner", SP_target_scriptrunner, qfalse, &target_scriptrunner_info},
 	{"target_interest", SP_target_interest, Logical_True},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -728,6 +728,9 @@ extern entityInfo_t lmd_terminal_info;
 void lmd_toggle(gentity_t *ent);
 extern entityInfo_t lmd_toggle_info;
 
+void lmd_timer(gentity_t *ent);
+extern entityInfo_t lmd_timer_info;
+
 void lmd_train (gentity_t *self);
 extern entityInfo_t lmd_train_info;
 
@@ -856,6 +859,8 @@ spawn_t	spawnInitValues[] = {
 
 	{"lmd_toggle", lmd_toggle, Logical_True, &lmd_toggle_info},
 	{"t2_toggle", lmd_toggle, Logical_True},
+
+	{"lmd_timer", lmd_timer, Logical_True, &lmd_timer_info},
 
 	{"lmd_train", lmd_train, Logical_False, &lmd_train_info},
 	{"lmd_trainer", lmd_trainer, Logical_False, &lmd_trainer_info},

--- a/game/g_spawn.c
+++ b/game/g_spawn.c
@@ -753,6 +753,9 @@ extern entityInfo_t target_modify_info;
 void lmd_cskill_compare(gentity_t* self);
 extern entityInfo_t lmd_cskill_compare_info;
 
+void lmd_equalcheck(gentity_t* self);
+extern entityInfo_t lmd_equalcheck_info;
+
 void lmd_countcheck(gentity_t* self);
 extern entityInfo_t lmd_countcheck_info;
 
@@ -1146,6 +1149,9 @@ spawn_t	spawnInitValues[] = {
 	{"target_heal", sp_target_heal, Logical_True, &target_heal_info},
 	{"lmd_actor_modify", lmd_actor_modify, Logical_True, &lmd_actor_modify_info},
 	{"target_animate", sp_target_animate, Logical_True, &target_animate_info},
+
+	// lumaya:
+		{"lmd_equalcheck", lmd_equalcheck, Logical_True, &lmd_equalcheck_info},
 
 	{NULL, 0, Logical_False}
 };

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -1507,6 +1507,139 @@ void SP_target_counter(gentity_t* self)
     self->use = target_counter_use;
 }
 
+#define TARGET_DOORSTATE_MAX_DOORS 6
+
+static qboolean target_doorstate_is_door(gentity_t* ent)
+{
+    return ent && ent->classname && (!Q_stricmp(ent->classname, "func_door") || !Q_stricmp(ent->classname, "lmd_door"));
+}
+
+static qboolean target_doorstate_matches(gentity_t* door)
+{
+    const char* want = door->GenericStrings[15];
+
+    if (!want || !want[0])
+    {
+        return qfalse;
+    }
+
+    if (!Q_stricmp(want, "open"))
+    {
+        return (door->moverState == MOVER_POS2);
+    }
+
+    if (!Q_stricmp(want, "close") || !Q_stricmp(want, "closed"))
+    {
+        return (door->moverState == MOVER_POS1);
+    }
+
+    return qfalse;
+}
+
+const entityInfoData_t target_doorstate_keys[] = {
+    {"target", "Fired when every referenced door matches its wantPosition."},
+    {"target2", "Fired when any referenced door is missing or does not match its wantPosition."},
+    {"door1", "Targetname of the first door to check."},
+    {"door2", "Targetname of the second door to check."},
+    {"door3", "Targetname of the third door to check."},
+    {"door4", "Targetname of the fourth door to check."},
+    {"door5", "Targetname of the fifth door to check."},
+    {"door6", "Targetname of the sixth door to check."},
+    {NULL, NULL},
+};
+
+const entityInfo_t target_doorstate_info = {
+    "Checks a list of doors to ensure each is in its configured wantPosition. Fires target when all match, otherwise fires target2.",
+    NULL,
+    target_doorstate_keys
+};
+
+static void target_doorstate_use(gentity_t* self, gentity_t* other, gentity_t* activator)
+{
+    qboolean allMatch = qtrue;
+    qboolean hasDoor = qfalse;
+    int i;
+
+    if (!activator)
+    {
+        activator = self;
+    }
+
+    for (i = 0; i < TARGET_DOORSTATE_MAX_DOORS && allMatch; ++i)
+    {
+        const char* doorTarget = self->GenericStrings[i];
+        gentity_t* door = NULL;
+        qboolean foundDoor = qfalse;
+
+        if (!doorTarget || !doorTarget[0])
+        {
+            continue;
+        }
+
+        hasDoor = qtrue;
+
+        while ((door = G_Find(door, FOFS(targetname), doorTarget)) != NULL)
+        {
+            if (!target_doorstate_is_door(door))
+            {
+                continue;
+            }
+
+            foundDoor = qtrue;
+
+            if (!target_doorstate_matches(door))
+            {
+                allMatch = qfalse;
+                break;
+            }
+        }
+
+        if (!allMatch)
+        {
+            break;
+        }
+
+        if (!foundDoor)
+        {
+            allMatch = qfalse;
+            break;
+        }
+    }
+
+    if (!hasDoor)
+    {
+        allMatch = qfalse;
+    }
+
+    if (allMatch)
+    {
+        G_UseTargets(self, activator);
+    }
+    else if (self->target2 && self->target2[0])
+    {
+        G_UseTargets2(self, activator, self->target2);
+    }
+}
+
+void SP_target_doorstate(gentity_t* self)
+{
+    int i;
+
+    for (i = 0; i < TARGET_DOORSTATE_MAX_DOORS; ++i)
+    {
+        char keyName[8];
+
+        Com_sprintf(keyName, sizeof(keyName), "door%d", i + 1);
+        G_SpawnString(keyName, "", &self->GenericStrings[i]);
+        if (self->GenericStrings[i] && !self->GenericStrings[i][0])
+        {
+            self->GenericStrings[i] = NULL;
+        }
+    }
+
+    self->use = target_doorstate_use;
+}
+
 /*QUAKED target_random (.5 .5 .5) (-4 -4 -4) (4 4 4) USEONCE
 Randomly fires off only one of it's targets each time used
 

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -618,7 +618,7 @@ void Send_Target_Print(gentity_t* ent, int targ)
     }
 
     char* processedMsg = lmd_processMessagePlaceholders(activator, buf, ent->target2);
-    strncpy_s(buf, sizeof(buf), processedMsg, MAX_STRING_CHARS);
+    strncpy(buf, processedMsg, MAX_STRING_CHARS);
 
     if (buf[0] == '@' && buf[1] != '@')
     {

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -374,6 +374,8 @@ static void TargetWeapons_ParseAndGive(gentity_t* activator, const char* input, 
     char buffer[1024];
     Q_strncpyz(buffer, input, sizeof(buffer));
 
+    int forcedWeapon = -1;
+
     char* token = strtok(buffer, ".");
     while (token)
     {
@@ -510,9 +512,22 @@ static void TargetWeapons_ParseAndGive(gentity_t* activator, const char* input, 
                         activator->client->ps.fd.saberAnimLevel;
                 }
             }
+
+            if (forceGive && !justAllow && ammoAmount != 0)
+            {
+                forcedWeapon = weaponID;
+            }
         }
 
         token = strtok(NULL, ".");
+    }
+
+    if (forcedWeapon != -1)
+    {
+        activator->client->ps.weapon = forcedWeapon;
+        activator->client->ps.weaponstate = WEAPON_READY;
+        activator->client->ps.weaponTime = 0;
+        activator->s.weapon = forcedWeapon;
     }
 }
 

--- a/game/g_target.c
+++ b/game/g_target.c
@@ -757,6 +757,11 @@ void SP_target_print(gentity_t* ent)
         G_SpawnString("arg", "", &ent->target2);
 }
 
+const entityInfoData_t target_fp_spawnflags[] = {
+    {"1", "Modify only if FP is known"},
+    {NULL, NULL}
+};
+
 const entityInfoData_t target_fp_keys[] = {
 	{"targetname", "make the trigger target this value for the entity to be used"},
 	{"ModifyPowers", "E.g. ModifyPowers,heal2.rage2 -> would set force heal and rage to level 2. Available keys are: jump, push, pull, speed, seeing, heal, protect, absorb"
@@ -767,7 +772,7 @@ const entityInfoData_t target_fp_keys[] = {
 
 const entityInfo_t target_fp_info = {
 	"The activator is given the forcepower + levels given in the ModifyPowers key. ForcePowers not given in ModifyPowers key will remain unchanged. Only death can reset this.",
-	NULL,
+	target_fp_spawnflags,
 	target_fp_keys
 };
 
@@ -810,10 +815,15 @@ int lmd_get_forcePowerMapIndex(const char *token) {
 	return -1;
 }
 
+extern qboolean PlayerUseableCheck(gentity_t *self, gentity_t *activator);
+
 void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 {
 	if (!activator || !activator->client)
 		return;
+
+    if (!PlayerUseableCheck(ent, activator))
+        return;
 
 	activator->client->Lmd.customForceRegenSpeedMultiplier = ent->modelScale[0];
 	
@@ -828,6 +838,9 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 			int fpIndex = lmd_get_forcePowerMapIndex(powerName);
 			if (fpIndex >= 0 && level >= 0 && level <= FORCE_LEVEL_5)
 			{
+			    if (ent->spawnflags & 1 && !(activator->client->ps.fd.forcePowersKnown & (1 << fpIndex)))
+			        continue;
+			    
 				activator->client->ps.fd.forcePowerLevel[fpIndex] = level;
 				if (level > 0)
 					activator->client->ps.fd.forcePowersKnown |= (1 << fpIndex);
@@ -840,8 +853,11 @@ void Use_Target_Fp (gentity_t *ent, gentity_t *other, gentity_t *activator)
 	}
 }
 
+extern void PlayerUsableGetKeys(gentity_t *ent);
+
 void SP_target_fp( gentity_t *ent )
 {
+    PlayerUsableGetKeys(ent);
 	G_SpawnString("ModifyPowers", "", &ent->target2);
 	G_SpawnFloat("ForceRegenSpeedMultiplier", "0.0", &ent->modelScale[0]);
 

--- a/game/g_vehicles.c
+++ b/game/g_vehicles.c
@@ -3429,16 +3429,16 @@ void G_VehUpdateShields( gentity_t *targ )
 #endif
 
 // Set the parent entity of this Vehicle NPC.
-GAME_INLINE void SetParent( Vehicle_t *pVeh, bgEntity_t *pParentEntity ) { pVeh->m_pParentEntity = pParentEntity; }
+void SetParent( Vehicle_t *pVeh, bgEntity_t *pParentEntity ) { pVeh->m_pParentEntity = pParentEntity; }
 
 // Add a pilot to the vehicle.
-GAME_INLINE void SetPilot( Vehicle_t *pVeh, bgEntity_t *pPilot ) { pVeh->m_pPilot = pPilot; }
+void SetPilot( Vehicle_t *pVeh, bgEntity_t *pPilot ) { pVeh->m_pPilot = pPilot; }
 
 // Add a passenger to the vehicle (false if we're full).
-GAME_INLINE bool AddPassenger( Vehicle_t *pVeh ) { return false; }
+bool AddPassenger( Vehicle_t *pVeh ) { return false; }
 
 // Whether this vehicle is currently inhabited (by anyone) or not.
-GAME_INLINE bool Inhabited( Vehicle_t *pVeh ) { return ( pVeh->m_pPilot || pVeh->m_iNumPassengers ) ? true : false; }
+bool Inhabited( Vehicle_t *pVeh ) { return ( pVeh->m_pPilot || pVeh->m_iNumPassengers ) ? true : false; }
 
 
 // Setup the shared functions (one's that all vehicles would generally use).

--- a/game/g_vehicles.c
+++ b/game/g_vehicles.c
@@ -3429,7 +3429,10 @@ void G_VehUpdateShields( gentity_t *targ )
 #endif
 
 // Set the parent entity of this Vehicle NPC.
-void SetParent( Vehicle_t *pVeh, bgEntity_t *pParentEntity ) { pVeh->m_pParentEntity = pParentEntity; }
+void __attribute__((visibility("default"))) SetParent( Vehicle_t *pVeh, bgEntity_t *pParentEntity )
+{
+	pVeh->m_pParentEntity = pParentEntity;
+}
 
 // Add a pilot to the vehicle.
 void SetPilot( Vehicle_t *pVeh, bgEntity_t *pPilot ) { pVeh->m_pPilot = pPilot; }

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -253,6 +253,13 @@ typedef struct renderInfo_s
 	int			boltValidityTime;
 } renderInfo_t;
 
+typedef struct {
+	int runIndex; // 0 means none, index + 1 otherwise
+	qboolean pendingStart;
+	qboolean running;
+	qboolean pendingStop;
+} lmdHiRunClient_t;
+
 // this structure is cleared on each ClientSpawn(),
 // except for 'client->pers' and 'client->sess'
 struct gclient_s {
@@ -611,6 +618,7 @@ struct gclient_s {
 		qboolean lockSaber;
 		int canPickUpWeapons;
 		float customForceRegenSpeedMultiplier;
+		lmdHiRunClient_t hiRuns;
 	}Lmd;
 	unsigned int lastTargetUse;
 	unsigned int infoChanged;


### PR DESCRIPTION
I got slightly annoyed by lmd_gate, so here we are.

Added a WantPosition spawn key for func_door and lmd_door.
target_doorstate validates referenced doors are in their desired positions before firing (keys door1-door6, values targetnames of doors)
keys:

{"target", "Fired when every referenced door matches its wantPosition."},
{"target2", "Fired when any referenced door is missing or does not match its wantPosition."},
{"door1", "Targetname of the first door to check."},
{"door2", "Targetname of the second door to check."},
{"door3", "Targetname of the third door to check."},
{"door4", "Targetname of the fourth door to check."},
{"door5", "Targetname of the fifth door to check."},
{"door6", "Targetname of the sixth door to check."},
Example:

/place target_doorstate * targetname,when_we_fire_this,target,to_fire_when_all_wantPositions_ok,target2,to_fire_when_wantPositions_arent_ok,door1,targetname_of_door1,door2,targetname_of_door2