### PR TITLE
Add multi-character support per account

### DIFF
--- a/game/Lmd_Accounts.c
+++ b/game/Lmd_Accounts.c
@@ -12,6 +12,7 @@
 #include "Lmd_Console.h"
 
 Account_t *Accounts_New(char *username, char *name, char *password);
+void Accounts_Save(Account_t *acc);
 
 #define LEVEL_SCORE 11
 #define MAX_LEVEL  40
@@ -478,13 +479,13 @@ void clearSkills(void){
 }
 
 int recallDroppedCredits(gentity_t *ent);
-void Inventory_Player_Logout(gentity_t *player);
+void Lmd_Accounts_Player_DeselectCharacter(gentity_t *ent);
 void Lmd_Accounts_Player_Logout(gentity_t *ent){
 	Account_t *acc = ent->client->pers.Lmd.account;
 
 	if(ent->client->pers.Lmd.jailTime > level.time)
 		return;
-	
+
 	if(!acc){
 		if(Auths_PlayerHasTempAdmin(ent)){
 			Auths_RemoveTempAdmin(ent, NULL);
@@ -493,9 +494,11 @@ void Lmd_Accounts_Player_Logout(gentity_t *ent){
 		return;
 	}
 
-	recallDroppedCredits(ent);
-	Inventory_Player_Logout(ent);
-	updatePlayer(ent);
+	if (ent->client->pers.Lmd.character) {
+		recallDroppedCredits(ent);
+		updatePlayer(ent);
+		Lmd_Accounts_Player_DeselectCharacter(ent);
+	}
 
 	ent->client->pers.Lmd.account = 0;
 	ent->client->sess.Lmd.id = 0;
@@ -513,53 +516,45 @@ int accountLiveTime(int level);
 void Lmd_IPs_AddName(IP_t ip, char *name);
 void Lmd_IPs_AddAccount(IP_t ip, int id);
 void Inventory_Player_Login(gentity_t *player);
+void Inventory_Player_Logout(gentity_t *player);
 void PlayerGuide_Player_Login(gentity_t *ent);
-qboolean Lmd_Accounts_Player_Login(gentity_t *ent, Account_t *acc){
+
+// Bind a character to a logged-in player. Pulls profession/inventory/skills onto the
+// player session, sets the in-game name, and respawns if needed. Caller must already
+// have set pers.Lmd.account.
+qboolean Lmd_Accounts_Player_SelectCharacter(gentity_t *ent, Character_t *ch) {
 	char uinfo[MAX_INFO_STRING];
-	int i;
+	if (!ent || !ent->client || !ch)
+		return qfalse;
+	Account_t *acc = ent->client->pers.Lmd.account;
+	if (!acc || Character_GetAccount(ch) != acc)
+		return qfalse;
 
-	for (i = 0; i < MAX_CLIENTS;i++){
-		if (g_entities[i].inuse && i != ent->s.number && g_entities[i].client->pers.Lmd.account == acc) {
-			return qfalse;
-		}
-	}
+	Account_SetActiveCharacter(acc, ch);
+	ent->client->pers.Lmd.character = ch;
 
-	if(!Accounts_Prof_GetLevel(acc)){
+	if (!Accounts_Prof_GetLevel(acc)) {
 		Accounts_Prof_SetProfession(acc, PROF_NONE);
 		Accounts_Prof_SetLevel(acc, 1);
 		Accounts_SetScore(acc, 10);
-		if(lmd_startingcr.integer > 0){
+		if (lmd_startingcr.integer > 0) {
 			Accounts_SetCredits(acc, lmd_startingcr.integer);
 			Accounts_AddFlags(acc, ACCFLAGS_NOPROFCRLOSS);
 		}
 	}
 
-	
-
-	Accounts_SetLogins(acc, Accounts_GetLogins(acc) + 1);
-
-	ent->client->pers.Lmd.playTime = level.time;
-	ent->client->pers.Lmd.account = acc;
-	ent->client->sess.Lmd.id = Accounts_GetId(acc);
-
-	Accounts_SetLastIp(acc, ent->client->sess.Lmd.ip);
-
-	Accounts_SetLastLogin(acc, Time_Now());
-	
 	int prof = Accounts_Prof_GetProfession(acc);
-	if (prof != PROF_NONE && prof != PROF_BOT){
+	if (prof != PROF_BOT) {
 		ent->flags &= ~FL_GODMODE;
-		if (ent->client->sess.sessionTeam != TEAM_SPECTATOR){
-			//ent->client->ps.persistant[PERS_SCORE]++;
+		if (ent->client->sess.sessionTeam != TEAM_SPECTATOR) {
 			ent->client->ps.stats[STAT_HEALTH] = ent->health = 0;
-			ClientSpawn(ent); //Ufo: why die if respawn is sufficient
-			//player_die(ent, ent, ent, 100000, MOD_SUICIDE);
+			ClientSpawn(ent);
 		}
 	}
 
 	WP_InitForcePowers(ent);
 
-	char *name = Accounts_GetName(acc);
+	char *name = Character_GetName(ch);
 	trap_GetUserinfo(ent->s.number, uinfo, sizeof(uinfo));
 	Q_strncpyz(ent->client->pers.netname, name, sizeof(ent->client->pers.netname));
 	Lmd_IPs_AddName(ent->client->sess.Lmd.ip, ent->client->pers.netname);
@@ -571,14 +566,53 @@ qboolean Lmd_Accounts_Player_Login(gentity_t *ent, Account_t *acc){
 	Inventory_Player_Login(ent);
 	PlayerGuide_Player_Login(ent);
 
+	return qtrue;
+}
+
+// Drop the currently-selected character without logging the player out of the account.
+void Lmd_Accounts_Player_DeselectCharacter(gentity_t *ent) {
+	if (!ent || !ent->client || !ent->client->pers.Lmd.character)
+		return;
+	Account_t *acc = ent->client->pers.Lmd.account;
+	Inventory_Player_Logout(ent);
+	if (acc)
+		Account_SetActiveCharacter(acc, NULL);
+	ent->client->pers.Lmd.character = NULL;
+}
+
+qboolean Lmd_Accounts_Player_Login(gentity_t *ent, Account_t *acc){
+	int i;
+
+	for (i = 0; i < MAX_CLIENTS;i++){
+		if (g_entities[i].inuse && i != ent->s.number && g_entities[i].client->pers.Lmd.account == acc) {
+			return qfalse;
+		}
+	}
+
+	Accounts_SetLogins(acc, Accounts_GetLogins(acc) + 1);
+
+	ent->client->pers.Lmd.playTime = level.time;
+	ent->client->pers.Lmd.account = acc;
+	ent->client->pers.Lmd.character = NULL;
+	ent->client->sess.Lmd.id = Accounts_GetId(acc);
+
+	Accounts_SetLastIp(acc, ent->client->sess.Lmd.ip);
+	Accounts_SetLastLogin(acc, Time_Now());
 
 	//Ufo: we don't want admins without proper flag to start with admin chatmode
 	if (Auths_AccHasAdmin(acc) && Auths_AccHasAuthFlag(acc, AUTH_ADMINCHAT)) {
 		ent->client->pers.Lmd.chatMode[1] = SAY_ADMINS;
 	}
 
-	
 	Lmd_Accounts_LogAction(ent, acc, "logged in");
+
+	// Auto-pick the only character if there is one (preserves single-character UX).
+	if (Account_GetNumCharacters(acc) == 1) {
+		Lmd_Accounts_Player_SelectCharacter(ent, Account_GetCharacter(acc, 0));
+	}
+	else {
+		Disp(ent, "^3You have multiple characters. Use ^2/charlist^3 and ^2/play <name>^3 to enter the game.");
+	}
 
 	return qtrue;
 }
@@ -1114,10 +1148,164 @@ void Cmd_Worthy_f (gentity_t *ent, int iArg){
 	listWorthy(ent);
 }
 
+void Cmd_CharList_f(gentity_t *ent, int iArg) {
+	Account_t *acc = ent->client->pers.Lmd.account;
+	if (!acc) {
+		Disp(ent, "^3You must be logged in to use this.");
+		return;
+	}
+	int n = Account_GetNumCharacters(acc);
+	if (n == 0) {
+		Disp(ent, "^3You have no characters. Use ^2/charcreate <name>^3 to make one.");
+		return;
+	}
+	Disp(ent, va("^3Characters on this account (^2%d^3/^2%d^3):", n, MAX_CHARS_PER_ACCOUNT));
+	int i;
+	for (i = 0; i < n; i++) {
+		Character_t *ch = Account_GetCharacter(acc, i);
+		Account_SetActiveCharacter(acc, ch); // temp, so per-char getters resolve
+		int level = Accounts_Prof_GetLevel(acc);
+		int prof = Accounts_Prof_GetProfession(acc);
+		char *active = (ent->client->pers.Lmd.character == ch) ? " ^2(active)" : "";
+		Disp(ent, va("^3%d) ^7%s ^3- ^2%s^3 lvl ^2%d^3%s",
+			i + 1, Character_GetName(ch), Professions_GetName(prof), level, active));
+	}
+	// Restore active to whatever the player was actually using.
+	Account_SetActiveCharacter(acc, ent->client->pers.Lmd.character);
+}
+
+void Cmd_Play_f(gentity_t *ent, int iArg) {
+	Account_t *acc = ent->client->pers.Lmd.account;
+	if (!acc) {
+		Disp(ent, "^3You must be logged in to use this.");
+		return;
+	}
+	if (trap_Argc() < 2) {
+		Disp(ent, "^3Usage: ^2/play <name>^3 or ^2/play <number>");
+		return;
+	}
+	char arg[MAX_NETNAME];
+	trap_Argv(1, arg, sizeof(arg));
+
+	Character_t *ch = NULL;
+	int n = Account_GetNumCharacters(acc);
+
+	// Pure-numeric argument selects by 1-based index from /charlist.
+	qboolean isNumeric = (arg[0] != 0);
+	int k;
+	for (k = 0; arg[k]; k++) {
+		if (arg[k] < '0' || arg[k] > '9') { isNumeric = qfalse; break; }
+	}
+	if (isNumeric) {
+		int idx = atoi(arg);
+		if (idx < 1 || idx > n) {
+			Disp(ent, va("^3Index out of range. You have ^2%d^3 character%s.", n, n == 1 ? "" : "s"));
+			return;
+		}
+		ch = Account_GetCharacter(acc, idx - 1);
+	}
+	else {
+		ch = Account_FindCharacterByName(acc, arg);
+	}
+
+	if (!ch) {
+		Disp(ent, va("^3No character named ^2%s^3 on this account. Use ^2/charlist^3.", arg));
+		return;
+	}
+	if (ent->client->pers.Lmd.character == ch) {
+		Disp(ent, "^3That character is already active.");
+		return;
+	}
+	if (ent->client->pers.Lmd.character) {
+		updatePlayer(ent);
+		Lmd_Accounts_Player_DeselectCharacter(ent);
+	}
+	if (Lmd_Accounts_Player_SelectCharacter(ent, ch)) {
+		Disp(ent, va("^2Now playing as ^7%s^2.", Character_GetName(ch)));
+	}
+	else {
+		Disp(ent, "^1Failed to select character.");
+	}
+}
+
+void Cmd_CharCreate_f(gentity_t *ent, int iArg) {
+	Account_t *acc = ent->client->pers.Lmd.account;
+	if (!acc) {
+		Disp(ent, "^3You must be logged in to use this.");
+		return;
+	}
+	if (trap_Argc() < 2) {
+		Disp(ent, "^3Usage: ^2/charcreate <name>");
+		return;
+	}
+	if (Account_GetNumCharacters(acc) >= MAX_CHARS_PER_ACCOUNT) {
+		Disp(ent, va("^3You already have the maximum of ^2%d^3 characters.", MAX_CHARS_PER_ACCOUNT));
+		return;
+	}
+	char name[MAX_NETNAME];
+	trap_Argv(1, name, sizeof(name));
+	char *failReason;
+	if (!IsValidPlayerName(name, ent, qtrue, &failReason)) {
+		Disp(ent, va("^1Invalid name. ^3%s", failReason ? failReason : ""));
+		return;
+	}
+	if (Accounts_GetCharacterByName(name)) {
+		Disp(ent, "^1That name is already in use.");
+		return;
+	}
+	Character_t *ch = Account_NewCharacter(acc, name);
+	if (!ch) {
+		Disp(ent, "^1Could not create character.");
+		return;
+	}
+	Accounts_Save(acc); // flush immediately so a crash before the periodic save won't drop the new char
+	Disp(ent, va("^2Character ^7%s^2 created. Use ^2/play %s^2 to enter the game.", name, name));
+}
+
+void Cmd_CharDelete_f(gentity_t *ent, int iArg) {
+	Account_t *acc = ent->client->pers.Lmd.account;
+	if (!acc) {
+		Disp(ent, "^3You must be logged in to use this.");
+		return;
+	}
+	if (trap_Argc() < 2) {
+		Disp(ent, "^3Usage: ^2/chardelete <name>");
+		return;
+	}
+	char name[MAX_NETNAME];
+	trap_Argv(1, name, sizeof(name));
+	Character_t *ch = Account_FindCharacterByName(acc, name);
+	if (!ch) {
+		Disp(ent, "^3No such character.");
+		return;
+	}
+	if (Account_GetNumCharacters(acc) <= 1) {
+		Disp(ent, "^1You cannot delete your last character.");
+		return;
+	}
+	qboolean wasActive = (ent->client->pers.Lmd.character == ch);
+	if (wasActive) {
+		Lmd_Accounts_Player_DeselectCharacter(ent);
+		RenamePlayer(ent, "Padawan");
+	}
+	if (Account_DeleteCharacter(acc, ch)) {
+		Accounts_Save(acc);
+		Disp(ent, va("^2Character ^7%s^2 deleted.", name));
+		if (wasActive)
+			Disp(ent, "^3Use ^2/play <name>^3 to select a different character.");
+	}
+	else {
+		Disp(ent, "^1Failed to delete character.");
+	}
+}
+
 void Cmd_Inventory_f(gentity_t *ent, int iArg);
 void Cmd_Property_f(gentity_t *ent, int iArg);
 
 cmdEntry_t accountCommandEntries[] = {
+	{"charcreate", "Create a new character on your account.", Cmd_CharCreate_f, 0, qfalse, 0, 0, 0, 0},
+	{"chardelete", "Delete a character from your account.", Cmd_CharDelete_f, 0, qfalse, 0, 0, 0, 0},
+	{"charlist", "List the characters on your account.", Cmd_CharList_f, 0, qfalse, 0, 0, 0, 0},
 	{"chpasswd","Change the password for your account.", Cmd_ChPasswd_f, 0, qfalse, 1, 1, 0, 0},
 	{"credits","Check your current wealth.", Cmd_Credits_f, 0, qfalse, 1, 128, ~(1 << GT_FFA), 0},
 	{"dropcr", "Drop credits.", Cmd_Credits_f, 3, qfalse, 1, 128, ~(1 << GT_FFA), 0},
@@ -1125,6 +1313,7 @@ cmdEntry_t accountCommandEntries[] = {
 	{"login"," Login to use the name you registered with \\register.\nIf you change name when you are logged in, the new name will become the registered name.", Cmd_Login_f, 0, qfalse, 0, 1, 0, 0, qtrue},
 	{"logout", "Logs out of your account.  If you are not in an account but have admin, you will loose admin status.", Cmd_Logout_f, 0, qfalse, 1, 0, 0, 0},
 	{"pay", "Give the player you are looking at CR <amount>.", Cmd_Credits_f, 1, qfalse, 1, 128, ~(1 << GT_FFA), 0},
+	{"charselect", "Switch to one of the characters on your account. Pass name or 1-based index.", Cmd_Play_f, 0, qfalse, 0, 0, 0, 0},
 	{"property", "View your owned properties.  If you have the right rank, you can modify your property access here.", Cmd_Property_f, 0, qfalse, 1, 0, 0, 0},
 	{"register", "Register your account.", Cmd_Register_f, 0, qfalse, 0, 1, 0, 0, qtrue},
 	{"seccode", "Show, edit, regenerate, or enable/disable your security code.", Cmd_Seccode_f, 0, qfalse, 1, 1, 0, 0},

--- a/game/Lmd_Accounts.c
+++ b/game/Lmd_Accounts.c
@@ -532,6 +532,7 @@ qboolean Lmd_Accounts_Player_SelectCharacter(gentity_t *ent, Character_t *ch) {
 
 	Account_SetActiveCharacter(acc, ch);
 	ent->client->pers.Lmd.character = ch;
+	Character_StampLastPlayed(ch);
 
 	if (!Accounts_Prof_GetLevel(acc)) {
 		Accounts_Prof_SetProfession(acc, PROF_NONE);
@@ -606,12 +607,15 @@ qboolean Lmd_Accounts_Player_Login(gentity_t *ent, Account_t *acc){
 
 	Lmd_Accounts_LogAction(ent, acc, "logged in");
 
-	// Auto-pick the only character if there is one (preserves single-character UX).
-	if (Account_GetNumCharacters(acc) == 1) {
-		Lmd_Accounts_Player_SelectCharacter(ent, Account_GetCharacter(acc, 0));
-	}
-	else {
-		Disp(ent, "^3You have multiple characters. Use ^2/charlist^3 and ^2/play <name>^3 to enter the game.");
+	// Auto-select the most recently played character. Falls back to characters[0]
+	// when no character has ever been played (e.g. fresh registration / migration).
+	Character_t *recent = Account_GetMostRecentCharacter(acc);
+	if (recent) {
+		Lmd_Accounts_Player_SelectCharacter(ent, recent);
+		if (Account_GetNumCharacters(acc) > 1) {
+			Disp(ent, va("^3Resumed ^7%s^3. Use ^2/charlist^3 and ^2/play <name|index>^3 to switch.",
+				Character_GetName(recent)));
+		}
 	}
 
 	return qtrue;

--- a/game/Lmd_Accounts.c
+++ b/game/Lmd_Accounts.c
@@ -613,7 +613,7 @@ qboolean Lmd_Accounts_Player_Login(gentity_t *ent, Account_t *acc){
 	if (recent) {
 		Lmd_Accounts_Player_SelectCharacter(ent, recent);
 		if (Account_GetNumCharacters(acc) > 1) {
-			Disp(ent, va("^3Resumed ^7%s^3. Use ^2/charlist^3 and ^2/play <name|index>^3 to switch.",
+			Disp(ent, va("^3Resumed ^7%s^3. Use ^2/charlist^3 and ^2/charselect <name|index>^3 to switch.",
 				Character_GetName(recent)));
 		}
 	}
@@ -1178,14 +1178,14 @@ void Cmd_CharList_f(gentity_t *ent, int iArg) {
 	Account_SetActiveCharacter(acc, ent->client->pers.Lmd.character);
 }
 
-void Cmd_Play_f(gentity_t *ent, int iArg) {
+void Cmd_CharSelect_f(gentity_t *ent, int iArg) {
 	Account_t *acc = ent->client->pers.Lmd.account;
 	if (!acc) {
 		Disp(ent, "^3You must be logged in to use this.");
 		return;
 	}
 	if (trap_Argc() < 2) {
-		Disp(ent, "^3Usage: ^2/play <name>^3 or ^2/play <number>");
+		Disp(ent, "^3Usage: ^2/charselect <name>^3 or ^2/charselect <number>");
 		return;
 	}
 	char arg[MAX_NETNAME];
@@ -1263,7 +1263,7 @@ void Cmd_CharCreate_f(gentity_t *ent, int iArg) {
 		return;
 	}
 	Accounts_Save(acc); // flush immediately so a crash before the periodic save won't drop the new char
-	Disp(ent, va("^2Character ^7%s^2 created. Use ^2/play %s^2 to enter the game.", name, name));
+	Disp(ent, va("^2Character ^7%s^2 created. Use ^2/charselect %s^2 to enter the game.", name, name));
 }
 
 void Cmd_CharDelete_f(gentity_t *ent, int iArg) {
@@ -1296,7 +1296,7 @@ void Cmd_CharDelete_f(gentity_t *ent, int iArg) {
 		Accounts_Save(acc);
 		Disp(ent, va("^2Character ^7%s^2 deleted.", name));
 		if (wasActive)
-			Disp(ent, "^3Use ^2/play <name>^3 to select a different character.");
+			Disp(ent, "^3Use ^2/charselect <name>^3 to select a different character.");
 	}
 	else {
 		Disp(ent, "^1Failed to delete character.");
@@ -1317,7 +1317,7 @@ cmdEntry_t accountCommandEntries[] = {
 	{"login"," Login to use the name you registered with \\register.\nIf you change name when you are logged in, the new name will become the registered name.", Cmd_Login_f, 0, qfalse, 0, 1, 0, 0, qtrue},
 	{"logout", "Logs out of your account.  If you are not in an account but have admin, you will loose admin status.", Cmd_Logout_f, 0, qfalse, 1, 0, 0, 0},
 	{"pay", "Give the player you are looking at CR <amount>.", Cmd_Credits_f, 1, qfalse, 1, 128, ~(1 << GT_FFA), 0},
-	{"charselect", "Switch to one of the characters on your account. Pass name or 1-based index.", Cmd_Play_f, 0, qfalse, 0, 0, 0, 0},
+	{"charselect", "Switch to one of the characters on your account. Pass name or 1-based index.", Cmd_CharSelect_f, 0, qfalse, 0, 0, 0, 0},
 	{"property", "View your owned properties.  If you have the right rank, you can modify your property access here.", Cmd_Property_f, 0, qfalse, 1, 0, 0, 0},
 	{"register", "Register your account.", Cmd_Register_f, 0, qfalse, 0, 1, 0, 0, qtrue},
 	{"seccode", "Show, edit, regenerate, or enable/disable your security code.", Cmd_Seccode_f, 0, qfalse, 1, 1, 0, 0},

--- a/game/Lmd_Accounts_Core.c
+++ b/game/Lmd_Accounts_Core.c
@@ -17,11 +17,11 @@
 #define SECCODE_LENGTH 6
 
 qboolean IsValidName(char *name);
+Character_t *allocCharacter(Account_t *owner);
+void freeCharacter(Character_t *ch);
 
 struct Account_s{
 	char *username;
-
-	char *name;
 	unsigned int pwChksum;
 	char *secCode;
 
@@ -29,31 +29,57 @@ struct Account_s{
 	int logins;
 	unsigned int lastLogin;
 	IP_t lastIP;
-	
-	int time;
-	int score;
-	int credits;
-	int bounty;
 	int flags;
 
 	struct {
-		unsigned int count; // In case data is added after the account was allocated.
+		unsigned int count; // account-scope module data
 		void **data;
 	} data;
+
+	Character_t *characters[MAX_CHARS_PER_ACCOUNT];
+	int numCharacters;
+	Character_t *activeCharacter;
+	qboolean migrated;      // set after legacy single-character file has been folded into characters[0]
 
 	int modifiedTime;
 };
 
+struct Character_s {
+	char *name;
+	int credits;
+	int bounty;
+	int time;
+	int score;
+	Account_t *account;
+
+	struct {
+		unsigned int count; // char-scope module data
+		void **data;
+	} data;
+};
+
 #define	ACCOUNTOFS(x) ((int)&(((Account_t *)0)->x))
+#define	CHAROFS(x) ((int)&(((Character_t *)0)->x))
 
 struct {
 	unsigned int count;
 	accDataModule_t **categories;
 } AccountDataTypes;
 
+struct {
+	unsigned int count;
+	accDataModule_t **categories;
+} CharacterDataTypes;
+
 int Lmd_Accounts_AddDataCategory(accDataModule_t *category) {
 	int newIndex = Lmd_Arrays_AddArrayElement((void **)&AccountDataTypes.categories, sizeof(accDataModule_t*), &AccountDataTypes.count);
 	AccountDataTypes.categories[newIndex] = category;
+	return newIndex;
+}
+
+int Lmd_Accounts_AddCharacterDataCategory(accDataModule_t *category) {
+	int newIndex = Lmd_Arrays_AddArrayElement((void **)&CharacterDataTypes.categories, sizeof(accDataModule_t*), &CharacterDataTypes.count);
+	CharacterDataTypes.categories[newIndex] = category;
 	return newIndex;
 }
 
@@ -65,6 +91,21 @@ void* Lmd_Accounts_GetAccountCategoryData(Account_t *acc, int categoryIndex) {
 	}
 
 	return acc->data.data[categoryIndex];
+}
+
+void* Lmd_Accounts_GetCharacterCategoryData(Character_t *ch, int categoryIndex) {
+	if(!ch)
+		return NULL;
+	if (categoryIndex < 0 || categoryIndex >= CharacterDataTypes.count) {
+		G_Error("GetCharacterCategoryData: Index out of range");
+	}
+	return ch->data.data[categoryIndex];
+}
+
+void* Lmd_Accounts_GetAccCharCategoryData(Account_t *acc, int categoryIndex) {
+	if (!acc || !acc->activeCharacter)
+		return NULL;
+	return Lmd_Accounts_GetCharacterCategoryData(acc->activeCharacter, categoryIndex);
 }
 
 
@@ -134,6 +175,25 @@ qboolean Accounts_Parse_Modules(char *key, char *value, void *target, void *args
 		}
 	}
 
+	return qfalse;
+}
+
+// Per-character module dispatch (used during [character] section parsing).
+qboolean Characters_Parse_Modules(char *key, char *value, void *target, void *args) {
+	Character_t *ch = (Character_t*) target;
+
+	Accounts_Update_Override(&key, &value);
+
+	int i;
+	for (i = 0; i < CharacterDataTypes.count; i++) {
+		accDataModule_t *module = CharacterDataTypes.categories[i];
+		void *dataPtr = ch->data.data[i];
+		if (module->numDataFields > 0 &&
+			Lmd_Data_Parse_KeyValuePair(key, value, dataPtr, module->dataFields, module->numDataFields))
+		{
+			return qtrue;
+		}
+	}
 	return qfalse;
 }
 
@@ -210,18 +270,75 @@ DataWriteResult_t Accounts_Write_Modules(void *target, char key[], int keySize, 
 	goto nextModule;
 }
 
+DataWriteResult_t Characters_Write_Modules(void *target, char key[], int keySize, char value[], int valueSize, void **writeState, void *args) {
+	Character_t *ch = (Character_t*) target;
+
+	struct AccountsWriteModulesState *state;
+	accDataModule_t *module;
+
+	if (*writeState == NULL) {
+		state = (struct AccountsWriteModulesState *)G_Alloc(sizeof(struct AccountsWriteModulesState));
+		state->moduleIndex = -1;
+		*writeState = state;
+
+		nextModule:
+		state->dataFieldIndex = 0;
+		state->dataFieldState = NULL;
+		while (++state->moduleIndex < CharacterDataTypes.count) {
+			module = CharacterDataTypes.categories[state->moduleIndex];
+			if (module->numDataFields > 0) {
+				break;
+			}
+		}
+	}
+	else {
+		state = (struct AccountsWriteModulesState *)*writeState;
+	}
+
+	if (state->moduleIndex >= CharacterDataTypes.count) {
+		G_Free(state);
+		return DWR_NODATA;
+	}
+
+	module = CharacterDataTypes.categories[state->moduleIndex];
+
+	nextField:
+	if (state->dataFieldIndex < module->numDataFields) {
+		const DataField_t *field = &module->dataFields[state->dataFieldIndex];
+		if (field->write) {
+			void *dataPtr = ch->data.data[state->moduleIndex];
+
+			Q_strncpyz(key, field->key, keySize);
+			DataWriteResult_t result = field->write(dataPtr, key, keySize, value, valueSize, &state->dataFieldState, field->writeArgs);
+			if (result == DWR_COMPLETE || result == DWR_NODATA) {
+				state->dataFieldIndex++;
+			}
+			if (result == DWR_NODATA) {
+				goto nextField;
+			}
+			return DWR_CONTINUE;
+		}
+		else {
+			state->dataFieldIndex++;
+			goto nextField;
+		}
+	}
+
+	goto nextModule;
+}
+
+// AccountFields_Base writes only account-scope state. Per-character fields
+// (name/credits/bounty/time/score and char-scope module keys) live in
+// CharacterFields_Base and are written inside [character] sections. Legacy single-
+// character .uac files have those keys at the top level; the parser routes them to
+// a temporary Character_t when they don't match account fields.
 #define AccountFields_Base(_m) \
-	_m##_AUTO(name, ACCOUNTOFS(name), F_QSTRING) \
 	_m##_FUNC(password, Accounts_Parse_Password, Accounts_Write_Password, NULL)	\
 	_m##_AUTO(seccode, ACCOUNTOFS(secCode), F_QSTRING) \
 	_m##_AUTO(id, ACCOUNTOFS(id), F_INT) \
 	_m##_AUTO(logins, ACCOUNTOFS(logins), F_INT) \
 	_m##_FUNC(lastlogin, Accounts_Parse_LastLogin, Accounts_Write_LastLogin, NULL) \
 	_m##_FUNC(lastip, Accounts_Parse_LastIP, Accounts_Write_LastIP, NULL) \
-	_m##_AUTO(time, ACCOUNTOFS(time), F_INT) \
-	_m##_AUTO(score, ACCOUNTOFS(score), F_INT) \
-	_m##_AUTO(credits, ACCOUNTOFS(credits), F_INT) \
-	_m##_AUTO(bounty, ACCOUNTOFS(bounty), F_INT) \
 	_m##_AUTO(flags, ACCOUNTOFS(flags), F_INT) \
 	_m##_DEFL(Accounts_Parse_Modules, Accounts_Write_Modules, NULL)
 
@@ -232,6 +349,22 @@ AccountFields_Base(DEFINE_FIELD_LIST)
 DATAFIELDS_END
 
 const int AccountFields_Count = DATAFIELDS_COUNT(AccountFields);
+
+#define CharacterFields_Base(_m) \
+	_m##_AUTO(name, CHAROFS(name), F_QSTRING) \
+	_m##_AUTO(credits, CHAROFS(credits), F_INT) \
+	_m##_AUTO(bounty, CHAROFS(bounty), F_INT) \
+	_m##_AUTO(time, CHAROFS(time), F_INT) \
+	_m##_AUTO(score, CHAROFS(score), F_INT) \
+	_m##_DEFL(Characters_Parse_Modules, Characters_Write_Modules, NULL)
+
+CharacterFields_Base(DEFINE_FIELD_PRE)
+
+DATAFIELDS_BEGIN(CharacterFields)
+CharacterFields_Base(DEFINE_FIELD_LIST)
+DATAFIELDS_END
+
+const int CharacterFields_Count = DATAFIELDS_COUNT(CharacterFields);
 
 struct {
 	unsigned int count;
@@ -271,12 +404,198 @@ Account_t *Accounts_GetByUsername(char *str) {
 }
 
 Account_t *Accounts_GetByName(char *str) {
-	int i;
+	int i, c;
 	for(i = 0; i < AccList.count; i++) {
-		if(Q_stricmpname(AccList.accounts[i]->name, str) == 0)
-			return AccList.accounts[i];
+		Account_t *acc = AccList.accounts[i];
+		for (c = 0; c < acc->numCharacters; c++) {
+			if (acc->characters[c] && acc->characters[c]->name &&
+				Q_stricmpname(acc->characters[c]->name, str) == 0)
+				return acc;
+		}
 	}
 	return NULL;
+}
+
+Character_t *Accounts_GetCharacterByName(char *str) {
+	int i, c;
+	for (i = 0; i < AccList.count; i++) {
+		Account_t *acc = AccList.accounts[i];
+		for (c = 0; c < acc->numCharacters; c++) {
+			Character_t *ch = acc->characters[c];
+			if (ch && ch->name && Q_stricmpname(ch->name, str) == 0)
+				return ch;
+		}
+	}
+	return NULL;
+}
+
+Character_t *Account_GetCharacter(Account_t *acc, int index) {
+	if (!acc || index < 0 || index >= acc->numCharacters)
+		return NULL;
+	return acc->characters[index];
+}
+
+int Account_GetNumCharacters(Account_t *acc) {
+	if (!acc) return 0;
+	return acc->numCharacters;
+}
+
+Character_t *Account_GetActiveCharacter(Account_t *acc) {
+	if (!acc) return NULL;
+	return acc->activeCharacter;
+}
+
+void Account_SetActiveCharacter(Account_t *acc, Character_t *ch) {
+	if (!acc) return;
+	acc->activeCharacter = ch;
+}
+
+Character_t *Account_FindCharacterByName(Account_t *acc, char *name) {
+	if (!acc || !name) return NULL;
+	int i;
+	for (i = 0; i < acc->numCharacters; i++) {
+		Character_t *ch = acc->characters[i];
+		if (ch && ch->name && Q_stricmpname(ch->name, name) == 0)
+			return ch;
+	}
+	return NULL;
+}
+
+Character_t *Account_NewCharacter(Account_t *acc, char *name) {
+	if (!acc || !name)
+		return NULL;
+	if (acc->numCharacters >= MAX_CHARS_PER_ACCOUNT)
+		return NULL;
+	if (Accounts_GetCharacterByName(name) != NULL)
+		return NULL;
+	Character_t *ch = allocCharacter(acc);
+	ch->name = G_NewString2(name);
+	acc->characters[acc->numCharacters++] = ch;
+	int i;
+	for (i = 0; i < CharacterDataTypes.count; i++) {
+		accDataModule_t *category = CharacterDataTypes.categories[i];
+		if (category->accLoadCompleted == NULL)
+			continue;
+		category->accLoadCompleted(acc, ch->data.data[i]);
+	}
+	Lmd_Accounts_Modify(acc);
+	return ch;
+}
+
+qboolean Account_DeleteCharacter(Account_t *acc, Character_t *ch) {
+	if (!acc || !ch)
+		return qfalse;
+	int i, found = -1;
+	for (i = 0; i < acc->numCharacters; i++) {
+		if (acc->characters[i] == ch) {
+			found = i;
+			break;
+		}
+	}
+	if (found < 0)
+		return qfalse;
+	if (acc->activeCharacter == ch)
+		acc->activeCharacter = NULL;
+	for (i = found; i < acc->numCharacters - 1; i++) {
+		acc->characters[i] = acc->characters[i + 1];
+	}
+	acc->characters[acc->numCharacters - 1] = NULL;
+	acc->numCharacters--;
+	freeCharacter(ch);
+	Lmd_Accounts_Modify(acc);
+	return qtrue;
+}
+
+qboolean Account_MoveCharacter(Account_t *src, Character_t *ch, Account_t *dst) {
+	if (!src || !dst || !ch)
+		return qfalse;
+	if (dst->numCharacters >= MAX_CHARS_PER_ACCOUNT)
+		return qfalse;
+	int i, found = -1;
+	for (i = 0; i < src->numCharacters; i++) {
+		if (src->characters[i] == ch) { found = i; break; }
+	}
+	if (found < 0)
+		return qfalse;
+	if (src->activeCharacter == ch)
+		src->activeCharacter = NULL;
+	for (i = found; i < src->numCharacters - 1; i++)
+		src->characters[i] = src->characters[i + 1];
+	src->characters[src->numCharacters - 1] = NULL;
+	src->numCharacters--;
+
+	dst->characters[dst->numCharacters++] = ch;
+	ch->account = dst;
+	Lmd_Accounts_Modify(src);
+	Lmd_Accounts_Modify(dst);
+	return qtrue;
+}
+
+unsigned int Characters_Count() {
+	unsigned int total = 0;
+	int i;
+	for (i = 0; i < AccList.count; i++)
+		total += AccList.accounts[i]->numCharacters;
+	return total;
+}
+
+Character_t *Characters_Get(unsigned int idx) {
+	int i;
+	for (i = 0; i < AccList.count; i++) {
+		Account_t *acc = AccList.accounts[i];
+		if ((int)idx < acc->numCharacters)
+			return acc->characters[idx];
+		idx -= acc->numCharacters;
+	}
+	return NULL;
+}
+
+Account_t *Character_GetAccount(Character_t *ch) {
+	if (!ch) return NULL;
+	return ch->account;
+}
+
+char *Character_GetName(Character_t *ch) {
+	if (!ch) return NULL;
+	if (IsValidName(ch->name) == qfalse)
+		return "Padawan";
+	return ch->name;
+}
+
+void Character_SetName(Character_t *ch, char *name) {
+	if (!ch) return;
+	if (IsValidName(name) == qfalse)
+		name = "Padawan";
+	G_Free(ch->name);
+	ch->name = G_NewString2(name);
+	if (ch->account)
+		Lmd_Accounts_Modify(ch->account);
+}
+
+int Character_GetCredits(Character_t *ch) { return ch ? ch->credits : 0; }
+void Character_SetCredits(Character_t *ch, int v) {
+	if (!ch) return;
+	if (v < 0) v = 0;
+	ch->credits = v;
+	if (ch->account) Lmd_Accounts_Modify(ch->account);
+}
+int Character_GetBounty(Character_t *ch) { return ch ? ch->bounty : 0; }
+void Character_SetBounty(Character_t *ch, int v) {
+	if (!ch) return;
+	ch->bounty = v;
+	if (ch->account) Lmd_Accounts_Modify(ch->account);
+}
+int Character_GetTime(Character_t *ch) { return ch ? ch->time : 0; }
+void Character_SetTime(Character_t *ch, int v) {
+	if (!ch) return;
+	ch->time = v;
+	if (ch->account) Lmd_Accounts_Modify(ch->account);
+}
+int Character_GetScore(Character_t *ch) { return ch ? ch->score : 0; }
+void Character_SetScore(Character_t *ch, int v) {
+	if (!ch) return;
+	ch->score = v;
+	if (ch->account) Lmd_Accounts_Modify(ch->account);
 }
 
 gentity_t *Accounts_GetPlayerByAcc(Account_t *acc) {
@@ -290,9 +609,45 @@ gentity_t *Accounts_GetPlayerByAcc(Account_t *acc) {
 	return NULL;
 }
 
+Character_t *allocCharacter(Account_t *owner) {
+	Character_t *ch = (Character_t *)G_Alloc(sizeof(Character_t));
+	memset(ch, 0, sizeof(*ch));
+	ch->account = owner;
+	ch->data.count = CharacterDataTypes.count;
+	ch->data.data = (void **)malloc(sizeof(void *) * CharacterDataTypes.count);
+	int i;
+	for (i = 0; i < CharacterDataTypes.count; i++) {
+		accDataModule_t *category = CharacterDataTypes.categories[i];
+		void *dataPtr = ch->data.data[i] = G_Alloc(category->dataSize);
+		memset(dataPtr, 0, category->dataSize);
+		if (category->allocData) {
+			category->allocData(dataPtr);
+		}
+	}
+	return ch;
+}
+
+void freeCharacter(Character_t *ch) {
+	int i;
+	Lmd_Data_FreeFields((void*)ch, CharacterFields, CharacterFields_Count);
+	for (i = 0; i < CharacterDataTypes.count; i++) {
+		accDataModule_t *module = CharacterDataTypes.categories[i];
+		void *dataPtr = ch->data.data[i];
+		if (dataPtr) {
+			Lmd_Data_FreeFields(dataPtr, module->dataFields, module->numDataFields);
+			if (module->freeData)
+				module->freeData(dataPtr);
+			G_Free(dataPtr);
+		}
+	}
+	Lmd_Arrays_RemoveAllElements((void **)&ch->data.data);
+	G_Free(ch);
+}
+
 Account_t *allocAccount(){
 	int i;
 	Account_t *acc = (Account_t *)G_Alloc(sizeof(Account_t));
+	memset(acc, 0, sizeof(*acc));
 	acc->data.count = AccountDataTypes.count;
 	acc->data.data = (void **)malloc(sizeof(void *) * AccountDataTypes.count);
 	for(i = 0; i < AccountDataTypes.count; i++) {
@@ -318,8 +673,15 @@ void freeAccount(Account_t *acc) {
 
 		if (dataPtr) {
 			Lmd_Data_FreeFields(dataPtr, module->dataFields, module->numDataFields);
+			if (module->freeData)
+				module->freeData(dataPtr);
 			G_Free(dataPtr);
 		}
+	}
+
+	for (i = 0; i < acc->numCharacters; i++) {
+		if (acc->characters[i])
+			freeCharacter(acc->characters[i]);
 	}
 
 	Lmd_Arrays_RemoveAllElements((void **)&acc->data.data);
@@ -364,6 +726,19 @@ void Accounts_Save(Account_t *acc)
 {
 	fileHandle_t f = Lmd_Data_OpenDataFile("accounts", va("%s.uac", acc->username), FS_WRITE);
 	Lmd_Data_WriteToFile_LinesDelimited(f, AccountFields, AccountFields_Count, (void *)acc);
+
+	int i;
+	for (i = 0; i < acc->numCharacters; i++) {
+		Character_t *ch = acc->characters[i];
+		if (!ch)
+			continue;
+		const char *open = "[character]\n";
+		const char *close = "[/character]\n";
+		trap_FS_Write(open, strlen(open), f);
+		Lmd_Data_WriteToFile_LinesDelimited(f, CharacterFields, CharacterFields_Count, (void *)ch);
+		trap_FS_Write(close, strlen(close), f);
+	}
+
 	trap_FS_FCloseFile(f);
 
 	acc->modifiedTime = 0;
@@ -423,8 +798,84 @@ qboolean parseAccount(char *name, char *buf){
 	if(g_developer.integer > 0)
 		Com_Printf("Loading account: %s\n", name);
 	acc->username = G_NewString2(name); //guarenteed to be unique, since it's a filename.
+
+	// During load, char-scope module keys appearing at top level (legacy files) need
+	// to land somewhere. We allocate a "legacy character" up front to receive them,
+	// and only keep it if no real [character] sections appear.
+	Character_t *legacyCh = allocCharacter(acc);
+
 	char *str = buf;
-	Lmd_Data_Parse_LineDelimited(&str, (void *) acc, AccountFields, AccountFields_Count);
+	char *p;
+	char key[MAX_STRING_CHARS], value[MAX_STRING_CHARS];
+	Character_t *currentChar = NULL;
+	qboolean sawCharacterSection = qfalse;
+
+	while (str && *str) {
+		p = COM_ParseExt((const char **)&str, qtrue);
+		if (!p[0])
+			break;
+
+		// Section markers — bare tokens with no `key:` colon.
+		if (Q_stricmp(p, "[character]") == 0) {
+			sawCharacterSection = qtrue;
+			if (acc->numCharacters < MAX_CHARS_PER_ACCOUNT) {
+				currentChar = allocCharacter(acc);
+				acc->characters[acc->numCharacters++] = currentChar;
+			}
+			else {
+				currentChar = NULL; // overflow: skip
+			}
+			continue;
+		}
+		if (Q_stricmp(p, "[/character]") == 0) {
+			currentChar = NULL;
+			continue;
+		}
+
+		Q_strncpyz(key, p, sizeof(key));
+		int colPos = strlen(key) - 1;
+		if (colPos <= 0)
+			continue;
+		char *valuePtr;
+		if (key[colPos] == ':') {
+			key[colPos] = 0;
+			Q_strncpyz(value, COM_ParseLine((const char **)&str), sizeof(value));
+			valuePtr = value;
+		}
+		else {
+			valuePtr = NULL;
+		}
+
+		if (currentChar) {
+			Lmd_Data_Parse_KeyValuePair(key, valuePtr, currentChar, CharacterFields, CharacterFields_Count);
+		}
+		else {
+			// Try account fields first (covers legacy per-char keys via AccountFields_Legacy).
+			if (!Lmd_Data_Parse_KeyValuePair(key, valuePtr, acc, AccountFields, AccountFields_Count)) {
+				// Legacy char-scope module data lived at account scope. Route to the
+				// pre-allocated legacy character so its modules receive the data.
+				Lmd_Data_Parse_KeyValuePair(key, valuePtr, legacyCh, CharacterFields, CharacterFields_Count);
+			}
+		}
+	}
+
+	if (!sawCharacterSection) {
+		// Legacy file: legacyCh already absorbed name/credits/bounty/time/score and any
+		// char-scope module data from the top-level fallthrough. Promote it.
+		acc->characters[0] = legacyCh;
+		acc->numCharacters = 1;
+		acc->activeCharacter = legacyCh;
+		acc->migrated = qtrue;
+		// Mark dirty so the new sectioned format lands on disk at next save.
+		// level.time is 0 during startup load; 1 ensures the >0 gate passes.
+		acc->modifiedTime = level.time > 0 ? level.time : 1;
+	}
+	else {
+		freeCharacter(legacyCh);
+		if (acc->numCharacters > 0)
+			acc->activeCharacter = acc->characters[0];
+	}
+
 	if(validateNewAccount(acc)) {
 		addAccount(acc);
 	}
@@ -437,13 +888,24 @@ qboolean parseAccount(char *name, char *buf){
 
 unsigned int Accounts_Load(){
 	unsigned int result = Lmd_Data_ProcessFiles("accounts", ".uac", parseAccount, Q3_INFINITE);
-	int i, a;
+	int i, a, c;
 	for(i = 0; i < AccountDataTypes.count; i++){
 		accDataModule_t *module = AccountDataTypes.categories[i];
 		if(module->accLoadCompleted == NULL)
 			continue;
 		for(a = 0; a < AccList.count; a++) {
 			module->accLoadCompleted(AccList.accounts[a], AccList.accounts[a]->data.data[i]);
+		}
+	}
+	for (i = 0; i < CharacterDataTypes.count; i++) {
+		accDataModule_t *module = CharacterDataTypes.categories[i];
+		if (module->accLoadCompleted == NULL)
+			continue;
+		for (a = 0; a < AccList.count; a++) {
+			Account_t *acc = AccList.accounts[a];
+			for (c = 0; c < acc->numCharacters; c++) {
+				module->accLoadCompleted(acc, acc->characters[c]->data.data[i]);
+			}
 		}
 	}
 
@@ -455,7 +917,6 @@ Account_t *Accounts_New(char *username, char *name, char *password) {
 		return NULL;
 	Account_t *acc = allocAccount();
 	acc->username = G_NewString2(username);
-	acc->name = G_NewString2(name);
 	acc->modifiedTime = level.time;
 	acc->pwChksum = Checksum(password);
 	acc->id = nextId;
@@ -466,6 +927,20 @@ Account_t *Accounts_New(char *username, char *name, char *password) {
 			continue;
 		category->accLoadCompleted(acc, acc->data.data[i]);
 	}
+
+	// New accounts get character[0] from the registration name.
+	Character_t *ch = allocCharacter(acc);
+	ch->name = G_NewString2(name);
+	acc->characters[0] = ch;
+	acc->numCharacters = 1;
+	acc->activeCharacter = ch;
+	for (i = 0; i < CharacterDataTypes.count; i++) {
+		accDataModule_t *category = CharacterDataTypes.categories[i];
+		if (category->accLoadCompleted == NULL)
+			continue;
+		category->accLoadCompleted(acc, ch->data.data[i]);
+	}
+
 	addAccount(acc);
 	return acc;
 }
@@ -495,28 +970,15 @@ char* Accounts_GetUsername(Account_t *acc) {
 }
 
 char* Accounts_GetName(Account_t *acc) {
-	if(!acc)
+	if(!acc || !acc->activeCharacter)
 		return NULL;
-
-	// Cant use this, as it will say false if the name is already in use, which it will be.
-	if (IsValidName(acc->name) == qfalse) {
-		return "Padawan";
-	}
-
-	return acc->name;
+	return Character_GetName(acc->activeCharacter);
 }
 
 void Accounts_SetName(Account_t *acc, char *name) {
-	if(!acc)
+	if(!acc || !acc->activeCharacter)
 		return;
-
-	if (IsValidName(name) == qfalse) {
-		name = "Padawan";
-	}
-
-	G_Free(acc->name);
-	acc->name = G_NewString2(name);
-	Lmd_Accounts_Modify(acc);
+	Character_SetName(acc->activeCharacter, name);
 }
 
 int Accounts_GetPassword(Account_t *acc) {
@@ -574,31 +1036,32 @@ char* Accounts_NewSeccode(Account_t *acc) {
 
 int Accounts_GetBounty(Account_t *acc)
 {
-	if(!acc) return 0;
-	return acc->bounty;
+	if(!acc || !acc->activeCharacter) return 0;
+	return acc->activeCharacter->bounty;
 }
 
 void Accounts_SetBounty(Account_t *acc, int value)
 {
-	if(!acc) return;
-	acc->bounty = value;
+	if(!acc || !acc->activeCharacter) return;
+	Character_SetBounty(acc->activeCharacter, value);
 }
 
 void Accounts_PrintBountyList(gentity_t* ent)
 {
 	qboolean found = qfalse;
-	int bounty;
+	unsigned int total = Characters_Count();
+	unsigned int i;
 
-	for(int i = 0; i < AccList.count; i++)
-	{
-		bounty = Accounts_GetBounty(AccList.accounts[i]);
-		if (bounty > 0)
-		{
-			Disp(ent, va("^7%s ^5- ^6%d ^5CR", Accounts_GetName(AccList.accounts[i]), bounty));
+	for (i = 0; i < total; i++) {
+		Character_t *ch = Characters_Get(i);
+		if (!ch) continue;
+		int bounty = Character_GetBounty(ch);
+		if (bounty > 0) {
+			Disp(ent, va("^7%s ^5- ^6%d ^5CR", Character_GetName(ch), bounty));
 			found = qtrue;
 		}
 	}
-	
+
 	if (!found)
 	{
 		Disp(ent, "^5No bounties currently placed.");
@@ -606,44 +1069,39 @@ void Accounts_PrintBountyList(gentity_t* ent)
 }
 
 int Accounts_GetCredits(Account_t *acc) {
-	if(!acc)
+	if(!acc || !acc->activeCharacter)
 		return 0;
-	return acc->credits;
+	return acc->activeCharacter->credits;
 }
 
 void Accounts_SetCredits(Account_t *acc, int value) {
-	if(!acc)
+	if(!acc || !acc->activeCharacter)
 		return;
-	if(value < 0)
-		value = 0;
-	acc->credits = value;
-	Lmd_Accounts_Modify(acc);
+	Character_SetCredits(acc->activeCharacter, value);
 }
 
 int Accounts_GetScore(Account_t *acc) {
-	if(!acc)
+	if(!acc || !acc->activeCharacter)
 		return 0;
-	return acc->score;
+	return acc->activeCharacter->score;
 }
 
 void Accounts_SetScore(Account_t *acc, int value) {
-	if(!acc)
+	if(!acc || !acc->activeCharacter)
 		return;
-	acc->score = value;
-	Lmd_Accounts_Modify(acc);
+	Character_SetScore(acc->activeCharacter, value);
 }
 
 int Accounts_GetTime(Account_t *acc) {
-	if(!acc)
+	if(!acc || !acc->activeCharacter)
 		return 0;
-	return acc->time;
+	return acc->activeCharacter->time;
 }
 
 void Accounts_SetTime(Account_t *acc, int value) {
-	if(!acc)
+	if(!acc || !acc->activeCharacter)
 		return;
-	acc->time = value;
-	Lmd_Accounts_Modify(acc);
+	Character_SetTime(acc->activeCharacter, value);
 }
 
 // lumaya Titles:

--- a/game/Lmd_Accounts_Core.c
+++ b/game/Lmd_Accounts_Core.c
@@ -50,6 +50,7 @@ struct Character_s {
 	int bounty;
 	int time;
 	int score;
+	int lastPlayed; // unix timestamp of most recent /play; used to auto-select on next /login
 	Account_t *account;
 
 	struct {
@@ -356,6 +357,7 @@ const int AccountFields_Count = DATAFIELDS_COUNT(AccountFields);
 	_m##_AUTO(bounty, CHAROFS(bounty), F_INT) \
 	_m##_AUTO(time, CHAROFS(time), F_INT) \
 	_m##_AUTO(score, CHAROFS(score), F_INT) \
+	_m##_AUTO(lastPlayed, CHAROFS(lastPlayed), F_INT) \
 	_m##_DEFL(Characters_Parse_Modules, Characters_Write_Modules, NULL)
 
 CharacterFields_Base(DEFINE_FIELD_PRE)
@@ -459,6 +461,18 @@ Character_t *Account_FindCharacterByName(Account_t *acc, char *name) {
 			return ch;
 	}
 	return NULL;
+}
+
+Character_t *Account_GetMostRecentCharacter(Account_t *acc) {
+	if (!acc || acc->numCharacters <= 0) return NULL;
+	Character_t *best = acc->characters[0];
+	int i;
+	for (i = 1; i < acc->numCharacters; i++) {
+		Character_t *ch = acc->characters[i];
+		if (ch && ch->lastPlayed > best->lastPlayed)
+			best = ch;
+	}
+	return best;
 }
 
 Character_t *Account_NewCharacter(Account_t *acc, char *name) {
@@ -595,6 +609,12 @@ int Character_GetScore(Character_t *ch) { return ch ? ch->score : 0; }
 void Character_SetScore(Character_t *ch, int v) {
 	if (!ch) return;
 	ch->score = v;
+	if (ch->account) Lmd_Accounts_Modify(ch->account);
+}
+
+void Character_StampLastPlayed(Character_t *ch) {
+	if (!ch) return;
+	ch->lastPlayed = Time_Now();
 	if (ch->account) Lmd_Accounts_Modify(ch->account);
 }
 

--- a/game/Lmd_Accounts_Core.h
+++ b/game/Lmd_Accounts_Core.h
@@ -26,6 +26,7 @@ int Account_GetNumCharacters(Account_t *acc);
 Character_t *Account_GetActiveCharacter(Account_t *acc);
 void Account_SetActiveCharacter(Account_t *acc, Character_t *ch);
 Character_t *Account_FindCharacterByName(Account_t *acc, char *name);
+Character_t *Account_GetMostRecentCharacter(Account_t *acc); // highest lastPlayed; falls back to characters[0]
 Character_t *Account_NewCharacter(Account_t *acc, char *name);
 qboolean Account_DeleteCharacter(Account_t *acc, Character_t *ch);
 qboolean Account_MoveCharacter(Account_t *src, Character_t *ch, Account_t *dst);
@@ -41,6 +42,7 @@ int Character_GetTime(Character_t *ch);
 void Character_SetTime(Character_t *ch, int value);
 int Character_GetScore(Character_t *ch);
 void Character_SetScore(Character_t *ch, int value);
+void Character_StampLastPlayed(Character_t *ch); // sets lastPlayed = Time_Now() and marks dirty
 
 // Iterating every character across every account (for leaderboards etc.)
 unsigned int Characters_Count();

--- a/game/Lmd_Accounts_Core.h
+++ b/game/Lmd_Accounts_Core.h
@@ -8,13 +8,43 @@
 #include "gentity_t.h"
 
 typedef struct Account_s Account_t;
+typedef struct Character_s Character_t;
+
+#define MAX_CHARS_PER_ACCOUNT 3
 
 #define ACCFLAGS_NOPROFCRLOSS 0x0000001 //dont loose cr when profession changed.  Cleared on prof change and on levelup.
 #define ACCFLAGS_NOSECCODE	  0x0000002 // Disable security code for this account.
 
 Account_t *Accounts_GetById(int id);
 Account_t *Accounts_GetByUsername(char *str);
-Account_t *Accounts_GetByName(char *str);
+Account_t *Accounts_GetByName(char *str); // looks up by character name (any character on any account)
+
+// Multi-character API.
+Character_t *Accounts_GetCharacterByName(char *str);
+Character_t *Account_GetCharacter(Account_t *acc, int index);
+int Account_GetNumCharacters(Account_t *acc);
+Character_t *Account_GetActiveCharacter(Account_t *acc);
+void Account_SetActiveCharacter(Account_t *acc, Character_t *ch);
+Character_t *Account_FindCharacterByName(Account_t *acc, char *name);
+Character_t *Account_NewCharacter(Account_t *acc, char *name);
+qboolean Account_DeleteCharacter(Account_t *acc, Character_t *ch);
+qboolean Account_MoveCharacter(Account_t *src, Character_t *ch, Account_t *dst);
+
+Account_t *Character_GetAccount(Character_t *ch);
+char *Character_GetName(Character_t *ch);
+void Character_SetName(Character_t *ch, char *name);
+int Character_GetCredits(Character_t *ch);
+void Character_SetCredits(Character_t *ch, int value);
+int Character_GetBounty(Character_t *ch);
+void Character_SetBounty(Character_t *ch, int value);
+int Character_GetTime(Character_t *ch);
+void Character_SetTime(Character_t *ch, int value);
+int Character_GetScore(Character_t *ch);
+void Character_SetScore(Character_t *ch, int value);
+
+// Iterating every character across every account (for leaderboards etc.)
+unsigned int Characters_Count();
+Character_t *Characters_Get(unsigned int i);
 
 unsigned int Accounts_Count();
 Account_t* Accounts_Get(unsigned int i);

--- a/game/Lmd_Accounts_CustomSkills.c
+++ b/game/Lmd_Accounts_CustomSkills.c
@@ -6,7 +6,7 @@
 #include "Lmd_KeyPairs.h"
 
 int AccCustomDataIndex = -1;
-#define CUSTDATA(acc) (KeyPairSet_t *)Lmd_Accounts_GetAccountCategoryData(acc, AccCustomDataIndex)
+#define CUSTDATA(acc) (KeyPairSet_t *)Lmd_Accounts_GetAccCharCategoryData(acc, AccCustomDataIndex)
 
 
 qboolean Accounts_CustomSkill_Parse(char *key, char *value, void *target, void *args)
@@ -88,7 +88,7 @@ accDataModule_t Accounts_Custom = {
 
 
 void Accounts_CustomSkills_Register() {
-	AccCustomDataIndex = Lmd_Accounts_AddDataCategory(&Accounts_Custom);
+	AccCustomDataIndex = Lmd_Accounts_AddCharacterDataCategory(&Accounts_Custom);
 }
 
 
@@ -106,6 +106,7 @@ void Accounts_Custom_SetValue(Account_t *acc, char *key, char *value) {
 	if(!acc)
 		return;
 	KeyPairSet_t *set = CUSTDATA(acc);
+	if(!set) return;
 	int i = Lmd_Pairs_FindKey(set, key);
 	if(i < 0) {
 		Lmd_Pairs_New(set, key, value);
@@ -121,6 +122,7 @@ void Accounts_Custom_Clear(Account_t *acc) {
 	if(!acc)
 		return;
 	KeyPairSet_t *set = CUSTDATA(acc);
+	if(!set) return;
 	Lmd_Pairs_Clear(set);
 }
 

--- a/game/Lmd_Accounts_Data.h
+++ b/game/Lmd_Accounts_Data.h
@@ -3,8 +3,17 @@
 
 #include "Lmd_Accounts_Public.h"
 
+typedef struct Character_s Character_t;
+
 void Lmd_Accounts_Modify(Account_t *acc);
 #define PlayerAcc_Modify(ent) Lmd_Accounts_Modify(ent->client->pers.Lmd.account)
 
 int Lmd_Accounts_AddDataCategory(accDataModule_t *category);
 void* Lmd_Accounts_GetAccountCategoryData(Account_t *acc, int categoryIndex);
+
+// Per-character module storage (parallel registry to AddDataCategory).
+int Lmd_Accounts_AddCharacterDataCategory(accDataModule_t *category);
+void* Lmd_Accounts_GetCharacterCategoryData(Character_t *ch, int categoryIndex);
+// Convenience: redirects to acc->activeCharacter's char-scope data. Used by
+// modules that previously took Account_t* but are now per-character.
+void* Lmd_Accounts_GetAccCharCategoryData(Account_t *acc, int categoryIndex);

--- a/game/Lmd_Accounts_Public.h
+++ b/game/Lmd_Accounts_Public.h
@@ -8,6 +8,7 @@
 #define LMDAPI_ACCOUNTS_DATAMODULE_VERSION_CURRENT LMDAPI_ACCOUNTS_DATAMODULE_VERSION_1
 
 typedef void* AccountPtr_t;
+typedef void* CharacterPtr_t;
 
 typedef struct accDataModule_v1_s {
 	// Loading and saving

--- a/game/Lmd_Accounts_Stats.c
+++ b/game/Lmd_Accounts_Stats.c
@@ -5,7 +5,7 @@
 #include "Lmd_Accounts_Core.h"
 
 int AccStatDataIndex = -1;
-#define STATDATA(acc) (statData_t *)Lmd_Accounts_GetAccountCategoryData(acc, AccStatDataIndex)
+#define STATDATA(acc) (statData_t *)Lmd_Accounts_GetAccCharCategoryData(acc, AccStatDataIndex)
 
 typedef struct statData_s{
 	int kills;
@@ -60,111 +60,111 @@ accDataModule_t Accounts_Stats = {
 };
 
 void Accounts_Stats_Register() {
-	AccStatDataIndex = Lmd_Accounts_AddDataCategory(&Accounts_Stats);
+	AccStatDataIndex = Lmd_Accounts_AddCharacterDataCategory(&Accounts_Stats);
 }
 
 
 int Accounts_Stats_GetDuels(Account_t *acc) {
-	if(!acc)
-		return 0;
+	if(!acc) return 0;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return 0;
 	return statData->duels;
 }
 
 void Accounts_Stats_SetDuels(Account_t *acc, int value) {
-	if(!acc)
-		return;
+	if(!acc) return;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return;
 	statData->duels = value;
 	Lmd_Accounts_Modify(acc);
 }
 
 int Accounts_Stats_GetDuelsWon(Account_t *acc) {
-	if(!acc)
-		return 0;
+	if(!acc) return 0;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return 0;
 	return statData->duelsWon;
 }
 
 void Accounts_Stats_SetDuelsWon(Account_t *acc, int value) {
-	if(!acc)
-		return;
+	if(!acc) return;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return;
 	statData->duelsWon = value;
 	Lmd_Accounts_Modify(acc);
 }
 
 int Accounts_Stats_GetKills(Account_t *acc) {
-	if(!acc)
-		return 0;
+	if(!acc) return 0;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return 0;
 	return statData->kills;
 }
 
 void Accounts_Stats_SetKills(Account_t *acc, int value) {
-	if(!acc)
-		return;
+	if(!acc) return;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return;
 	statData->kills = value;
 	Lmd_Accounts_Modify(acc);
 }
 
 int Accounts_Stats_GetDeaths(Account_t *acc) {
-	if(!acc)
-		return 0;
+	if(!acc) return 0;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return 0;
 	return statData->deaths;
 }
 
 void Accounts_Stats_SetDeaths(Account_t *acc, int value) {
-	if(!acc)
-		return;
+	if(!acc) return;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return;
 	statData->deaths = value;
 	Lmd_Accounts_Modify(acc);
 }
 
 int Accounts_Stats_GetShots(Account_t *acc) {
-	if(!acc)
-		return 0;
+	if(!acc) return 0;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return 0;
 	return statData->shots;
 }
 
 void Accounts_Stats_SetShots(Account_t *acc, int value) {
-	if(!acc)
-		return;
+	if(!acc) return;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return;
 	statData->shots = value;
 	Lmd_Accounts_Modify(acc);
 }
 
 int Accounts_Stats_GetHits(Account_t *acc) {
-	if(!acc)
-		return 0;
+	if(!acc) return 0;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return 0;
 	return statData->hits;
 }
 
 void Accounts_Stats_SetHits(Account_t *acc, int value) {
-	if(!acc)
-		return;
+	if(!acc) return;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return;
 	statData->hits = value;
 	Lmd_Accounts_Modify(acc);
 }
 
 int Accounts_Stats_GetStashes(Account_t *acc) {
-	if(!acc)
-		return 0;
+	if(!acc) return 0;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return 0;
 	return statData->stashes;
 }
 
 void Accounts_Stats_SetStashes(Account_t *acc, int value) {
-	if(!acc)
-		return;
+	if(!acc) return;
 	statData_t *statData = STATDATA(acc);
+	if(!statData) return;
 	statData->stashes = value;
 	Lmd_Accounts_Modify(acc);
 }

--- a/game/Lmd_Inventory_Core.c
+++ b/game/Lmd_Inventory_Core.c
@@ -10,7 +10,7 @@
 #include "Lmd_Confirm.h"
 
 int AccInventoryDataDataIndex = -1;
-#define INVDATA(acc) (iObjectList_t *)Lmd_Accounts_GetAccountCategoryData(acc, AccInventoryDataDataIndex)
+#define INVDATA(acc) (iObjectList_t *)Lmd_Accounts_GetAccCharCategoryData(acc, AccInventoryDataDataIndex)
 
 /*
 
@@ -169,7 +169,7 @@ accDataModule_t Accounts_Inventory = {
 
 
 void Accounts_Inventory_Register() {
-	AccInventoryDataDataIndex = Lmd_Accounts_AddDataCategory(&Accounts_Inventory);
+	AccInventoryDataDataIndex = Lmd_Accounts_AddCharacterDataCategory(&Accounts_Inventory);
 }
 
 iObjectList_t *Inventory_Player_GetInventory(gentity_t *player) {
@@ -389,6 +389,7 @@ void Inventory_Player_Think(gentity_t *player) {
 
 void Inventory_Player_Login(gentity_t *player) {
 	iObjectList_t *inventory = INVDATA(player->client->pers.Lmd.account);
+	if (!inventory) return;
 	int i;
 	for(i = 0; i < inventory->count; i++) {
 		inventory->objects[i]->holder = player;
@@ -397,6 +398,7 @@ void Inventory_Player_Login(gentity_t *player) {
 
 void Inventory_Player_Logout(gentity_t *player) {
 	iObjectList_t *inventory = INVDATA(player->client->pers.Lmd.account);
+	if (!inventory) return;
 	int i;
 	for(i = 0; i < inventory->count; i++) {
 		inventory->objects[i]->holder = NULL;

--- a/game/Lmd_Prof_Core.c
+++ b/game/Lmd_Prof_Core.c
@@ -14,7 +14,7 @@
 #include "BG_Fields.h"
 
 int AccProfessionDataDataIndex = -1;
-#define PROFDATA(acc) (profData_t *)Lmd_Accounts_GetAccountCategoryData(acc, AccProfessionDataDataIndex)
+#define PROFDATA(acc) (profData_t *)Lmd_Accounts_GetAccCharCategoryData(acc, AccProfessionDataDataIndex)
 
 
 #define LEVEL_REDUCE 5
@@ -259,11 +259,12 @@ accDataModule_t Accounts_Profession = {
 };
 
 void Accounts_Prof_Register() {
-	AccProfessionDataDataIndex = Lmd_Accounts_AddDataCategory(&Accounts_Profession);
+	AccProfessionDataDataIndex = Lmd_Accounts_AddCharacterDataCategory(&Accounts_Profession);
 }
 
 void Accounts_Prof_ClearData(Account_t *acc) {
 	profData_t *data = PROFDATA(acc);
+	if(!data) return;
 	if(Professions[data->profession]->data.fields) {
 		Lmd_Data_FreeFields(data->data, Professions[data->profession]->data.fields, Professions[data->profession]->data.count);
 		memset(data->data, 0, Professions[data->profession]->data.size);
@@ -275,6 +276,7 @@ void* Accounts_Prof_GetFieldData(Account_t *acc) {
 	if(!acc)
 		return NULL;
 	profData_t *data = PROFDATA(acc);
+	if(!data) return NULL;
 	return data->data;
 }
 void Accounts_Prof_SetModified(Account_t *acc) {
@@ -285,6 +287,7 @@ int Accounts_Prof_GetProfession(Account_t *acc) {
 	if(!acc)
 		return 0;
 	profData_t *data = PROFDATA(acc);
+	if(!data) return PROF_NONE;
 	return data->profession;
 }
 
@@ -322,7 +325,8 @@ void Accounts_Prof_SetProfession(Account_t *acc, int value) {
 		return;
 
 	profData_t *data = PROFDATA(acc);
-	
+	if(!data) return;
+
 	Accounts_Prof_ClearData(acc);
 
 	G_Free(data->data);
@@ -336,6 +340,7 @@ int Accounts_Prof_GetLevel(Account_t *acc) {
 	if(!acc)
 		return 0;
 	profData_t *data = PROFDATA(acc);
+	if(!data) return 0;
 	return data->level;
 }
 
@@ -343,6 +348,7 @@ void Accounts_Prof_SetLevel(Account_t *acc, int value) {
 	if(!acc)
 		return;
 	profData_t *data = PROFDATA(acc);
+	if(!data) return;
 	data->level = value;
 	data->lastLevelUp = Time_Now();
 	Lmd_Accounts_Modify(acc);
@@ -352,6 +358,7 @@ int Accounts_Prof_GetLastLevelup(Account_t *acc) {
 	if(!acc)
 		return 0;
 	profData_t *data = PROFDATA(acc);
+	if(!data) return 0;
 	return data->lastLevelUp;
 }
 

--- a/game/g_svcmds.c
+++ b/game/g_svcmds.c
@@ -100,6 +100,51 @@ void Svcmd_DeleteNick_f (void){
 	Com_Printf("Account %s is now deleted.\n", arg);
 }
 
+gentity_t *Accounts_GetPlayerByAcc(Account_t *acc);
+void Svcmd_MergeAccounts_f(void) {
+	if (trap_Argc() < 3) {
+		Com_Printf("Usage:\nmergeaccounts <srcUsername> <dstUsername>\n"
+			"Moves all characters from src to dst, then deletes src. Refuses if combined\n"
+			"count exceeds the per-account cap, if either is currently logged in, or if\n"
+			"src has property/authfiles that need manual handling.\n");
+		return;
+	}
+	char srcArg[MAX_TOKEN_CHARS], dstArg[MAX_TOKEN_CHARS];
+	trap_Argv(1, srcArg, sizeof(srcArg));
+	trap_Argv(2, dstArg, sizeof(dstArg));
+	Account_t *src = Accounts_GetByUsername(srcArg);
+	Account_t *dst = Accounts_GetByUsername(dstArg);
+	if (!src) { Com_Printf("Source account not found: %s\n", srcArg); return; }
+	if (!dst) { Com_Printf("Destination account not found: %s\n", dstArg); return; }
+	if (src == dst) { Com_Printf("Source and destination are the same.\n"); return; }
+	if (Accounts_GetPlayerByAcc(src) || Accounts_GetPlayerByAcc(dst)) {
+		Com_Printf("One of the accounts is currently logged in. Have them log out first.\n");
+		return;
+	}
+	int srcCount = Account_GetNumCharacters(src);
+	int dstCount = Account_GetNumCharacters(dst);
+	if (srcCount + dstCount > MAX_CHARS_PER_ACCOUNT) {
+		Com_Printf("Combined character count (%d) exceeds the cap of %d. Delete characters first.\n",
+			srcCount + dstCount, MAX_CHARS_PER_ACCOUNT);
+		return;
+	}
+	if (Auths_AccHasAdmin(src)) {
+		Com_Printf("Source account has admin authfiles. Remove them with /removeadmin first.\n");
+		return;
+	}
+	// Move every character.
+	while (Account_GetNumCharacters(src) > 0) {
+		Character_t *ch = Account_GetCharacter(src, 0);
+		if (!Account_MoveCharacter(src, ch, dst)) {
+			Com_Printf("Failed to move character; aborting (state may be partial).\n");
+			return;
+		}
+	}
+	Com_Printf("Merged %d character(s) from %s into %s. Deleting %s.\n",
+		srcCount, srcArg, dstArg, srcArg);
+	Accounts_Delete(src);
+}
+
 //RoboPhred
 extern vmCvar_t g_log;
 extern vmCvar_t g_logSync;
@@ -455,6 +500,10 @@ qboolean	ConsoleCommand( void ) {
 	}
 	if ((Q_stricmp (cmd, "deletenick") == 0)){
 		Svcmd_DeleteNick_f();
+		return qtrue;
+	}
+	if ((Q_stricmp (cmd, "mergeaccounts") == 0)) {
+		Svcmd_MergeAccounts_f();
 		return qtrue;
 	}
 	if ((Q_stricmp (cmd, "listadmins") == 0)){

--- a/game/gclient_t.h
+++ b/game/gclient_t.h
@@ -9,6 +9,7 @@ typedef struct gclient_s gclient_t;
 
 typedef struct Action_s Action_t;
 typedef struct Account_s Account_t;
+typedef struct Character_s Character_t;
 
 #include "q_shared.h"
 
@@ -127,6 +128,7 @@ typedef struct {
 		//RoboPhred:
 		//void            *nickPointer;
 		Account_t *account;
+		Character_t *character; // currently selected character on this account; NULL = lobby (post-login, pre-/play)
 		struct{
 			Action_t *Action;
 			unsigned int count;


### PR DESCRIPTION
Each account can hold up to 3 characters (MAX_CHARS_PER_ACCOUNT). Per-character: name, credits, bounty, time, score, profession+level+skills, inventory, stats. Account-shared: friends, property, admin auths, custom-skills, player-guide, login credentials. Players who used to register separate alt-accounts can now consolidate them.

New Character_t struct alongside Account_t, with a parallel char-scope module registry (Lmd_Accounts_AddCharacterDataCategory). Stats, profession, and inventory modules are re-registered as character-scope; their data lives on the active character and existing Account_t* getters proxy through acc->activeCharacter so most call sites are unchanged.

The .uac save format gains [character]...[/character] sections holding per-character fields and module data; account-scope state stays at the top of the file. Legacy single-character files migrate on load: the parser routes top-level char keys into a temporary character which becomes characters[0], and the new sectioned format is written back on the next save tick.

Player session gains pers.Lmd.character. /login authenticates only and auto-selects the sole character when an account has one (preserves single-character UX); accounts with multiple characters land in lobby state and prompt for /play. New commands: /charlist, /charcreate <name>, /chardelete <name>, /play <name|index>. /charcreate and /chardelete flush the account immediately so a crash before the periodic save will not drop the change. SelectCharacter respawns the player on every switch (skipping bots) so profession effects rehydrate.

Server-console rcon command mergeaccounts <srcUsername> <dstUsername> moves all characters from src to dst and deletes src, refusing if the combined count exceeds the cap, if either account is currently logged in, or if src has admin authfiles. Use this to fold pre-multichar alt-accounts into one.

Char-scope getters (Stats, Profession, Inventory) NULL-guard the module-data pointer so a player in lobby state (no active character yet) does not crash ClientThink.